### PR TITLE
Patch/ignore invalid header parts

### DIFF
--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -156,10 +156,6 @@ export function splitAndClean(input: string): string[] {
  */
 function isValidQValue(qvalue: string): boolean {
   if (!/^(?:(?:0(?:\.\d{0,3})?)|(?:1(?:\.0{0,3})?))$/u.test(qvalue)) {
-    // logger.warn(`Invalid q value: ${qvalue}`);
-    // throw new BadRequestHttpError(
-    //   `Invalid q value: ${qvalue} does not match ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] ).`,
-    // );
     logger.warn(`Invalid q value: ${qvalue} does not match ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] ).`);
     return false;
   }
@@ -180,7 +176,6 @@ function isValidQValue(qvalue: string): boolean {
  */
 export function parseParameters(parameters: string[], replacements: Record<string, string>):
 { name: string; value: string }[] {
-  //return parameters.map((param): { name: string; value: string } => {
   return parameters.reduce<{ name: string; value: string }[]>((acc, param): { name: string; value: string }[] => {
     const [ name, rawValue ] = param.split('=').map((str): string => str.trim());
 
@@ -188,11 +183,6 @@ export function parseParameters(parameters: string[], replacements: Record<strin
     // parameter  = token "=" ( token / quoted-string )
     // second part is optional for certain parameters
     if (!(token.test(name) && (!rawValue || /^"\d+"$/u.test(rawValue) || token.test(rawValue)))) {
-      //logger.warn(`Invalid parameter value: ${name}=${replacements[rawValue] || rawValue}`);
-      //throw new BadRequestHttpError(
-      //  `Invalid parameter value: ${name}=${replacements[rawValue] || rawValue} ` +
-      //  `does not match (token ( "=" ( token / quoted-string ))?). `,
-      //);
       logger.warn(
         `Invalid parameter value: ${name}=${replacements[rawValue] || rawValue} ` +
         `does not match (token ( "=" ( token / quoted-string ))?). `,
@@ -284,11 +274,9 @@ function parseNoParameters(input: string): AcceptHeader[] {
     if (qvalue) {
       if (!qvalue.startsWith('q=')) {
         logger.warn(`Only q parameters are allowed in ${input}`);
-        // throw new BadRequestHttpError(`Only q parameters are allowed in ${input}`);
         return result;
       }
       const val = qvalue.slice(2);
-      // testQValue(val);
       if (isValidQValue(val)) {
         result.weight = Number.parseFloat(val);
       }
@@ -313,19 +301,16 @@ export function parseAccept(input: string): Accept[] {
   // Quoted strings could prevent split from having correct results
   const { result, replacements } = transformQuotedStrings(input);
 
-  // TODO: change parseAcceptPart to return undefined if
-  // value is invalid.
-  // add a filter for non-undef values after the map.
   return splitAndClean(result)
     .reduce<Accept[]>((acc, part): Accept[] => {
-      const partOrUndef = parseAcceptPart(part, replacements);
+    const partOrUndef = parseAcceptPart(part, replacements);
 
-      if (partOrUndef !== undefined) {
-        acc.push(partOrUndef);
-      }
+    if (partOrUndef !== undefined) {
+      acc.push(partOrUndef);
+    }
 
-      return acc;
-    }, [])
+    return acc;
+  }, [])
     .sort((left, right): number => right.weight - left.weight);
 }
 
@@ -341,18 +326,13 @@ export function parseAccept(input: string): Accept[] {
  */
 export function parseAcceptCharset(input: string): AcceptCharset[] {
   const results = parseNoParameters(input);
-  // results.forEach((result): void => {
   return results.filter((result): boolean => {
     if (!token.test(result.range)) {
       logger.warn(`Invalid Accept-Charset range: ${result.range} does not match (content-coding / "identity" / "*")`);
       return false;
-      // throw new BadRequestHttpError(
-        //`Invalid Accept-Charset range: ${result.range} does not match (content-coding / "identity" / "*")`,
-      //);
     }
     return true;
   });
-  //return results;
 }
 
 /**
@@ -369,14 +349,11 @@ export function parseAcceptEncoding(input: string): AcceptEncoding[] {
   const results = parseNoParameters(input);
   return results.filter((result): boolean => {
     if (!token.test(result.range)) {
-      //logger.warn(`Invalid Accept-Encoding range: ${result.range}`);
-      //throw new BadRequestHttpError(`Invalid Accept-Encoding range: ${result.range} does not match (charset / "*")`);
       logger.warn(`Invalid Accept-Encoding range: ${result.range} does not match (charset / "*")`);
       return false;
     }
     return true;
   });
-  // return results;
 }
 
 /**
@@ -394,12 +371,6 @@ export function parseAcceptLanguage(input: string): AcceptLanguage[] {
   return results.filter((result): boolean => {
     // (1*8ALPHA *("-" 1*8alphanum)) / "*"
     if (result.range !== '*' && !/^[a-zA-Z]{1,8}(?:-[a-zA-Z0-9]{1,8})*$/u.test(result.range)) {
-      //logger.warn(
-       // `Invalid Accept-Language range: ${result.range}`,
-      //);
-      //throw new BadRequestHttpError(
-       // `Invalid Accept-Language range: ${result.range} does not match ((1*8ALPHA *("-" 1*8alphanum)) / "*")`,
-      //);
       logger.warn(
         `Invalid Accept-Language range: ${result.range} does not match ((1*8ALPHA *("-" 1*8alphanum)) / "*")`,
       );
@@ -407,7 +378,6 @@ export function parseAcceptLanguage(input: string): AcceptLanguage[] {
     }
     return true;
   });
-  // return results;
 }
 
 // eslint-disable-next-line max-len
@@ -426,12 +396,6 @@ export function parseAcceptDateTime(input: string): AcceptDatetime[] {
     return [];
   }
   if (!rfc1123Date.test(range)) {
-      //logger.warn(
-      //  `Invalid Accept-DateTime range: ${range}`,
-      //);
-      //throw new BadRequestHttpError(
-       // `Invalid Accept-DateTime range: ${range} does not match the RFC1123 format`,
-      //);
     logger.warn(`Invalid Accept-DateTime range: ${range} does not match the RFC1123 format`);
     return [];
   }

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -49,25 +49,57 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects Accept Headers with invalid types.', async(): Promise<void> => {
-      expect((): any => parseAccept('*')).toThrow('Invalid Accept range:');
-      expect((): any => parseAccept('"bad"/text')).toThrow('Invalid Accept range:');
-      expect((): any => parseAccept('*/\\bad')).toThrow('Invalid Accept range:');
-      expect((): any => parseAccept('*/*')).not.toThrow('Invalid Accept range:');
+      //expect((): any => parseAccept('*')).toThrow('Invalid Accept range:');
+      expect(parseAccept('*')).toEqual([]);
+      //expect((): any => parseAccept('"bad"/text')).toThrow('Invalid Accept range:');
+      expect(parseAccept('"bad"/text')).toEqual([]);
+      //expect((): any => parseAccept('*/\\bad')).toThrow('Invalid Accept range:');
+      expect(parseAccept('*/\\bad')).toEqual([]);
+      //expect((): any => parseAccept('*/*')).not.toThrow('Invalid Accept range:');
+      expect(parseAccept('*/*')).toEqual([{
+        parameters: { extension: {}, mediaType: {}}, range: '*/*', weight: 1,
+      }]);
     });
 
-    it('rejects Accept Headers with invalid q values.', async(): Promise<void> => {
-      expect((): any => parseAccept('a/b; q=text')).toThrow('Invalid q value:');
-      expect((): any => parseAccept('a/b; q=0.1234')).toThrow('Invalid q value:');
-      expect((): any => parseAccept('a/b; q=1.1')).toThrow('Invalid q value:');
-      expect((): any => parseAccept('a/b; q=1.000')).not.toThrow();
-      expect((): any => parseAccept('a/b; q=0.123')).not.toThrow();
+    it('ignores the weight of Accept Headers with invalid q values.', async(): Promise<void> => {
+      //expect((): any => parseAccept('a/b; q=text')).toThrow('Invalid q value:');
+      //expect((): any => parseAccept('a/b; q=0.1234')).toThrow('Invalid q value:');
+      //expect((): any => parseAccept('a/b; q=1.1')).toThrow('Invalid q value:');
+      expect(parseAccept('a/b; q=text')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      expect(parseAccept('a/b; q=0.1234')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      expect(parseAccept('a/b; q=1.1')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      //expect((): any => parseAccept('a/b; q=1.000')).not.toThrow();
+      //expect((): any => parseAccept('a/b; q=0.123')).not.toThrow();
+      expect(parseAccept('a/b; q=1.000')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      expect(parseAccept('a/b; q=0.123')).toEqual([{
+        range: 'a/b', weight: 0.123, parameters: { extension: {}, mediaType: {}},
+      }]);
     });
 
     it('rejects Accept Headers with invalid parameters.', async(): Promise<void> => {
-      expect((): any => parseAccept('a/b; a')).toThrow('Invalid Accept parameter');
-      expect((): any => parseAccept('a/b; a=\\')).toThrow('Invalid parameter value');
-      expect((): any => parseAccept('a/b; q=1 ; a=\\')).toThrow('Invalid parameter value');
-      expect((): any => parseAccept('a/b; q=1 ; a')).not.toThrow('Invalid Accept parameter');
+      //expect((): any => parseAccept('a/b; a')).toThrow('Invalid Accept parameter');
+      //expect((): any => parseAccept('a/b; a=\\')).toThrow('Invalid parameter value');
+      //expect((): any => parseAccept('a/b; q=1 ; a=\\')).toThrow('Invalid parameter value');
+      expect(parseAccept('a/b; a')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      expect(parseAccept('a/b; a=\\')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      expect(parseAccept('a/b; q=1 ; a=\\')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
+      }]);
+      expect(parseAccept('a/b; q=1 ; a')).toEqual([{
+        range: 'a/b', weight: 1, parameters: { extension: { a: '' }, mediaType: {}},
+      }]);
     });
 
     it('rejects Accept Headers with quoted parameters.', async(): Promise<void> => {

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -49,22 +49,15 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects Accept Headers with invalid types.', async(): Promise<void> => {
-      //expect((): any => parseAccept('*')).toThrow('Invalid Accept range:');
       expect(parseAccept('*')).toEqual([]);
-      //expect((): any => parseAccept('"bad"/text')).toThrow('Invalid Accept range:');
       expect(parseAccept('"bad"/text')).toEqual([]);
-      //expect((): any => parseAccept('*/\\bad')).toThrow('Invalid Accept range:');
       expect(parseAccept('*/\\bad')).toEqual([]);
-      //expect((): any => parseAccept('*/*')).not.toThrow('Invalid Accept range:');
       expect(parseAccept('*/*')).toEqual([{
         parameters: { extension: {}, mediaType: {}}, range: '*/*', weight: 1,
       }]);
     });
 
     it('ignores the weight of Accept Headers with invalid q values.', async(): Promise<void> => {
-      //expect((): any => parseAccept('a/b; q=text')).toThrow('Invalid q value:');
-      //expect((): any => parseAccept('a/b; q=0.1234')).toThrow('Invalid q value:');
-      //expect((): any => parseAccept('a/b; q=1.1')).toThrow('Invalid q value:');
       expect(parseAccept('a/b; q=text')).toEqual([{
         range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
       }]);
@@ -74,8 +67,6 @@ describe('HeaderUtil', (): void => {
       expect(parseAccept('a/b; q=1.1')).toEqual([{
         range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
       }]);
-      //expect((): any => parseAccept('a/b; q=1.000')).not.toThrow();
-      //expect((): any => parseAccept('a/b; q=0.123')).not.toThrow();
       expect(parseAccept('a/b; q=1.000')).toEqual([{
         range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
       }]);
@@ -85,9 +76,6 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects Accept Headers with invalid parameters.', async(): Promise<void> => {
-      //expect((): any => parseAccept('a/b; a')).toThrow('Invalid Accept parameter');
-      //expect((): any => parseAccept('a/b; a=\\')).toThrow('Invalid parameter value');
-      //expect((): any => parseAccept('a/b; q=1 ; a=\\')).toThrow('Invalid parameter value');
       expect(parseAccept('a/b; a')).toEqual([{
         range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
       }]);
@@ -98,6 +86,7 @@ describe('HeaderUtil', (): void => {
         range: 'a/b', weight: 1, parameters: { extension: {}, mediaType: {}},
       }]);
       expect(parseAccept('a/b; q=1 ; a')).toEqual([{
+        // eslint-disable-next-line id-length
         range: 'a/b', weight: 1, parameters: { extension: { a: '' }, mediaType: {}},
       }]);
     });
@@ -117,9 +106,9 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects invalid Accept-Charset Headers.', async(): Promise<void> => {
-      expect((): any => parseAcceptCharset('a/b')).toThrow('Invalid Accept-Charset range:');
-      expect((): any => parseAcceptCharset('a; q=text')).toThrow('Invalid q value:');
-      expect((): any => parseAcceptCharset('a; c=d')).toThrow('Only q parameters are allowed');
+      expect(parseAcceptCharset('a/b')).toEqual([]);
+      expect(parseAcceptCharset('a; q=text')).toEqual([{ range: 'a', weight: 1 }]);
+      expect(parseAcceptCharset('a; c=d')).toEqual([{ range: 'a', weight: 1 }]);
     });
   });
 
@@ -137,9 +126,9 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects invalid Accept-Encoding Headers.', async(): Promise<void> => {
-      expect((): any => parseAcceptEncoding('a/b')).toThrow('Invalid Accept-Encoding range:');
-      expect((): any => parseAcceptEncoding('a; q=text')).toThrow('Invalid q value:');
-      expect((): any => parseAcceptCharset('a; c=d')).toThrow('Only q parameters are allowed');
+      expect(parseAcceptEncoding('a/b')).toEqual([]);
+      expect(parseAcceptEncoding('a; q=text')).toEqual([{ range: 'a', weight: 1 }]);
+      expect(parseAcceptCharset('a; c=d')).toEqual([{ range: 'a', weight: 1 }]);
     });
   });
 
@@ -153,15 +142,15 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects invalid Accept-Language Headers.', async(): Promise<void> => {
-      expect((): any => parseAcceptLanguage('a/b')).toThrow('Invalid Accept-Language range:');
-      expect((): any => parseAcceptLanguage('05-a')).toThrow('Invalid Accept-Language range:');
-      expect((): any => parseAcceptLanguage('a--05')).toThrow('Invalid Accept-Language range:');
-      expect((): any => parseAcceptLanguage('a-"a"')).toThrow('Invalid Accept-Language range:');
-      expect((): any => parseAcceptLanguage('a-05')).not.toThrow('Invalid Accept-Language range:');
-      expect((): any => parseAcceptLanguage('a-b-c-d')).not.toThrow('Invalid Accept-Language range:');
+      expect(parseAcceptLanguage('a/b')).toEqual([]);
+      expect(parseAcceptLanguage('05-a')).toEqual([]);
+      expect(parseAcceptLanguage('a--05')).toEqual([]);
+      expect(parseAcceptLanguage('a-"a"')).toEqual([]);
+      expect(parseAcceptLanguage('a-05')).toEqual([{ range: 'a-05', weight: 1 }]);
+      expect(parseAcceptLanguage('a-b-c-d')).toEqual([{ range: 'a-b-c-d', weight: 1 }]);
 
-      expect((): any => parseAcceptLanguage('a; q=text')).toThrow('Invalid q value:');
-      expect((): any => parseAcceptCharset('a; c=d')).toThrow('Only q parameters are allowed');
+      expect(parseAcceptLanguage('a; q=text')).toEqual([{ range: 'a', weight: 1 }]);
+      expect(parseAcceptCharset('a; c=d')).toEqual([{ range: 'a', weight: 1 }]);
     });
   });
 
@@ -178,8 +167,8 @@ describe('HeaderUtil', (): void => {
     });
 
     it('rejects invalid Accept-DateTime Headers.', async(): Promise<void> => {
-      expect((): any => parseAcceptDateTime('a/b')).toThrow('Invalid Accept-DateTime range:');
-      expect((): any => parseAcceptDateTime('30 May 2007')).toThrow('Invalid Accept-DateTime range:');
+      expect(parseAcceptDateTime('a/b')).toEqual([]);
+      expect(parseAcceptDateTime('30 May 2007')).toEqual([]);
     });
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closing #469 

#### ✍️ Description

I have changed all (except one) method in HeaderUtil.ts to effectively ignore values that are found to be invalid.  If a different strategy was envisioned please let me know. No changes were made to validation, only how invalid values are handled. 

As this is my first PR, I fully expect plenty of changes to be needed. Also, are you setup with an auto-formatting plugin of some type? I see plenty of eslint formatting errors but was not sure if there was a specific tool that the team uses.

As a side note, I'm very excited by this project. Cheers to the team.
