### PR TITLE
Correctly handle authorization edge cases based on resource existence

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,7 @@ The following changes are relevant for v3 custom configs that replaced certain f
 ### Interface changes
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.
 - The output of `parseContentType` in `HeaderUtil` was changed to include parameters.
+- `PermissionReader`s take an additional `modes` parameter as input.
 
 ## v3.0.0
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,7 @@ These changes are relevant if you wrote custom modules for the server that depen
 - `PermissionReader`s take an additional `modes` parameter as input.
 - The `ResourceStore` function `resourceExists` has been renamed to `hasResource`
   and has been moved to a separate `ResourceSet` interface.
-- Several `ModesExtractor`s now take a `ResourceSet` as constructor parameter.
+- Several `ModesExtractor`s `PermissionBasedAuthorizer` now take a `ResourceSet` as constructor parameter.
 
 ## v3.0.0
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,8 @@ The following changes are relevant for v3 custom configs that replaced certain f
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.
 - The output of `parseContentType` in `HeaderUtil` was changed to include parameters.
 - `PermissionReader`s take an additional `modes` parameter as input.
+- The `ResourceStore` function `resourceExists` has been renamed to `hasResource`
+  and has been moved to a separate `ResourceSet` interface.
 
 ## v3.0.0
 ### New features

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ These changes are relevant if you wrote custom modules for the server that depen
 - `PermissionReader`s take an additional `modes` parameter as input.
 - The `ResourceStore` function `resourceExists` has been renamed to `hasResource`
   and has been moved to a separate `ResourceSet` interface.
+- Several `ModesExtractor`s now take a `ResourceSet` as constructor parameter.
 
 ## v3.0.0
 ### New features

--- a/config/http/middleware/handlers/cors.json
+++ b/config/http/middleware/handlers/cors.json
@@ -15,6 +15,7 @@
         "DELETE"
       ],
       "options_credentials": true,
+      "options_preflightContinue": true,
       "options_exposedHeaders": [
         "Accept-Patch",
         "ETag",

--- a/config/ldp/handler/components/authorizer.json
+++ b/config/ldp/handler/components/authorizer.json
@@ -4,7 +4,8 @@
     {
       "comment": "Matches requested permissions with those available.",
       "@id": "urn:solid-server:default:Authorizer",
-      "@type": "PermissionBasedAuthorizer"
+      "@type": "PermissionBasedAuthorizer",
+      "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" }
     }
   ]
 }

--- a/config/ldp/handler/components/operation-handler.json
+++ b/config/ldp/handler/components/operation-handler.json
@@ -6,8 +6,12 @@
       "@type": "WaterfallHandler",
       "handlers": [
         {
+          "@type": "OptionsOperationHandler",
+          "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" }
+        },
+        {
           "@type": "GetOperationHandler",
-          "store": { "@id": "urn:solid-server:default:ResourceStore" },
+          "store": { "@id": "urn:solid-server:default:ResourceStore" }
         },
         {
           "@type": "PostOperationHandler",
@@ -23,7 +27,7 @@
         },
         {
           "@type": "HeadOperationHandler",
-          "store": { "@id": "urn:solid-server:default:ResourceStore" },
+          "store": { "@id": "urn:solid-server:default:ResourceStore" }
         },
         {
           "@type": "PatchOperationHandler",

--- a/config/ldp/modes/default.json
+++ b/config/ldp/modes/default.json
@@ -12,7 +12,8 @@
         },
         {
           "comment": "Extract access modes based on the HTTP method.",
-          "@type": "MethodModesExtractor"
+          "@type": "MethodModesExtractor",
+          "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" }
         },
         {
           "@type": "StaticThrowHandler",
@@ -27,8 +28,14 @@
       "source": {
         "@type": "WaterfallHandler",
         "handlers": [
-          { "@type": "N3PatchModesExtractor" },
-          { "@type": "SparqlUpdateModesExtractor" },
+          {
+            "@type": "N3PatchModesExtractor",
+            "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" }
+          },
+          {
+            "@type": "SparqlUpdateModesExtractor",
+            "resourceSet": { "@id": "urn:solid-server:default:CachedResourceSet" }
+          },
           {
             "@type": "StaticThrowHandler",
             "error": { "@type": "UnsupportedMediaTypeHttpError" }

--- a/config/storage/middleware/default.json
+++ b/config/storage/middleware/default.json
@@ -7,6 +7,12 @@
   ],
   "@graph": [
     {
+      "comment": "A cache to prevent duplicate existence checks on resources.",
+      "@id": "urn:solid-server:default:CachedResourceSet",
+      "@type": "CachedResourceSet",
+      "source": { "@id": "urn:solid-server:default:ResourceStore" }
+    },
+    {
       "comment": "Sets up a stack of utility stores used by most instances.",
       "@id": "urn:solid-server:default:ResourceStore",
       "@type": "MonitoringStore",

--- a/src/authorization/PermissionReader.ts
+++ b/src/authorization/PermissionReader.ts
@@ -1,7 +1,7 @@
 import type { CredentialSet } from '../authentication/Credentials';
 import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
 import { AsyncHandler } from '../util/handlers/AsyncHandler';
-import type { PermissionSet } from './permissions/Permissions';
+import type { AccessMode, PermissionSet } from './permissions/Permissions';
 
 export interface PermissionReaderInput {
   /**
@@ -12,6 +12,12 @@ export interface PermissionReaderInput {
    * Identifier of the resource that will be read/modified.
    */
   identifier: ResourceIdentifier;
+  /**
+   * This is the minimum set of access modes the output needs to contain,
+   * allowing the handler to limit its search space to this set.
+   * However, non-exhaustive information about other access modes can still be returned.
+   */
+  modes: Set<AccessMode>;
 }
 
 /**

--- a/src/authorization/WebAclReader.ts
+++ b/src/authorization/WebAclReader.ts
@@ -64,7 +64,8 @@ export class WebAclReader extends PermissionReader {
     const isAcl = this.aclStrategy.isAuxiliaryIdentifier(identifier);
     const mainIdentifier = isAcl ? this.aclStrategy.getSubjectIdentifier(identifier) : identifier;
 
-    // Determine the full authorization for the agent granted by the applicable ACL
+    // Determine the full authorization for the agent granted by the applicable ACL.
+    // Note that we don't filter on input modes as all results are needed for the WAC-Allow header.
     const acl = await this.getAclRecursive(mainIdentifier);
     return this.createPermissions(credentials, acl, isAcl);
   }

--- a/src/authorization/permissions/MethodModesExtractor.ts
+++ b/src/authorization/permissions/MethodModesExtractor.ts
@@ -5,7 +5,7 @@ import { isContainerIdentifier } from '../../util/PathUtil';
 import { ModesExtractor } from './ModesExtractor';
 import { AccessMode } from './Permissions';
 
-const READ_METHODS = new Set([ 'GET', 'HEAD' ]);
+const READ_METHODS = new Set([ 'OPTIONS', 'GET', 'HEAD' ]);
 const SUPPORTED_METHODS = new Set([ ...READ_METHODS, 'PUT', 'POST', 'DELETE' ]);
 
 /**

--- a/src/authorization/permissions/MethodModesExtractor.ts
+++ b/src/authorization/permissions/MethodModesExtractor.ts
@@ -1,37 +1,63 @@
 import type { Operation } from '../../http/Operation';
+import type { ResourceSet } from '../../storage/ResourceSet';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { isContainerIdentifier } from '../../util/PathUtil';
 import { ModesExtractor } from './ModesExtractor';
 import { AccessMode } from './Permissions';
 
 const READ_METHODS = new Set([ 'GET', 'HEAD' ]);
-const WRITE_METHODS = new Set([ 'PUT', 'DELETE' ]);
-const APPEND_METHODS = new Set([ 'POST' ]);
-const SUPPORTED_METHODS = new Set([ ...READ_METHODS, ...WRITE_METHODS, ...APPEND_METHODS ]);
+const SUPPORTED_METHODS = new Set([ ...READ_METHODS, 'PUT', 'POST', 'DELETE' ]);
 
 /**
  * Generates permissions for the base set of methods that always require the same permissions.
  * Specifically: GET, HEAD, POST, PUT and DELETE.
  */
 export class MethodModesExtractor extends ModesExtractor {
+  private readonly resourceSet: ResourceSet;
+
+  /**
+   * Certain permissions depend on the existence of the target resource.
+   * The provided {@link ResourceSet} will be used for that.
+   * @param resourceSet - {@link ResourceSet} that can verify the target resource existence.
+   */
+  public constructor(resourceSet: ResourceSet) {
+    super();
+    this.resourceSet = resourceSet;
+  }
+
   public async canHandle({ method }: Operation): Promise<void> {
     if (!SUPPORTED_METHODS.has(method)) {
       throw new NotImplementedHttpError(`Cannot determine permissions of ${method}`);
     }
   }
 
-  public async handle({ method }: Operation): Promise<Set<AccessMode>> {
-    const result = new Set<AccessMode>();
+  public async handle({ method, target }: Operation): Promise<Set<AccessMode>> {
+    const modes = new Set<AccessMode>();
+    // Reading requires Read permissions on the resource
     if (READ_METHODS.has(method)) {
-      result.add(AccessMode.read);
+      modes.add(AccessMode.read);
     }
-    if (WRITE_METHODS.has(method)) {
-      result.add(AccessMode.write);
-      result.add(AccessMode.append);
-      result.add(AccessMode.create);
-      result.add(AccessMode.delete);
-    } else if (APPEND_METHODS.has(method)) {
-      result.add(AccessMode.append);
+    // Setting a resource's representation requires Write permissions
+    if (method === 'PUT') {
+      modes.add(AccessMode.write);
+      // …and, if the resource does not exist yet, Create permissions are required as well
+      if (!await this.resourceSet.hasResource(target)) {
+        modes.add(AccessMode.create);
+      }
     }
-    return result;
+    // Creating a new resource in a container requires Append access to that container
+    if (method === 'POST') {
+      modes.add(AccessMode.append);
+    }
+    // Deleting a resource requires Delete access
+    if (method === 'DELETE') {
+      modes.add(AccessMode.delete);
+      // …and, if the target is a container, Read permissions are required as well
+      // as this exposes if a container is empty or not
+      if (isContainerIdentifier(target)) {
+        modes.add(AccessMode.read);
+      }
+    }
+    return modes;
   }
 }

--- a/src/authorization/permissions/N3PatchModesExtractor.ts
+++ b/src/authorization/permissions/N3PatchModesExtractor.ts
@@ -1,6 +1,7 @@
 import type { Operation } from '../../http/Operation';
 import type { N3Patch } from '../../http/representation/N3Patch';
 import { isN3Patch } from '../../http/representation/N3Patch';
+import type { ResourceSet } from '../../storage/ResourceSet';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
 import { ModesExtractor } from './ModesExtractor';
 import { AccessMode } from './Permissions';
@@ -14,13 +15,25 @@ import { AccessMode } from './Permissions';
  * https://solid.github.io/specification/protocol#n3-patch
  */
 export class N3PatchModesExtractor extends ModesExtractor {
+  private readonly resourceSet: ResourceSet;
+
+  /**
+   * Certain permissions depend on the existence of the target resource.
+   * The provided {@link ResourceSet} will be used for that.
+   * @param resourceSet - {@link ResourceSet} that can verify the target resource existence.
+   */
+  public constructor(resourceSet: ResourceSet) {
+    super();
+    this.resourceSet = resourceSet;
+  }
+
   public async canHandle({ body }: Operation): Promise<void> {
     if (!isN3Patch(body)) {
       throw new NotImplementedHttpError('Can only determine permissions of N3 Patch documents.');
     }
   }
 
-  public async handle({ body }: Operation): Promise<Set<AccessMode>> {
+  public async handle({ body, target }: Operation): Promise<Set<AccessMode>> {
     const { deletes, inserts, conditions } = body as N3Patch;
 
     const accessModes = new Set<AccessMode>();
@@ -32,6 +45,9 @@ export class N3PatchModesExtractor extends ModesExtractor {
     // When ?insertions is non-empty, servers MUST (also) treat the request as an Append operation.
     if (inserts.length > 0) {
       accessModes.add(AccessMode.append);
+      if (!await this.resourceSet.hasResource(target)) {
+        accessModes.add(AccessMode.create);
+      }
     }
     // When ?deletions is non-empty, servers MUST treat the request as a Read and Write operation.
     if (deletes.length > 0) {

--- a/src/http/ldp/OptionsOperationHandler.ts
+++ b/src/http/ldp/OptionsOperationHandler.ts
@@ -1,0 +1,36 @@
+import type { ResourceSet } from '../../storage/ResourceSet';
+import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { NoContentResponseDescription } from '../output/response/NoContentResponseDescription';
+import type { ResponseDescription } from '../output/response/ResponseDescription';
+import type { OperationHandlerInput } from './OperationHandler';
+import { OperationHandler } from './OperationHandler';
+
+/**
+ * Handles OPTIONS {@link Operation}s by always returning a 204.
+ */
+export class OptionsOperationHandler extends OperationHandler {
+  private readonly resourceSet: ResourceSet;
+
+  /**
+   * Uses a {@link ResourceSet} to determine the existence of the target resource which impacts the response code.
+   * @param resourceSet - {@link ResourceSet} that knows if the target resource exists or not.
+   */
+  public constructor(resourceSet: ResourceSet) {
+    super();
+    this.resourceSet = resourceSet;
+  }
+
+  public async canHandle({ operation }: OperationHandlerInput): Promise<void> {
+    if (operation.method !== 'OPTIONS') {
+      throw new NotImplementedHttpError('This handler only supports OPTIONS operations');
+    }
+  }
+
+  public async handle({ operation }: OperationHandlerInput): Promise<ResponseDescription> {
+    if (!await this.resourceSet.hasResource(operation.target)) {
+      throw new NotFoundHttpError();
+    }
+    return new NoContentResponseDescription();
+  }
+}

--- a/src/http/ldp/PatchOperationHandler.ts
+++ b/src/http/ldp/PatchOperationHandler.ts
@@ -42,7 +42,7 @@ export class PatchOperationHandler extends OperationHandler {
     // RFC7231, §4.3.4: If the target resource does not have a current representation and the
     //   PUT successfully creates one, then the origin server MUST inform the
     //   user agent by sending a 201 (Created) response.
-    const exists = await this.store.resourceExists(operation.target, operation.conditions);
+    const exists = await this.store.hasResource(operation.target);
     await this.store.modifyResource(operation.target, operation.body as Patch, operation.conditions);
     if (exists) {
       return new ResetResponseDescription();

--- a/src/http/ldp/PutOperationHandler.ts
+++ b/src/http/ldp/PutOperationHandler.ts
@@ -38,7 +38,7 @@ export class PutOperationHandler extends OperationHandler {
     }
     // A more efficient approach would be to have the server return metadata indicating if a resource was new
     // See https://github.com/solid/community-server/issues/632
-    const exists = await this.store.resourceExists(operation.target, operation.conditions);
+    const exists = await this.store.hasResource(operation.target);
     await this.store.setRepresentation(operation.target, operation.body, operation.conditions);
     if (exists) {
       return new ResetResponseDescription();

--- a/src/http/output/response/NoContentResponseDescription.ts
+++ b/src/http/output/response/NoContentResponseDescription.ts
@@ -1,0 +1,10 @@
+import { ResponseDescription } from './ResponseDescription';
+
+/**
+ * Corresponds to a 204 response.
+ */
+export class NoContentResponseDescription extends ResponseDescription {
+  public constructor() {
+    super(204);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ export * from './http/ldp/DeleteOperationHandler';
 export * from './http/ldp/GetOperationHandler';
 export * from './http/ldp/HeadOperationHandler';
 export * from './http/ldp/OperationHandler';
+export * from './http/ldp/OptionsOperationHandler';
 export * from './http/ldp/PatchOperationHandler';
 export * from './http/ldp/PostOperationHandler';
 export * from './http/ldp/PutOperationHandler';
@@ -103,6 +104,7 @@ export * from './http/output/metadata/WwwAuthMetadataWriter';
 
 // HTTP/Output/Response
 export * from './http/output/response/CreatedResponseDescription';
+export * from './http/output/response/NoContentResponseDescription';
 export * from './http/output/response/OkResponseDescription';
 export * from './http/output/response/ResetResponseDescription';
 export * from './http/output/response/ResponseDescription';

--- a/src/index.ts
+++ b/src/index.ts
@@ -349,6 +349,7 @@ export * from './storage/validators/QuotaValidator';
 export * from './storage/AtomicResourceStore';
 export * from './storage/BaseResourceStore';
 export * from './storage/BasicConditions';
+export * from './storage/CachedResourceSet';
 export * from './storage/Conditions';
 export * from './storage/DataAccessorBasedStore';
 export * from './storage/IndexRepresentationStore';

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,7 @@ export * from './storage/PassthroughStore';
 export * from './storage/PatchingStore';
 export * from './storage/ReadOnlyStore';
 export * from './storage/RepresentationConvertingStore';
+export * from './storage/ResourceSet';
 export * from './storage/ResourceStore';
 export * from './storage/RoutingResourceStore';
 

--- a/src/pods/GeneratedPodManager.ts
+++ b/src/pods/GeneratedPodManager.ts
@@ -28,7 +28,7 @@ export class GeneratedPodManager implements PodManager {
    */
   public async createPod(identifier: ResourceIdentifier, settings: PodSettings, overwrite: boolean): Promise<void> {
     this.logger.info(`Creating pod ${identifier.path}`);
-    if (!overwrite && await this.store.resourceExists(identifier)) {
+    if (!overwrite && await this.store.hasResource(identifier)) {
       throw new ConflictHttpError(`There already is a resource at ${identifier.path}`);
     }
 

--- a/src/server/AuthorizingHttpHandler.ts
+++ b/src/server/AuthorizingHttpHandler.ts
@@ -66,7 +66,7 @@ export class AuthorizingHttpHandler extends OperationHttpHandler {
     const modes = await this.modesExtractor.handleSafe(operation);
     this.logger.verbose(`Required modes are read: ${[ ...modes ].join(',')}`);
 
-    const permissionSet = await this.permissionReader.handleSafe({ credentials, identifier: operation.target });
+    const permissionSet = await this.permissionReader.handleSafe({ credentials, identifier: operation.target, modes });
     this.logger.verbose(`Available permissions are ${JSON.stringify(permissionSet)}`);
 
     try {

--- a/src/server/middleware/CorsHandler.ts
+++ b/src/server/middleware/CorsHandler.ts
@@ -21,12 +21,13 @@ interface SimpleCorsOptions {
 
 /**
  * Handler that sets CORS options on the response.
- * In case of an OPTIONS request this handler will close the connection after adding its headers.
+ * In case of an OPTIONS request this handler will close the connection after adding its headers
+ * if `preflightContinue` is set to `false`.
  *
- * Solid, §7.1: "A data pod MUST implement the CORS protocol [FETCH] such that, to the extent possible,
- * the browser allows Solid apps to send any request and combination of request headers to the data pod,
- * and the Solid app can read any response and response headers received from the data pod."
- * Full details: https://solid.github.io/specification/protocol#cors-server
+ * Solid, §8.1: "A server MUST implement the CORS protocol [FETCH] such that, to the extent possible,
+ * the browser allows Solid apps to send any request and combination of request headers to the server,
+ * and the Solid app can read any response and response headers received from the server."
+ * Full details: https://solidproject.org/TR/2021/protocol-20211217#cors-server
  */
 export class CorsHandler extends HttpHandler {
   private readonly corsHandler: (

--- a/src/storage/BaseResourceStore.ts
+++ b/src/storage/BaseResourceStore.ts
@@ -11,7 +11,7 @@ import type { ResourceStore } from './ResourceStore';
  */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export class BaseResourceStore implements ResourceStore {
-  public async resourceExists(identifier: ResourceIdentifier, conditions?: Conditions): Promise<boolean> {
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
     throw new NotImplementedHttpError();
   }
 

--- a/src/storage/CachedResourceSet.ts
+++ b/src/storage/CachedResourceSet.ts
@@ -1,0 +1,24 @@
+import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
+import type { ResourceSet } from './ResourceSet';
+
+/**
+ * Caches resource existence in a `WeakMap` tied to the `ResourceIdentifier` object.
+ */
+export class CachedResourceSet implements ResourceSet {
+  private readonly source: ResourceSet;
+  private readonly cache: WeakMap<ResourceIdentifier, boolean>;
+
+  public constructor(source: ResourceSet) {
+    this.source = source;
+    this.cache = new WeakMap();
+  }
+
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
+    if (this.cache.has(identifier)) {
+      return this.cache.get(identifier)!;
+    }
+    const result = await this.source.hasResource(identifier);
+    this.cache.set(identifier, result);
+    return result;
+  }
+}

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -81,7 +81,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     this.auxiliaryStrategy = auxiliaryStrategy;
   }
 
-  public async resourceExists(identifier: ResourceIdentifier): Promise<boolean> {
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
     try {
       this.validateIdentifier(identifier);
       await this.accessor.getMetadata(identifier);
@@ -530,7 +530,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     // Make sure we don't already have a resource with this exact name (or with differing trailing slash)
     const withSlash = { path: ensureTrailingSlash(newID.path) };
     const withoutSlash = { path: trimTrailingSlashes(newID.path) };
-    if (await this.resourceExists(withSlash) || await this.resourceExists(withoutSlash)) {
+    if (await this.hasResource(withSlash) || await this.hasResource(withoutSlash)) {
       newID = this.createURI(container, isContainer);
     }
 

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -34,9 +34,9 @@ export class LockingResourceStore implements AtomicResourceStore {
     this.auxiliaryStrategy = auxiliaryStrategy;
   }
 
-  public async resourceExists(identifier: ResourceIdentifier, conditions?: Conditions): Promise<boolean> {
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
     return this.locks.withReadLock(this.getLockIdentifier(identifier),
-      async(): Promise<boolean> => this.source.resourceExists(identifier, conditions));
+      async(): Promise<boolean> => this.source.hasResource(identifier));
   }
 
   public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,

--- a/src/storage/MonitoringStore.ts
+++ b/src/storage/MonitoringStore.ts
@@ -19,8 +19,8 @@ export class MonitoringStore<T extends ResourceStore = ResourceStore>
     this.source = source;
   }
 
-  public async resourceExists(identifier: ResourceIdentifier, conditions?: Conditions): Promise<boolean> {
-    return this.source.resourceExists(identifier, conditions);
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
+    return this.source.hasResource(identifier);
   }
 
   public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,

--- a/src/storage/PassthroughStore.ts
+++ b/src/storage/PassthroughStore.ts
@@ -17,8 +17,8 @@ export class PassthroughStore<T extends ResourceStore = ResourceStore> implement
     this.source = source;
   }
 
-  public async resourceExists(identifier: ResourceIdentifier, conditions?: Conditions): Promise<boolean> {
-    return this.source.resourceExists(identifier, conditions);
+  public async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
+    return this.source.hasResource(identifier);
   }
 
   public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,

--- a/src/storage/ResourceSet.ts
+++ b/src/storage/ResourceSet.ts
@@ -1,0 +1,14 @@
+import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
+
+/**
+ * A set containing resources.
+ */
+export interface ResourceSet {
+  /**
+   * Check if a resource exists in this ResourceSet.
+   * @param identifier - Identifier of resource to check.
+   *
+   * @returns A promise resolving if the resource already exists.
+   */
+  hasResource: (identifier: ResourceIdentifier) => Promise<boolean>;
+}

--- a/src/storage/ResourceStore.ts
+++ b/src/storage/ResourceStore.ts
@@ -3,6 +3,7 @@ import type { Representation } from '../http/representation/Representation';
 import type { RepresentationPreferences } from '../http/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
 import type { Conditions } from './Conditions';
+import type { ResourceSet } from './ResourceSet';
 
 /**
  * A ResourceStore represents a collection of resources.
@@ -15,16 +16,7 @@ import type { Conditions } from './Conditions';
  * ResourceStores are also responsible for taking auxiliary resources into account
  * should those be relevant to the store.
  */
-export interface ResourceStore {
-
-  /**
-   * Check if a resource exists.
-   * @param identifier - Identifier of resource to check.
-   *
-   * @returns A promise resolving if the resource already exists
-   */
-  resourceExists: (identifier: ResourceIdentifier, conditions?: Conditions) => Promise<boolean>;
-
+export interface ResourceStore extends ResourceSet {
   /**
    * Retrieves a representation of a resource.
    * @param identifier - Identifier of the resource to read.

--- a/src/storage/RoutingResourceStore.ts
+++ b/src/storage/RoutingResourceStore.ts
@@ -20,9 +20,9 @@ export class RoutingResourceStore implements ResourceStore {
     this.rule = rule;
   }
 
-  public async resourceExists(identifier: ResourceIdentifier, conditions?: Conditions):
+  public async hasResource(identifier: ResourceIdentifier):
   Promise<boolean> {
-    return (await this.getStore(identifier)).resourceExists(identifier, conditions);
+    return (await this.getStore(identifier)).hasResource(identifier);
   }
 
   public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -42,7 +42,7 @@ export class JsonResourceStorage implements KeyValueStorage<string, unknown> {
 
   public async has(key: string): Promise<boolean> {
     const identifier = this.createIdentifier(key);
-    return await this.source.resourceExists(identifier);
+    return await this.source.hasResource(identifier);
   }
 
   public async set(key: string, value: unknown): Promise<this> {

--- a/src/storage/routing/ConvertingRouterRule.ts
+++ b/src/storage/routing/ConvertingRouterRule.ts
@@ -39,7 +39,7 @@ export class ConvertingRouterRule extends RouterRule {
         entry.supportChecker.supports({ identifier, representation }));
     } else {
       // No content-type given so we can only check if one of the stores has data for the identifier
-      store = await this.findStore(async(entry): Promise<boolean> => entry.store.resourceExists(identifier));
+      store = await this.findStore(async(entry): Promise<boolean> => entry.store.hasResource(identifier));
     }
     return store;
   }

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -70,7 +70,7 @@ describe('An http server with middleware', (): void => {
       .set('Access-Control-Request-Headers', 'content-type')
       .set('Access-Control-Request-Method', 'POST')
       .set('Host', 'test.com')
-      .expect(204);
+      .expect(200);
     expect(res.header).toEqual(expect.objectContaining({
       'access-control-allow-origin': '*',
       'access-control-allow-headers': 'content-type',

--- a/test/integration/PermissionTable.test.ts
+++ b/test/integration/PermissionTable.test.ts
@@ -44,10 +44,9 @@ const allModes = [ AM.read, AM.append, AM.create, AM.write, AM.delete ];
 // For PUT/PATCH/DELETE we return 205 instead of 200/204
 /* eslint-disable no-multi-spaces */
 const table: [string, string, AM[], AM[] | undefined, string, string, number, number][] = [
-  // We currently handle OPTIONS before authorization
-  // [ 'OPTIONS', 'C/R', [],                     undefined,              '',     '',  401, 401 ],
-  // [ 'OPTIONS', 'C/R', [],                     [ AM.read ],            '',     '',  200, 404 ],
-  // [ 'OPTIONS', 'C/R', [ AM.read ],            undefined,              '',     '',  200, 404 ],
+  [ 'OPTIONS', 'C/R', [],                     undefined,              '',     '',  401, 401 ],
+  [ 'OPTIONS', 'C/R', [],                     [ AM.read ],            '',     '',  204, 404 ],
+  [ 'OPTIONS', 'C/R', [ AM.read ],            undefined,              '',     '',  204, 404 ],
 
   [ 'HEAD',    'C/R', [],                     undefined,              '',     '',  401, 401 ],
   [ 'HEAD',    'C/R', [],                     [ AM.read ],            '',     '',  200, 404 ],

--- a/test/integration/PermissionTable.test.ts
+++ b/test/integration/PermissionTable.test.ts
@@ -1,0 +1,218 @@
+import fetch from 'cross-fetch';
+import { v4 } from 'uuid';
+import type { AclPermission } from '../../src/authorization/permissions/AclPermission';
+import { AccessMode as AM } from '../../src/authorization/permissions/Permissions';
+import { BasicRepresentation } from '../../src/http/representation/BasicRepresentation';
+import type { App } from '../../src/init/App';
+import type { ResourceStore } from '../../src/storage/ResourceStore';
+import { TEXT_TURTLE } from '../../src/util/ContentTypes';
+import { ensureTrailingSlash, joinUrl } from '../../src/util/PathUtil';
+import { AclHelper } from '../util/AclHelper';
+import { getPort } from '../util/Util';
+import {
+  getDefaultVariables,
+  getPresetConfigPath,
+  getTestConfigPath,
+  getTestFolder,
+  instantiateFromConfig, removeFolder,
+} from './Config';
+
+const DEFAULT_BODY = `@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://www.example.org/terms#>.
+
+ex:custom ex:givenName "Claudia".`;
+
+const INSERT = `@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://www.example.org/terms#>.
+_:patch a solid:InsertDeletePatch;
+  solid:inserts { ex:custom ex:givenName "Alex". }.`;
+
+const DELETE = `@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://www.example.org/terms#>.
+
+_:rename a solid:InsertDeletePatch;
+  solid:deletes { ex:custom ex:givenName "Claudia". }.`;
+
+const N3 = 'text/n3';
+const TXT = 'text/plain';
+
+const allModes = [ AM.read, AM.append, AM.create, AM.write, AM.delete ];
+
+// Based on https://github.com/solid/specification/issues/14#issuecomment-683480525
+// Columns: method, target, C/ permissions, C/R permissions, body, content-type, target exists, target does not exist
+// `undefined` implies C/R inherits the permissions of C/
+// For PUT/PATCH/DELETE we return 205 instead of 200/204
+/* eslint-disable no-multi-spaces */
+const table: [string, string, AM[], AM[] | undefined, string, string, number, number][] = [
+  // We currently handle OPTIONS before authorization
+  // [ 'OPTIONS', 'C/R', [],                     undefined,              '',     '',  401, 401 ],
+  // [ 'OPTIONS', 'C/R', [],                     [ AM.read ],            '',     '',  200, 404 ],
+  // [ 'OPTIONS', 'C/R', [ AM.read ],            undefined,              '',     '',  200, 404 ],
+
+  [ 'HEAD',    'C/R', [],                     undefined,              '',     '',  401, 401 ],
+  [ 'HEAD',    'C/R', [],                     [ AM.read ],            '',     '',  200, 404 ],
+  [ 'HEAD',    'C/R', [ AM.read ],            undefined,              '',     '',  200, 404 ],
+
+  [ 'GET',     'C/R', [],                     undefined,              '',     '',  401, 401 ],
+  [ 'GET',     'C/R', [],                     [ AM.read ],            '',     '',  200, 404 ],
+  [ 'GET',     'C/R', [ AM.read ],            undefined,              '',     '',  200, 404 ],
+  // Agreed upon deviation from the original table; more conservative interpretation allowed.
+  // Original returns 404 in the case of C/R not existing.
+  [ 'GET',     'C/R', [ AM.read ],            [ AM.write ],           '',     '',  401, 401 ],
+
+  [ 'POST',    'C/',  [],                     undefined,              '',     TXT, 401, 401 ],
+  [ 'POST',    'C/',  [],                     [ AM.read ],            '',     TXT, 401, 401 ],
+  [ 'POST',    'C/',  [ AM.append ],          undefined,              '',     TXT, 201, 201 ],
+  [ 'POST',    'C/',  [ AM.append ],          [ AM.read ],            '',     TXT, 201, 201 ],
+  [ 'POST',    'C/',  [ AM.read, AM.append ], undefined,              '',     TXT, 201, 201 ],
+  [ 'POST',    'C/',  [ AM.read, AM.append ], [ AM.read ],            '',     TXT, 201, 201 ],
+
+  [ 'PUT',     'C/',  [],                     undefined,              '',     N3,  401, 401 ],
+  [ 'PUT',     'C/',  [ AM.read ],            undefined,              '',     N3,  401, 401 ],
+  [ 'PUT',     'C/',  [ AM.write ],           undefined,              '',     N3,  205, 201 ],
+
+  [ 'PUT',     'C/R', [],                     undefined,              '',     TXT, 401, 401 ],
+  [ 'PUT',     'C/R', [],                     [ AM.read ],            '',     TXT, 401, 401 ],
+  [ 'PUT',     'C/R', [],                     [ AM.append ],          '',     TXT, 401, 401 ],
+  [ 'PUT',     'C/R', [],                     [ AM.write ],           '',     TXT, 205, 401 ],
+  [ 'PUT',     'C/R', [ AM.read ],            undefined,              '',     TXT, 401, 401 ],
+  [ 'PUT',     'C/R', [ AM.append ],          undefined,              '',     TXT, 401, 401 ],
+  [ 'PUT',     'C/R', [ AM.write ],           undefined,              '',     TXT, 205, 201 ],
+  [ 'PUT',     'C/R', [ AM.append ],          [ AM.write ],           '',     TXT, 205, 201 ],
+
+  [ 'PATCH',   'C/R', [],                     undefined,              DELETE, N3,  401, 401 ],
+  [ 'PATCH',   'C/R', [],                     [ AM.read ],            DELETE, N3,  401, 404 ],
+  [ 'PATCH',   'C/R', [],                     [ AM.append ],          INSERT, N3,  205, 401 ],
+  [ 'PATCH',   'C/R', [],                     [ AM.append ],          DELETE, N3,  401, 401 ],
+  [ 'PATCH',   'C/R', [],                     [ AM.write ],           INSERT, N3,  205, 401 ],
+  [ 'PATCH',   'C/R', [],                     [ AM.write ],           DELETE, N3,  401, 401 ],
+  [ 'PATCH',   'C/R', [ AM.append ],          [ AM.write ],           INSERT, N3,  205, 201 ],
+  [ 'PATCH',   'C/R', [ AM.append ],          [ AM.write ],           DELETE, N3,  401, 401 ],
+  // We currently return 409 instead of 404 in case a PATCH has no inserts and C/R does not exist.
+  // This is an agreed upon deviation from the original table
+  [ 'PATCH',   'C/R', [],                     [ AM.read, AM.write ],  DELETE, N3,  205, 409 ],
+
+  [ 'DELETE',  'C/R', [],                     undefined,              '',     '',  401, 401 ],
+  [ 'DELETE',  'C/R', [],                     [ AM.read ],            '',     '',  401, 404 ],
+  [ 'DELETE',  'C/R', [],                     [ AM.append ],          '',     '',  401, 401 ],
+  [ 'DELETE',  'C/R', [],                     [ AM.write ],           '',     '',  401, 401 ],
+  [ 'DELETE',  'C/R', [ AM.read ],            undefined,              '',     '',  401, 404 ],
+  [ 'DELETE',  'C/R', [ AM.append ],          undefined,              '',     '',  401, 401 ],
+  [ 'DELETE',  'C/R', [ AM.append ],          [ AM.read ],            '',     '',  401, 404 ],
+  // We throw a 404 instead of 401 since we don't yet check if the parent container has read permissions
+  // [ 'DELETE',  'C/R', [ AM.write ],           undefined,              '',     '',  205, 401 ],
+  [ 'DELETE',  'C/R', [ AM.write ],           [ AM.read ],            '',     '',  401, 404 ],
+  [ 'DELETE',  'C/R', [ AM.write ],           [ AM.append ],          '',     '',  401, 401 ],
+
+  [ 'DELETE',  'C/',  [],                     undefined,              '',     '',  401, 401 ],
+  [ 'DELETE',  'C/',  [ AM.read ],            undefined,              '',     '',  401, 404 ],
+  [ 'DELETE',  'C/',  [ AM.append ],          undefined,              '',     '',  401, 401 ],
+  [ 'DELETE',  'C/',  [ AM.write ],           undefined,              '',     '',  401, 401 ],
+  [ 'DELETE',  'C/',  [ AM.read, AM.write ],  undefined,              '',     '',  205, 404 ],
+];
+/* eslint-enable no-multi-spaces */
+
+function toPermission(modes: AM[]): AclPermission {
+  return Object.fromEntries(modes.map((mode): [AM, boolean] => [ mode, true ]));
+}
+
+const port = getPort('PermissionTable');
+const baseUrl = `http://localhost:${port}/`;
+
+const rootFilePath = getTestFolder('permissionTable');
+const stores: [string, any][] = [
+  [ 'in-memory storage', {
+    storeConfig: 'storage/backend/memory.json',
+    teardown: jest.fn(),
+  }],
+  [ 'on-disk storage', {
+    storeConfig: 'storage/backend/file.json',
+    teardown: async(): Promise<void> => removeFolder(rootFilePath),
+  }],
+];
+
+describe.each(stores)('A request on a server with %s', (name, { storeConfig, teardown }): void => {
+  let app: App;
+  let store: ResourceStore;
+  let aclHelper: AclHelper;
+
+  beforeAll(async(): Promise<void> => {
+    const variables = {
+      ...getDefaultVariables(port, baseUrl),
+      'urn:solid-server:default:variable:rootFilePath': rootFilePath,
+    };
+
+    // Create and start the server
+    const instances = await instantiateFromConfig(
+      'urn:solid-server:test:Instances',
+      [
+        getPresetConfigPath(storeConfig),
+        getTestConfigPath('ldp-with-auth.json'),
+      ],
+      variables,
+    ) as Record<string, any>;
+    ({ app, store } = instances);
+
+    await app.start();
+
+    // Create test helper for manipulating acl
+    aclHelper = new AclHelper(store);
+
+    // Set the root acl file to allow everything
+    await aclHelper.setSimpleAcl(baseUrl, {
+      permissions: { read: true, write: true, append: true, control: true },
+      agentClass: 'agent',
+      accessTo: true,
+      default: true,
+    });
+  });
+
+  afterAll(async(): Promise<void> => {
+    await teardown();
+    await app.stop();
+  });
+
+  describe.each(table)('%s %s with permissions C/: %s and C/R: %s.', (...entry): void => {
+    const [ method, target, cPerm, crPermTemp, body, contentType, existsCode, notExistsCode ] = entry;
+    const crPerm = crPermTemp ?? cPerm;
+    const id = v4();
+    const root = ensureTrailingSlash(joinUrl(baseUrl, id));
+    const container = ensureTrailingSlash(joinUrl(root, 'container/'));
+    const resource = joinUrl(container, 'resource');
+    const targetingContainer = target !== 'C/R';
+    const targetUrl = targetingContainer ? container : resource;
+    let init: RequestInit;
+
+    beforeEach(async(): Promise<void> => {
+      // POST is special as the request targets the container but we care about the generated resource
+      const parent = targetingContainer && method !== 'POST' ? root : container;
+
+      // Create C/ and set up permissions
+      await store.setRepresentation({ path: parent }, new BasicRepresentation([], TEXT_TURTLE));
+
+      await aclHelper.setSimpleAcl(parent, [
+        // In case we are targeting C/ we assume everything is allowed by the parent
+        { permissions: toPermission(parent === root ? allModes : cPerm), agentClass: 'agent', accessTo: true },
+        { permissions: toPermission(parent === root ? cPerm : crPerm), agentClass: 'agent', default: true },
+      ]);
+
+      // Set up fetch parameters
+      init = { method };
+      if (contentType && contentType.length > 0) {
+        init.body = body;
+        init.headers = { 'content-type': contentType };
+      }
+    });
+
+    it('target does not exist.', async(): Promise<void> => {
+      const response = await fetch(targetUrl, init);
+      expect(response.status).toBe(notExistsCode);
+    });
+
+    it('target exists.', async(): Promise<void> => {
+      await store.setRepresentation({ path: targetUrl }, new BasicRepresentation(DEFAULT_BODY, TEXT_TURTLE));
+      const response = await fetch(targetUrl, init);
+      expect(response.status).toBe(existsCode);
+    });
+  });
+});

--- a/test/unit/authorization/AllStaticReader.test.ts
+++ b/test/unit/authorization/AllStaticReader.test.ts
@@ -23,12 +23,12 @@ describe('An AllStaticReader', (): void => {
 
   it('always returns permissions matching the given allow parameter.', async(): Promise<void> => {
     let authorizer = new AllStaticReader(true);
-    await expect(authorizer.handle({ credentials, identifier })).resolves.toEqual({
+    await expect(authorizer.handle({ credentials, identifier, modes: new Set() })).resolves.toEqual({
       [CredentialGroup.agent]: getPermissions(true),
     });
 
     authorizer = new AllStaticReader(false);
-    await expect(authorizer.handle({ credentials, identifier })).resolves.toEqual({
+    await expect(authorizer.handle({ credentials, identifier, modes: new Set() })).resolves.toEqual({
       [CredentialGroup.agent]: getPermissions(false),
     });
   });

--- a/test/unit/authorization/PathBasedReader.test.ts
+++ b/test/unit/authorization/PathBasedReader.test.ts
@@ -15,6 +15,7 @@ describe('A PathBasedReader', (): void => {
     input = {
       identifier: { path: `${baseUrl}first` },
       credentials: {},
+      modes: new Set(),
     };
 
     readers = [

--- a/test/unit/authorization/PermissionBasedAuthorizer.test.ts
+++ b/test/unit/authorization/PermissionBasedAuthorizer.test.ts
@@ -2,11 +2,14 @@ import { CredentialGroup } from '../../../src/authentication/Credentials';
 import type { AuthorizerInput } from '../../../src/authorization/Authorizer';
 import { PermissionBasedAuthorizer } from '../../../src/authorization/PermissionBasedAuthorizer';
 import { AccessMode } from '../../../src/authorization/permissions/Permissions';
+import type { ResourceSet } from '../../../src/storage/ResourceSet';
 import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError';
+import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import { UnauthorizedHttpError } from '../../../src/util/errors/UnauthorizedHttpError';
 
 describe('A PermissionBasedAuthorizer', (): void => {
   let input: AuthorizerInput;
+  let resourceSet: jest.Mocked<ResourceSet>;
   let authorizer: PermissionBasedAuthorizer;
 
   beforeEach(async(): Promise<void> => {
@@ -16,8 +19,11 @@ describe('A PermissionBasedAuthorizer', (): void => {
       permissionSet: {},
       credentials: {},
     };
+    resourceSet = {
+      hasResource: jest.fn().mockResolvedValue(true),
+    };
 
-    authorizer = new PermissionBasedAuthorizer();
+    authorizer = new PermissionBasedAuthorizer(resourceSet);
   });
 
   it('can handle any input.', async(): Promise<void> => {
@@ -52,5 +58,14 @@ describe('A PermissionBasedAuthorizer', (): void => {
 
   it('defaults to empty permissions for the Authorization.', async(): Promise<void> => {
     await expect(authorizer.handle(input)).resolves.toBeUndefined();
+  });
+
+  it('throws a 404 in case the target resource does not exist and would not be written to.', async(): Promise<void> => {
+    resourceSet.hasResource.mockResolvedValueOnce(false);
+    input.modes = new Set([ AccessMode.delete ]);
+    input.permissionSet = {
+      [CredentialGroup.public]: { read: true },
+    };
+    await expect(authorizer.handle(input)).rejects.toThrow(NotFoundHttpError);
   });
 });

--- a/test/unit/authorization/UnionPermissionReader.test.ts
+++ b/test/unit/authorization/UnionPermissionReader.test.ts
@@ -3,7 +3,8 @@ import type { PermissionReader, PermissionReaderInput } from '../../../src/autho
 import { UnionPermissionReader } from '../../../src/authorization/UnionPermissionReader';
 
 describe('A UnionPermissionReader', (): void => {
-  const input: PermissionReaderInput = { credentials: {}, identifier: { path: 'http://test.com/foo' }};
+  const input: PermissionReaderInput =
+    { credentials: {}, identifier: { path: 'http://test.com/foo' }, modes: new Set() };
   let readers: jest.Mocked<PermissionReader>[];
   let unionReader: UnionPermissionReader;
 

--- a/test/unit/authorization/permissions/MethodModesExtractor.test.ts
+++ b/test/unit/authorization/permissions/MethodModesExtractor.test.ts
@@ -1,10 +1,19 @@
 import { MethodModesExtractor } from '../../../../src/authorization/permissions/MethodModesExtractor';
 import { AccessMode } from '../../../../src/authorization/permissions/Permissions';
 import type { Operation } from '../../../../src/http/Operation';
+import type { ResourceSet } from '../../../../src/storage/ResourceSet';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
 describe('A MethodModesExtractor', (): void => {
-  const extractor = new MethodModesExtractor();
+  let resourceSet: jest.Mocked<ResourceSet>;
+  let extractor: MethodModesExtractor;
+
+  beforeEach(async(): Promise<void> => {
+    resourceSet = {
+      hasResource: jest.fn().mockResolvedValue(true),
+    };
+    extractor = new MethodModesExtractor(resourceSet);
+  });
 
   it('can handle HEAD/GET/POST/PUT/DELETE.', async(): Promise<void> => {
     await expect(extractor.canHandle({ method: 'HEAD' } as Operation)).resolves.toBeUndefined();
@@ -29,11 +38,22 @@ describe('A MethodModesExtractor', (): void => {
 
   it('requires write for PUT operations.', async(): Promise<void> => {
     await expect(extractor.handle({ method: 'PUT' } as Operation))
-      .resolves.toEqual(new Set([ AccessMode.append, AccessMode.write, AccessMode.create, AccessMode.delete ]));
+      .resolves.toEqual(new Set([ AccessMode.write ]));
   });
 
-  it('requires write for DELETE operations.', async(): Promise<void> => {
-    await expect(extractor.handle({ method: 'DELETE' } as Operation))
-      .resolves.toEqual(new Set([ AccessMode.append, AccessMode.write, AccessMode.create, AccessMode.delete ]));
+  it('requires create for PUT operations if the target does not exist.', async(): Promise<void> => {
+    resourceSet.hasResource.mockResolvedValueOnce(false);
+    await expect(extractor.handle({ method: 'PUT' } as Operation))
+      .resolves.toEqual(new Set([ AccessMode.write, AccessMode.create ]));
+  });
+
+  it('requires delete for DELETE operations.', async(): Promise<void> => {
+    await expect(extractor.handle({ method: 'DELETE', target: { path: 'http://example.com/foo' }} as Operation))
+      .resolves.toEqual(new Set([ AccessMode.delete ]));
+  });
+
+  it('also requires read for DELETE operations on containers.', async(): Promise<void> => {
+    await expect(extractor.handle({ method: 'DELETE', target: { path: 'http://example.com/foo/' }} as Operation))
+      .resolves.toEqual(new Set([ AccessMode.delete, AccessMode.read ]));
   });
 });

--- a/test/unit/http/ldp/OptionsOperationHandler.test.ts
+++ b/test/unit/http/ldp/OptionsOperationHandler.test.ts
@@ -1,0 +1,44 @@
+import { OptionsOperationHandler } from '../../../../src/http/ldp/OptionsOperationHandler';
+import type { Operation } from '../../../../src/http/Operation';
+import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
+import { BasicConditions } from '../../../../src/storage/BasicConditions';
+import type { ResourceSet } from '../../../../src/storage/ResourceSet';
+import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
+import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
+
+describe('An OptionsOperationHandler', (): void => {
+  let operation: Operation;
+  const conditions = new BasicConditions({});
+  const preferences = {};
+  const body = new BasicRepresentation();
+  let resourceSet: jest.Mocked<ResourceSet>;
+  let handler: OptionsOperationHandler;
+
+  beforeEach(async(): Promise<void> => {
+    operation = { method: 'OPTIONS', target: { path: 'http://test.com/foo' }, preferences, conditions, body };
+    resourceSet = {
+      hasResource: jest.fn().mockResolvedValue(true),
+    };
+    handler = new OptionsOperationHandler(resourceSet);
+  });
+
+  it('only supports Options operations.', async(): Promise<void> => {
+    await expect(handler.canHandle({ operation })).resolves.toBeUndefined();
+    operation.method = 'GET';
+    await expect(handler.canHandle({ operation })).rejects.toThrow(NotImplementedHttpError);
+    operation.method = 'HEAD';
+    await expect(handler.canHandle({ operation })).rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('returns a 204 response.', async(): Promise<void> => {
+    const result = await handler.handle({ operation });
+    expect(result.statusCode).toBe(204);
+    expect(result.metadata).toBeUndefined();
+    expect(result.data).toBeUndefined();
+  });
+
+  it('returns a 404 if the target resource does not exist.', async(): Promise<void> => {
+    resourceSet.hasResource.mockResolvedValueOnce(false);
+    await expect(handler.handle({ operation })).rejects.toThrow(NotFoundHttpError);
+  });
+});

--- a/test/unit/http/ldp/PatchOperationHandler.test.ts
+++ b/test/unit/http/ldp/PatchOperationHandler.test.ts
@@ -19,7 +19,7 @@ describe('A PatchOperationHandler', (): void => {
     operation = { method: 'PATCH', target: { path: 'http://test.com/foo' }, body, conditions, preferences: {}};
 
     store = {
-      resourceExists: jest.fn(),
+      hasResource: jest.fn(),
       modifyResource: jest.fn(),
     } as any;
 
@@ -47,7 +47,7 @@ describe('A PatchOperationHandler', (): void => {
   });
 
   it('returns the correct response if the resource already exists.', async(): Promise<void> => {
-    store.resourceExists.mockResolvedValueOnce(true);
+    store.hasResource.mockResolvedValueOnce(true);
     const result = await handler.handle({ operation });
     expect(store.modifyResource).toHaveBeenCalledTimes(1);
     expect(store.modifyResource).toHaveBeenLastCalledWith(operation.target, body, conditions);

--- a/test/unit/http/ldp/PutOperationHandler.test.ts
+++ b/test/unit/http/ldp/PutOperationHandler.test.ts
@@ -18,7 +18,7 @@ describe('A PutOperationHandler', (): void => {
     body = new BasicRepresentation('', 'text/turtle');
     operation = { method: 'PUT', target: { path: 'http://test.com/foo' }, body, conditions, preferences: {}};
     store = {
-      resourceExists: jest.fn(),
+      hasResource: jest.fn(),
       setRepresentation: jest.fn(),
     } as any;
 
@@ -46,7 +46,7 @@ describe('A PutOperationHandler', (): void => {
   });
 
   it('returns the correct response if the resource already exists.', async(): Promise<void> => {
-    store.resourceExists.mockResolvedValueOnce(true);
+    store.hasResource.mockResolvedValueOnce(true);
     const result = await handler.handle({ operation });
     expect(store.setRepresentation).toHaveBeenCalledTimes(1);
     expect(store.setRepresentation).toHaveBeenLastCalledWith(operation.target, body, conditions);

--- a/test/unit/pods/GeneratedPodManager.test.ts
+++ b/test/unit/pods/GeneratedPodManager.test.ts
@@ -20,7 +20,7 @@ describe('A GeneratedPodManager', (): void => {
     };
     store = {
       setRepresentation: jest.fn(),
-      resourceExists: jest.fn(),
+      hasResource: jest.fn(),
     } as any;
     generatorData = [
       { identifier: { path: '/path/' }, representation: '/' as any },
@@ -36,7 +36,7 @@ describe('A GeneratedPodManager', (): void => {
   });
 
   it('throws an error if the generate identifier is not available.', async(): Promise<void> => {
-    store.resourceExists.mockResolvedValueOnce(true);
+    store.hasResource.mockResolvedValueOnce(true);
     const result = manager.createPod({ path: `${base}user/` }, settings, false);
     await expect(result).rejects.toThrow(`There already is a resource at ${base}user/`);
     await expect(result).rejects.toThrow(ConflictHttpError);
@@ -52,7 +52,7 @@ describe('A GeneratedPodManager', (): void => {
   });
 
   it('allows overwriting when enabled.', async(): Promise<void> => {
-    store.resourceExists.mockResolvedValueOnce(true);
+    store.hasResource.mockResolvedValueOnce(true);
     await expect(manager.createPod({ path: `${base}${settings.login}/` }, settings, true)).resolves.toBeUndefined();
 
     expect(store.setRepresentation).toHaveBeenCalledTimes(3);

--- a/test/unit/server/AuthorizingHttpHandler.test.ts
+++ b/test/unit/server/AuthorizingHttpHandler.test.ts
@@ -62,7 +62,7 @@ describe('An AuthorizingHttpHandler', (): void => {
     expect(modesExtractor.handleSafe).toHaveBeenCalledTimes(1);
     expect(modesExtractor.handleSafe).toHaveBeenLastCalledWith(operation);
     expect(permissionReader.handleSafe).toHaveBeenCalledTimes(1);
-    expect(permissionReader.handleSafe).toHaveBeenLastCalledWith({ credentials, identifier: operation.target });
+    expect(permissionReader.handleSafe).toHaveBeenLastCalledWith({ credentials, identifier: operation.target, modes });
     expect(authorizer.handleSafe).toHaveBeenCalledTimes(1);
     expect(authorizer.handleSafe)
       .toHaveBeenLastCalledWith({ credentials, identifier: operation.target, modes, permissionSet });

--- a/test/unit/storage/BaseResourceStore.test.ts
+++ b/test/unit/storage/BaseResourceStore.test.ts
@@ -25,7 +25,7 @@ describe('A BaseResourceStore', (): void => {
     await expect(store.modifyResource(any, any)).rejects.toThrow(NotImplementedHttpError);
   });
 
-  it('errors on resourceExists.', async(): Promise<void> => {
-    await expect(store.resourceExists(any)).rejects.toThrow(NotImplementedHttpError);
+  it('errors on hasResource.', async(): Promise<void> => {
+    await expect(store.hasResource(any)).rejects.toThrow(NotImplementedHttpError);
   });
 });

--- a/test/unit/storage/CachedResourceSet.test.ts
+++ b/test/unit/storage/CachedResourceSet.test.ts
@@ -1,0 +1,39 @@
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import { CachedResourceSet } from '../../../src/storage/CachedResourceSet';
+import type { ResourceSet } from '../../../src/storage/ResourceSet';
+
+describe('A CachedResourceSet', (): void => {
+  const identifier: ResourceIdentifier = { path: 'http://example.com/foo' };
+  let source: jest.Mocked<ResourceSet>;
+  let set: CachedResourceSet;
+
+  beforeEach(async(): Promise<void> => {
+    source = {
+      hasResource: jest.fn().mockResolvedValue(true),
+    };
+
+    set = new CachedResourceSet(source);
+  });
+
+  it('calls the source.', async(): Promise<void> => {
+    await expect(set.hasResource(identifier)).resolves.toBe(true);
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith(identifier);
+  });
+
+  it('caches the result.', async(): Promise<void> => {
+    await expect(set.hasResource(identifier)).resolves.toBe(true);
+    await expect(set.hasResource(identifier)).resolves.toBe(true);
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith(identifier);
+  });
+
+  it('caches on the identifier object itself.', async(): Promise<void> => {
+    const copy = { ...identifier };
+    await expect(set.hasResource(identifier)).resolves.toBe(true);
+    await expect(set.hasResource(copy)).resolves.toBe(true);
+    expect(source.hasResource).toHaveBeenCalledTimes(2);
+    expect(source.hasResource).toHaveBeenNthCalledWith(1, identifier);
+    expect(source.hasResource).toHaveBeenNthCalledWith(2, copy);
+  });
+});

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -726,13 +726,13 @@ describe('A DataAccessorBasedStore', (): void => {
   describe('resource Exists', (): void => {
     it('should return false when the resource does not exist.', async(): Promise<void> => {
       const resourceID = { path: `${root}resource` };
-      await expect(store.resourceExists(resourceID)).resolves.toBeFalsy();
+      await expect(store.hasResource(resourceID)).resolves.toBeFalsy();
     });
 
     it('should return true when the resource exists.', async(): Promise<void> => {
       const resourceID = { path: `${root}resource` };
       accessor.data[resourceID.path] = representation;
-      await expect(store.resourceExists(resourceID)).resolves.toBeTruthy();
+      await expect(store.hasResource(resourceID)).resolves.toBeTruthy();
     });
 
     it('should rethrow any unexpected errors from validateIdentifier.', async(): Promise<void> => {
@@ -741,7 +741,7 @@ describe('A DataAccessorBasedStore', (): void => {
       accessor.getMetadata = jest.fn(async(): Promise<any> => {
         throw new Error('error');
       });
-      await expect(store.resourceExists(resourceID)).rejects.toThrow('error');
+      await expect(store.hasResource(resourceID)).rejects.toThrow('error');
       accessor.getMetadata = originalMetaData;
     });
   });

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -39,7 +39,7 @@ describe('A LockingResourceStore', (): void => {
       setRepresentation: jest.fn((): any => addOrder('setRepresentation')),
       deleteResource: jest.fn((): any => addOrder('deleteResource')),
       modifyResource: jest.fn((): any => addOrder('modifyResource')),
-      resourceExists: jest.fn((): any => addOrder('resourceExists')),
+      hasResource: jest.fn((): any => addOrder('hasResource')),
     };
 
     timeoutTrigger = new EventEmitter();
@@ -287,12 +287,12 @@ describe('A LockingResourceStore', (): void => {
     expect(order).toEqual([ 'lock read', 'useless get', 'timeout', 'unlock read' ]);
   });
 
-  it('resourceExists should only acquire and release the read lock.', async(): Promise<void> => {
-    await store.resourceExists(subjectId);
+  it('hasResource should only acquire and release the read lock.', async(): Promise<void> => {
+    await store.hasResource(subjectId);
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);
     expect(locker.withWriteLock).toHaveBeenCalledTimes(0);
-    expect(source.resourceExists).toHaveBeenCalledTimes(1);
-    expect(source.resourceExists).toHaveBeenLastCalledWith(subjectId, undefined);
-    expect(order).toEqual([ 'lock read', 'resourceExists', 'unlock read' ]);
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith(subjectId);
+    expect(order).toEqual([ 'lock read', 'hasResource', 'unlock read' ]);
   });
 });

--- a/test/unit/storage/MonitoringStore.test.ts
+++ b/test/unit/storage/MonitoringStore.test.ts
@@ -19,7 +19,7 @@ describe('A MonitoringStore', (): void => {
       setRepresentation: jest.fn(async(): Promise<any> => modified),
       deleteResource: jest.fn(async(): Promise<any> => modified),
       modifyResource: jest.fn(async(): Promise<any> => modified),
-      resourceExists: jest.fn(async(): Promise<any> => undefined),
+      hasResource: jest.fn(async(): Promise<any> => undefined),
     };
     store = new MonitoringStore(source);
     changedCallback = jest.fn();
@@ -106,9 +106,9 @@ describe('A MonitoringStore', (): void => {
     expect(changedCallback).toHaveBeenCalledWith({ path: 'http://example.org/modified/2' });
   });
 
-  it('calls resourceExists directly from the source.', async(): Promise<void> => {
-    await expect(store.resourceExists({ path: 'http://example.org/foo/bar' })).resolves.toBeUndefined();
-    expect(source.resourceExists).toHaveBeenCalledTimes(1);
-    expect(source.resourceExists).toHaveBeenLastCalledWith({ path: 'http://example.org/foo/bar' }, undefined);
+  it('calls hasResource directly from the source.', async(): Promise<void> => {
+    await expect(store.hasResource({ path: 'http://example.org/foo/bar' })).resolves.toBeUndefined();
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith({ path: 'http://example.org/foo/bar' });
   });
 });

--- a/test/unit/storage/PassthroughStore.test.ts
+++ b/test/unit/storage/PassthroughStore.test.ts
@@ -14,7 +14,7 @@ describe('A PassthroughStore', (): void => {
       setRepresentation: jest.fn(async(): Promise<any> => 'set'),
       deleteResource: jest.fn(async(): Promise<any> => 'delete'),
       modifyResource: jest.fn(async(): Promise<any> => 'modify'),
-      resourceExists: jest.fn(async(): Promise<any> => 'exists'),
+      hasResource: jest.fn(async(): Promise<any> => 'exists'),
     };
 
     store = new PassthroughStore(source);
@@ -50,9 +50,9 @@ describe('A PassthroughStore', (): void => {
     expect(source.modifyResource).toHaveBeenLastCalledWith({ path: 'modifyPath' }, {}, undefined);
   });
 
-  it('calls resourceExists directly from the source.', async(): Promise<void> => {
-    await expect(store.resourceExists({ path: 'existsPath' })).resolves.toBe('exists');
-    expect(source.resourceExists).toHaveBeenCalledTimes(1);
-    expect(source.resourceExists).toHaveBeenLastCalledWith({ path: 'existsPath' }, undefined);
+  it('calls hasResource directly from the source.', async(): Promise<void> => {
+    await expect(store.hasResource({ path: 'existsPath' })).resolves.toBe('exists');
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith({ path: 'existsPath' });
   });
 });

--- a/test/unit/storage/RoutingResourceStore.test.ts
+++ b/test/unit/storage/RoutingResourceStore.test.ts
@@ -17,7 +17,7 @@ describe('A RoutingResourceStore', (): void => {
       setRepresentation: jest.fn(),
       modifyResource: jest.fn(),
       deleteResource: jest.fn(),
-      resourceExists: jest.fn(),
+      hasResource: jest.fn(),
     };
 
     rule = new StaticAsyncHandler(true, source);
@@ -60,10 +60,10 @@ describe('A RoutingResourceStore', (): void => {
     expect(source.deleteResource).toHaveBeenLastCalledWith(identifier, 'conditions');
   });
 
-  it('calls resourceExists on the resulting store.', async(): Promise<void> => {
-    await expect(store.resourceExists(identifier)).resolves.toBeUndefined();
-    expect(source.resourceExists).toHaveBeenCalledTimes(1);
-    expect(source.resourceExists).toHaveBeenLastCalledWith(identifier, undefined);
+  it('calls hasResource on the resulting store.', async(): Promise<void> => {
+    await expect(store.hasResource(identifier)).resolves.toBeUndefined();
+    expect(source.hasResource).toHaveBeenCalledTimes(1);
+    expect(source.hasResource).toHaveBeenLastCalledWith(identifier);
   });
 
   it('throws a 404 if there is no body and no store was found.', async(): Promise<void> => {

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -19,7 +19,7 @@ describe('A JsonResourceStorage', (): void => {
   beforeEach(async(): Promise<void> => {
     const data: Record<string, string> = { };
     store = {
-      async resourceExists(identifier: ResourceIdentifier): Promise<boolean> {
+      async hasResource(identifier: ResourceIdentifier): Promise<boolean> {
         return Boolean(data[identifier.path]);
       },
       async getRepresentation(identifier: ResourceIdentifier): Promise<Representation> {

--- a/test/unit/storage/routing/ConvertingRouterRule.test.ts
+++ b/test/unit/storage/routing/ConvertingRouterRule.test.ts
@@ -39,18 +39,18 @@ describe('A ConvertingRouterRule', (): void => {
   });
 
   it('checks if the stores contain the identifier if there is no data.', async(): Promise<void> => {
-    store1.resourceExists = jest.fn().mockImplementationOnce((): any => true);
+    store1.hasResource = jest.fn().mockImplementationOnce((): any => true);
     await expect(rule.handle({ identifier: { path: 'identifier' }})).resolves.toBe(store1);
-    expect(store1.resourceExists).toHaveBeenCalledTimes(1);
+    expect(store1.hasResource).toHaveBeenCalledTimes(1);
   });
 
   it('returns the defaultStore if no other store has the resource.', async(): Promise<void> => {
-    store1.resourceExists = jest.fn().mockImplementationOnce((): any => false);
+    store1.hasResource = jest.fn().mockImplementationOnce((): any => false);
     await expect(rule.handle({ identifier: { path: 'identifier' }})).resolves.toBe(defaultStore);
   });
 
   it('throws the error if a store had a non-404 error.', async(): Promise<void> => {
-    store1.resourceExists = jest.fn().mockRejectedValueOnce(new InternalServerError());
+    store1.hasResource = jest.fn().mockRejectedValueOnce(new InternalServerError());
     await expect(rule.handle({ identifier: { path: 'identifier' }})).rejects.toThrow(InternalServerError);
   });
 });

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -7,12 +7,15 @@ const portNames = [
   'Conditions',
   'ContentNegotiation',
   'DynamicPods',
+  'GlobalQuota',
   'Identity',
   'LpdHandlerWithAuth',
   'LpdHandlerWithoutAuth',
   'Middleware',
   'N3Patch',
+  'PermissionTable',
   'PodCreation',
+  'PodQuota',
   'RedisResourceLocker',
   'RestrictedIdentity',
   'ServerFetch',
@@ -20,8 +23,7 @@ const portNames = [
   'SparqlStorage',
   'Subdomains',
   'WebSocketsProtocol',
-  'PodQuota',
-  'GlobalQuota',
+
   // Unit
   'BaseHttpServerFactory',
 ] as const;


### PR DESCRIPTION
#### 📁 Related issues

Closes #1161 (sort of? Depends on the 404 interpretation)

#### ✍️ Description

Targeting the 4.0.0 branch as several class signatures change.

List of changes in this PR:
 * `ResourceSet` interface with `hasResource` function, which is extended by `ResourceStore`.
 * `CachedResourceSet`  that uses a WeakMap
 * We now extract the correct access modes from a request (create/delete/etc. only when relevant)
 * 404 is returned when an agent has a) no access b) the resource does not exist, and c) the operation would not create the resource.
 * The WebACL reader now correctly checks the parent container existence for create/delete operations.
 * There is a cool table in the integrations tests to automate many of the tests on all of this.

Regarding the 404, this behaviour is based on the results from the tables in the linked issues. But I could not actually find references in the spec that this should happen which makes me wonder if this is actually still required? If yes I could use a spec reference because now I'm not sure how correct the implementation even is. Related to that: the tables also say to only return a Location header for POST requests if you have read permissions on the resource, which is also something we don't currently do.

The integration test table is based on the tables from the linked issues. It contains a few lines commented out where we have a mismatch with what was suggested. The question is if we are wrong there or if the table was just outdated.