### PR TITLE
Feat: Store content type parameters

### DIFF
--- a/src/http/input/metadata/ContentTypeParser.ts
+++ b/src/http/input/metadata/ContentTypeParser.ts
@@ -11,7 +11,7 @@ export class ContentTypeParser extends MetadataParser {
   public async handle(input: { request: HttpRequest; metadata: RepresentationMetadata }): Promise<void> {
     const contentType = input.request.headers['content-type'];
     if (contentType) {
-      input.metadata.contentType = parseContentType(contentType).type;
+      input.metadata.contentType = parseContentType(contentType).value;
     }
   }
 }

--- a/src/http/input/metadata/ContentTypeParser.ts
+++ b/src/http/input/metadata/ContentTypeParser.ts
@@ -1,5 +1,4 @@
 import type { HttpRequest } from '../../../server/HttpRequest';
-import { parseContentType } from '../../../util/HeaderUtil';
 import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
 import { MetadataParser } from './MetadataParser';
 

--- a/src/http/input/metadata/ContentTypeParser.ts
+++ b/src/http/input/metadata/ContentTypeParser.ts
@@ -11,7 +11,7 @@ export class ContentTypeParser extends MetadataParser {
   public async handle(input: { request: HttpRequest; metadata: RepresentationMetadata }): Promise<void> {
     const contentType = input.request.headers['content-type'];
     if (contentType) {
-      input.metadata.contentType = parseContentType(contentType).value;
+      input.metadata.contentType = contentType;
     }
   }
 }

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -5,7 +5,7 @@ import { InternalServerError } from '../../util/errors/InternalServerError';
 import type { ContentType } from '../../util/HeaderUtil';
 import { parseContentType } from '../../util/HeaderUtil';
 import { toNamedTerm, toObjectTerm, toCachedNamedNode, isTerm, toLiteral } from '../../util/TermUtil';
-import { CONTENT_TYPE, CONTENT_TYPE_TERM, CONTENT_LENGTH_TERM, XSD, SOLID_META, RDFS } from '../../util/Vocabularies';
+import { CONTENT_TYPE_TERM, CONTENT_LENGTH_TERM, XSD, SOLID_META, RDFS } from '../../util/Vocabularies';
 import type { ResourceIdentifier } from './ResourceIdentifier';
 import { isResourceIdentifier } from './ResourceIdentifier';
 
@@ -89,9 +89,10 @@ export class RepresentationMetadata {
 
     if (overrides) {
       if (typeof overrides === 'string') {
-        overrides = { [CONTENT_TYPE]: overrides };
+        this.contentType = overrides;
+      } else {
+        this.setOverrides(overrides);
       }
-      this.setOverrides(overrides);
     }
   }
 
@@ -357,7 +358,7 @@ export class RepresentationMetadata {
     this.removeAll(CONTENT_TYPE_TERM);
     const params = this.quads(this.id, SOLID_META.terms.contentTypeParameter);
     for (const quad of params) {
-      const paramEntries = this.quads(quad.object.value);
+      const paramEntries = this.quads(quad.object as BlankNode);
       this.store.removeQuads(paramEntries);
     }
     this.store.removeQuads(params);

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -341,10 +341,15 @@ export class RepresentationMetadata {
     const params = this.getAll(SOLID_META.terms.contentTypeParameter);
     return {
       value,
-      parameters: Object.fromEntries(params.map((param): [string, string] => [
-        this.store.getObjects(param, RDFS.terms.label, null)[0].value,
-        this.store.getObjects(param, SOLID_META.terms.value, null)[0].value,
-      ])),
+      parameters: Object.fromEntries(params.map((param): [string, string] => {
+        const labels = this.store.getObjects(param, RDFS.terms.label, null);
+        const values = this.store.getObjects(param, SOLID_META.terms.value, null);
+        if (labels.length !== 1 || values.length !== 1) {
+          this.logger.error(`Detected invalid content-type metadata for ${this.id.value}`);
+          return [ 'invalid', '' ];
+        }
+        return [ labels[0], values[0] ];
+      })),
     };
   }
 

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -355,7 +355,7 @@ export class RepresentationMetadata {
 
   private removeContentType(): void {
     this.removeAll(CONTENT_TYPE_TERM);
-    const params = this.store.getQuads(this.id, SOLID_META.terms.contentTypeParameter, null, null);
+    const params = this.quads(this.id, SOLID_META.terms.contentTypeParameter);
     for (const quad of params) {
       const paramEntries = this.quads(quad.object);
       this.store.removeQuads(paramEntries);

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -348,7 +348,7 @@ export class RepresentationMetadata {
           this.logger.error(`Detected invalid content-type metadata for ${this.id.value}`);
           return [ 'invalid', '' ];
         }
-        return [ labels[0], values[0] ];
+        return [ labels[0].value, values[0].value ];
       })),
     };
   }
@@ -357,7 +357,7 @@ export class RepresentationMetadata {
     this.removeAll(CONTENT_TYPE_TERM);
     const params = this.quads(this.id, SOLID_META.terms.contentTypeParameter);
     for (const quad of params) {
-      const paramEntries = this.quads(quad.object);
+      const paramEntries = this.quads(quad.object.value);
       this.store.removeQuads(paramEntries);
     }
     this.store.removeQuads(params);

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -306,7 +306,7 @@ export class RepresentationMetadata {
     return this;
   }
 
-  private setContentTypeParams(input: ContentType | string | undefined): void {
+  private setContentTypeParams(input?: ContentType | string): void {
     // Make sure complete Content-Type RDF structure is gone
     this.removeContentTypeParameters();
     

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -331,7 +331,7 @@ export class RepresentationMetadata {
 
   /**
    * Parse the internal RDF structure to retrieve the Record with ContentType Parameters.
-   * @returns An Record&lt;string,string&gt; object with Content-Type parameters and their values.
+   * @returns A {@link ContentType} object containing the value and optional parameters if there is one.
    */
   private getContentType(): ContentType | undefined {
     const value = this.get(CONTENT_TYPE_TERM)?.value;

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -357,9 +357,8 @@ export class RepresentationMetadata {
     this.removeAll(CONTENT_TYPE_TERM);
     const params = this.store.getQuads(this.id, SOLID_META.terms.contentTypeParameter, null, null);
     for (const quad of params) {
-      const labels = this.store.getQuads(quad.object, RDFS.terms.label, null, null);
-      const values = this.store.getQuads(quad.object, SOLID_META.terms.value, null, null);
-      this.store.removeQuads([ ...labels, ...values ]);
+      const paramEntries = this.quads(quad.object);
+      this.store.removeQuads(paramEntries);
     }
     this.store.removeQuads(params);
   }

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -318,12 +318,12 @@ export class RepresentationMetadata {
       input = parseContentTypeWithParameters(input);
     }
 
-    Object.entries(input.parameters ?? []).forEach(([ paramKey, paramValue ], idx): void => {
-      const paramNode = DataFactory.blankNode(`parameter${idx + 1}`);
-      this.addQuad(this.id, SOLID_META.terms.ContentTypeParameter, paramNode);
-      this.addQuad(paramNode, RDFS.terms.label, paramKey);
-      this.addQuad(paramNode, SOLID_META.terms.value, paramValue);
-    });
+    for (const [ key, value ] of Object.entries(input.parameters ?? [])) {
+      const node = DataFactory.blankNode();
+      this.addQuad(this.id, SOLID_META.terms.ContentTypeParameter, node);
+      this.addQuad(node, RDFS.terms.label, key);
+      this.addQuad(node, SOLID_META.terms.value, value);
+    );
   }
 
   /**

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -307,16 +307,16 @@ export class RepresentationMetadata {
   }
 
   private setContentTypeParams(input: ContentType | string | undefined): void {
-    if (input === undefined) {
-      this.removeContentTypeParameters();
+    // Make sure complete Content-Type RDF structure is gone
+    this.removeContentTypeParameters();
+    
+    if (!input) {
       return;
     }
+    
     if (typeof input === 'string') {
       input = parseContentTypeWithParameters(input);
     }
-
-    // Make sure complete Content-Type RDF structure is gone
-    this.removeContentTypeParameters();
 
     Object.entries(input.parameters ?? []).forEach(([ paramKey, paramValue ], idx): void => {
       const paramNode = DataFactory.blankNode(`parameter${idx + 1}`);

--- a/src/util/FetchUtil.ts
+++ b/src/util/FetchUtil.ts
@@ -58,7 +58,7 @@ Promise<Representation> {
     logger.warn(`Missing content-type header from ${response.url}`);
     throw error;
   }
-  const contentTypeValue = parseContentType(contentType).type;
+  const contentTypeValue = parseContentType(contentType).value;
 
   // Try to convert to quads
   const representation = new BasicRepresentation(body, contentTypeValue);

--- a/src/util/FetchUtil.ts
+++ b/src/util/FetchUtil.ts
@@ -9,7 +9,6 @@ import { getLoggerFor } from '../logging/LogUtil';
 import type { RepresentationConverter } from '../storage/conversion/RepresentationConverter';
 import { INTERNAL_QUADS } from './ContentTypes';
 import { BadRequestHttpError } from './errors/BadRequestHttpError';
-import { parseContentType } from './HeaderUtil';
 
 const logger = getLoggerFor('FetchUtil');
 
@@ -58,10 +57,9 @@ Promise<Representation> {
     logger.warn(`Missing content-type header from ${response.url}`);
     throw error;
   }
-  const contentTypeValue = parseContentType(contentType).value;
 
   // Try to convert to quads
-  const representation = new BasicRepresentation(body, contentTypeValue);
+  const representation = new BasicRepresentation(body, contentType);
   const preferences = { type: { [INTERNAL_QUADS]: 1 }};
   return converter.handleSafe({ representation, identifier: { path: response.url }, preferences });
 }

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -425,18 +425,6 @@ export function addHeader(response: HttpResponse, name: string, value: string | 
 }
 
 /**
- * Parses the Content-Type header.
- *
- * @param contentType - The media type of the content-type header
- *
- * @returns The parsed media type of the content-type
- */
-// export function parseContentType(contentType: string): { type: string } {
-//   const contentTypeValue = /^\s*([^;\s]*)/u.exec(contentType)![1];
-//   return { type: contentTypeValue };
-// }
-
-/**
  * Parses the Content-Type header and also parses any parameters in the header.
  *
  * @param input - The Content-Type header string.

--- a/src/util/HeaderUtil.ts
+++ b/src/util/HeaderUtil.ts
@@ -105,7 +105,7 @@ export interface AcceptDatetime extends AcceptHeader { }
  */
 export interface ContentType {
   value: string;
-  parameters?: Record<string, string>;
+  parameters: Record<string, string>;
 }
 
 // REUSED REGEXES
@@ -431,10 +431,10 @@ export function addHeader(response: HttpResponse, name: string, value: string | 
  *
  * @returns The parsed media type of the content-type
  */
-export function parseContentType(contentType: string): { type: string } {
-  const contentTypeValue = /^\s*([^;\s]*)/u.exec(contentType)![1];
-  return { type: contentTypeValue };
-}
+// export function parseContentType(contentType: string): { type: string } {
+//   const contentTypeValue = /^\s*([^;\s]*)/u.exec(contentType)![1];
+//   return { type: contentTypeValue };
+// }
 
 /**
  * Parses the Content-Type header and also parses any parameters in the header.
@@ -446,19 +446,18 @@ export function parseContentType(contentType: string): { type: string } {
  *
  * @returns A {@link ContentType} object containing the value and optional parameters.
  */
-export function parseContentTypeWithParameters(input: string): ContentType {
+export function parseContentType(input: string): ContentType {
   // Quoted strings could prevent split from having correct results
   const { result, replacements } = transformQuotedStrings(input);
   const [ value, ...params ] = result.split(';').map((str): string => str.trim());
-  return params.length > 0 ?
-    parseParameters(params, replacements).reduce<ContentType>((prev, cur): ContentType => {
-      if (!prev.parameters) {
-        prev.parameters = {};
-      }
+  return parseParameters(params, replacements)
+    .reduce<ContentType>(
+    (prev, cur): ContentType => {
       prev.parameters[cur.name] = cur.value;
       return prev;
-    }, { value }) :
-    { value };
+    },
+    { value, parameters: {}},
+  );
 }
 
 /**

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -123,6 +123,10 @@ export const RDF = createUriAndTermNamespace('http://www.w3.org/1999/02/22-rdf-s
   'type',
 );
 
+export const RDFS = createUriAndTermNamespace('http://www.w3.org/2000/01/rdf-schema#',
+  'label',
+);
+
 export const SOLID = createUriAndTermNamespace('http://www.w3.org/ns/solid/terms#',
   'deletes',
   'inserts',
@@ -148,6 +152,9 @@ export const SOLID_META = createUriAndTermNamespace('urn:npm:solid:community-ser
   'ResponseMetadata',
   // This is used to identify templates that can be used for the representation of a resource
   'template',
+  // This is used to store Content-Type Parameters
+  'ContentTypeParameter',
+  'value',
 );
 
 export const VANN = createUriAndTermNamespace('http://purl.org/vocab/vann/',

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -153,7 +153,7 @@ export const SOLID_META = createUriAndTermNamespace('urn:npm:solid:community-ser
   // This is used to identify templates that can be used for the representation of a resource
   'template',
   // This is used to store Content-Type Parameters
-  'ContentTypeParameter',
+  'contentTypeParameter',
   'value',
 );
 

--- a/test/unit/http/input/body/SparqlUpdateBodyParser.test.ts
+++ b/test/unit/http/input/body/SparqlUpdateBodyParser.test.ts
@@ -25,9 +25,9 @@ describe('A SparqlUpdateBodyParser', (): void => {
     input.metadata.contentType = 'text/plain';
     await expect(bodyParser.canHandle(input)).rejects.toThrow(UnsupportedMediaTypeHttpError);
     input.metadata.contentType = 'application/sparql-update;charset=utf-8';
-    await expect(bodyParser.canHandle(input)).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    await expect(bodyParser.canHandle(input)).resolves.toBeUndefined();
     input.metadata.contentType = 'application/sparql-update ; foo=bar';
-    await expect(bodyParser.canHandle(input)).rejects.toThrow(UnsupportedMediaTypeHttpError);
+    await expect(bodyParser.canHandle(input)).resolves.toBeUndefined();
     input.metadata.contentType = 'application/sparql-update';
     await expect(bodyParser.canHandle(input)).resolves.toBeUndefined();
   });

--- a/test/unit/http/input/metadata/ContentTypeParser.test.ts
+++ b/test/unit/http/input/metadata/ContentTypeParser.test.ts
@@ -20,7 +20,13 @@ describe('A ContentTypeParser', (): void => {
   it('sets the given content-type as metadata.', async(): Promise<void> => {
     request.headers['content-type'] = 'text/plain;charset=UTF-8';
     await expect(parser.handle({ request, metadata })).resolves.toBeUndefined();
-    expect(metadata.quads()).toHaveLength(1);
+    expect(metadata.quads()).toHaveLength(4);
     expect(metadata.contentType).toBe('text/plain');
+    expect(metadata.contentTypeObject).toEqual({
+      value: 'text/plain',
+      parameters: {
+        charset: 'UTF-8',
+      },
+    });
   });
 });

--- a/test/unit/http/representation/RepresentationMetadata.test.ts
+++ b/test/unit/http/representation/RepresentationMetadata.test.ts
@@ -1,4 +1,5 @@
 import 'jest-rdf';
+import type { BlankNode } from 'n3';
 import { DataFactory } from 'n3';
 import type { NamedNode, Quad } from 'rdf-js';
 import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
@@ -355,6 +356,15 @@ describe('A RepresentationMetadata', (): void => {
       expect(metadata.quads(null, SOLID_META.terms.contentTypeParameter, null, null)).toHaveLength(0);
       expect(metadata.quads(null, SOLID_META.terms.value, null, null)).toHaveLength(0);
       expect(metadata.quads(null, RDFS.terms.label, null, null)).toHaveLength(0);
+    });
+
+    it('can return invalid parameters when too many quads are present.', async(): Promise<void> => {
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.contentTypeObject).toBeUndefined();
+      metadata.contentType = 'text/plain; charset=utf-8; test=value1';
+      const param = metadata.quads(null, SOLID_META.terms.value)[0].subject;
+      metadata.addQuad(param as BlankNode, SOLID_META.terms.value, 'anomaly');
+      expect(metadata.contentTypeObject?.parameters).toMatchObject({ invalid: '' });
     });
   });
 });

--- a/test/unit/http/representation/RepresentationMetadata.test.ts
+++ b/test/unit/http/representation/RepresentationMetadata.test.ts
@@ -2,7 +2,7 @@ import 'jest-rdf';
 import { DataFactory } from 'n3';
 import type { NamedNode, Quad } from 'rdf-js';
 import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
-import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
+import { CONTENT_TYPE, SOLID_META, RDFS } from '../../../../src/util/Vocabularies';
 const { defaultGraph, literal, namedNode, quad } = DataFactory;
 
 // Helper functions to filter quads
@@ -295,6 +295,45 @@ describe('A RepresentationMetadata', (): void => {
       metadata.add(CONTENT_TYPE, 'a/b');
       metadata.add(CONTENT_TYPE, 'c/d');
       expect((): any => metadata.contentType).toThrow();
+    });
+
+    it('has a shorthand for Content-Type with parameters support.', async(): Promise<void> => {
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.contentTypeObject).toBeUndefined();
+      metadata.contentType = 'text/plain; charset=utf-8; test=value1';
+      expect(metadata.contentTypeObject).toEqual({
+        value: 'text/plain',
+        parameters: {
+          charset: 'utf-8',
+          test: 'value1',
+        },
+      });
+    });
+
+    it('can properly clear the Content-Type parameters explicitly.', async(): Promise<void> => {
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.contentTypeObject).toBeUndefined();
+      metadata.contentType = 'text/plain; charset=utf-8; test=value1';
+      metadata.contentType = undefined;
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.contentTypeObject).toBeUndefined();
+      expect(metadata.quads(null, SOLID_META.terms.ContentTypeParameter, null, null)).toHaveLength(0);
+      expect(metadata.quads(null, SOLID_META.terms.value, null, null)).toHaveLength(0);
+      expect(metadata.quads(null, RDFS.terms.label, null, null)).toHaveLength(0);
+    });
+
+    it('can properly clear the Content-Type parameters implicitly.', async(): Promise<void> => {
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.contentTypeObject).toBeUndefined();
+      metadata.contentType = 'text/plain; charset=utf-8; test=value1';
+      metadata.contentType = 'text/turtle';
+      expect(metadata.contentType).toBe('text/turtle');
+      expect(metadata.contentTypeObject).toEqual({
+        value: 'text/turtle',
+      });
+      expect(metadata.quads(null, SOLID_META.terms.ContentTypeParameter, null, null)).toHaveLength(0);
+      expect(metadata.quads(null, SOLID_META.terms.value, null, null)).toHaveLength(0);
+      expect(metadata.quads(null, RDFS.terms.label, null, null)).toHaveLength(0);
     });
   });
 });

--- a/test/unit/http/representation/RepresentationMetadata.test.ts
+++ b/test/unit/http/representation/RepresentationMetadata.test.ts
@@ -297,7 +297,7 @@ describe('A RepresentationMetadata', (): void => {
       expect((): any => metadata.contentType).toThrow();
     });
 
-    it('has a shorthand for Content-Type with parameters support.', async(): Promise<void> => {
+    it('has a shorthand for Content-Type as string.', async(): Promise<void> => {
       expect(metadata.contentType).toBeUndefined();
       expect(metadata.contentTypeObject).toBeUndefined();
       metadata.contentType = 'text/plain; charset=utf-8; test=value1';
@@ -310,6 +310,26 @@ describe('A RepresentationMetadata', (): void => {
       });
     });
 
+    it('has a shorthand for Content-Type as object.', async(): Promise<void> => {
+      expect(metadata.contentType).toBeUndefined();
+      expect(metadata.contentTypeObject).toBeUndefined();
+      metadata.contentTypeObject = {
+        value: 'text/plain',
+        parameters: {
+          charset: 'utf-8',
+          test: 'value1',
+        },
+      };
+      expect(metadata.contentTypeObject).toEqual({
+        value: 'text/plain',
+        parameters: {
+          charset: 'utf-8',
+          test: 'value1',
+        },
+      });
+      expect(metadata.contentType).toBe('text/plain');
+    });
+
     it('can properly clear the Content-Type parameters explicitly.', async(): Promise<void> => {
       expect(metadata.contentType).toBeUndefined();
       expect(metadata.contentTypeObject).toBeUndefined();
@@ -317,7 +337,7 @@ describe('A RepresentationMetadata', (): void => {
       metadata.contentType = undefined;
       expect(metadata.contentType).toBeUndefined();
       expect(metadata.contentTypeObject).toBeUndefined();
-      expect(metadata.quads(null, SOLID_META.terms.ContentTypeParameter, null, null)).toHaveLength(0);
+      expect(metadata.quads(null, SOLID_META.terms.contentTypeParameter, null, null)).toHaveLength(0);
       expect(metadata.quads(null, SOLID_META.terms.value, null, null)).toHaveLength(0);
       expect(metadata.quads(null, RDFS.terms.label, null, null)).toHaveLength(0);
     });
@@ -330,8 +350,9 @@ describe('A RepresentationMetadata', (): void => {
       expect(metadata.contentType).toBe('text/turtle');
       expect(metadata.contentTypeObject).toEqual({
         value: 'text/turtle',
+        parameters: {},
       });
-      expect(metadata.quads(null, SOLID_META.terms.ContentTypeParameter, null, null)).toHaveLength(0);
+      expect(metadata.quads(null, SOLID_META.terms.contentTypeParameter, null, null)).toHaveLength(0);
       expect(metadata.quads(null, SOLID_META.terms.value, null, null)).toHaveLength(0);
       expect(metadata.quads(null, RDFS.terms.label, null, null)).toHaveLength(0);
     });

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -7,6 +7,7 @@ import {
   parseAcceptEncoding,
   parseAcceptLanguage,
   parseContentType,
+  parseContentTypeWithParameters,
   parseForwarded,
 } from '../../../src/util/HeaderUtil';
 
@@ -200,6 +201,29 @@ describe('HeaderUtil', (): void => {
       expect(parseContentType('text/turtle; charset=UTF-8').type).toEqual(contentTypeTurtle);
     });
   });
+
+  describe('#parseContentTypeWithParameters', (): void => {
+    const contentTypePlain: any = {
+      value: 'text/plain',
+      parameters: {
+        charset: 'utf-8',
+      },
+    };
+    it('handles single content-type parameter (with leading and trailing whitespaces).', (): void => {
+      expect(parseContentTypeWithParameters('text/plain; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentTypeWithParameters(' text/plain; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentTypeWithParameters('text/plain ; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentTypeWithParameters(' text/plain ; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentTypeWithParameters(' text/plain ; charset="utf-8"')).toEqual(contentTypePlain);
+      expect(parseContentTypeWithParameters(' text/plain ; charset = "utf-8"')).toEqual(contentTypePlain);
+    });
+
+    it('handles multiple content-type parameters.', (): void => {
+      contentTypePlain.parameters.test = 'value1';
+      expect(parseContentTypeWithParameters('text/plain; charset=utf-8;test="value1"')).toEqual(contentTypePlain);
+    });
+  });
+
   describe('#parseForwarded', (): void => {
     it('handles an empty set of headers.', (): void => {
       expect(parseForwarded({})).toEqual({});

--- a/test/unit/util/HeaderUtil.test.ts
+++ b/test/unit/util/HeaderUtil.test.ts
@@ -7,7 +7,6 @@ import {
   parseAcceptEncoding,
   parseAcceptLanguage,
   parseContentType,
-  parseContentTypeWithParameters,
   parseForwarded,
 } from '../../../src/util/HeaderUtil';
 
@@ -191,18 +190,6 @@ describe('HeaderUtil', (): void => {
 
   describe('#parseContentType', (): void => {
     const contentTypeTurtle = 'text/turtle';
-    it('handles single content-type parameter (with leading and trailing whitespaces).', (): void => {
-      expect(parseContentType('text/turtle').type).toEqual(contentTypeTurtle);
-      expect(parseContentType('text/turtle ').type).toEqual(contentTypeTurtle);
-      expect(parseContentType(' text/turtle').type).toEqual(contentTypeTurtle);
-    });
-
-    it('handles multiple content-type parameters.', (): void => {
-      expect(parseContentType('text/turtle; charset=UTF-8').type).toEqual(contentTypeTurtle);
-    });
-  });
-
-  describe('#parseContentTypeWithParameters', (): void => {
     const contentTypePlain: any = {
       value: 'text/plain',
       parameters: {
@@ -210,17 +197,21 @@ describe('HeaderUtil', (): void => {
       },
     };
     it('handles single content-type parameter (with leading and trailing whitespaces).', (): void => {
-      expect(parseContentTypeWithParameters('text/plain; charset=utf-8')).toEqual(contentTypePlain);
-      expect(parseContentTypeWithParameters(' text/plain; charset=utf-8')).toEqual(contentTypePlain);
-      expect(parseContentTypeWithParameters('text/plain ; charset=utf-8')).toEqual(contentTypePlain);
-      expect(parseContentTypeWithParameters(' text/plain ; charset=utf-8')).toEqual(contentTypePlain);
-      expect(parseContentTypeWithParameters(' text/plain ; charset="utf-8"')).toEqual(contentTypePlain);
-      expect(parseContentTypeWithParameters(' text/plain ; charset = "utf-8"')).toEqual(contentTypePlain);
+      expect(parseContentType('text/turtle').value).toEqual(contentTypeTurtle);
+      expect(parseContentType('text/turtle ').value).toEqual(contentTypeTurtle);
+      expect(parseContentType(' text/turtle').value).toEqual(contentTypeTurtle);
+      expect(parseContentType('text/plain; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentType(' text/plain; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentType('text/plain ; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentType(' text/plain ; charset=utf-8')).toEqual(contentTypePlain);
+      expect(parseContentType(' text/plain ; charset="utf-8"')).toEqual(contentTypePlain);
+      expect(parseContentType(' text/plain ; charset = "utf-8"')).toEqual(contentTypePlain);
     });
 
     it('handles multiple content-type parameters.', (): void => {
+      expect(parseContentType('text/turtle; charset=UTF-8').value).toEqual(contentTypeTurtle);
       contentTypePlain.parameters.test = 'value1';
-      expect(parseContentTypeWithParameters('text/plain; charset=utf-8;test="value1"')).toEqual(contentTypePlain);
+      expect(parseContentType('text/plain; charset=utf-8;test="value1"')).toEqual(contentTypePlain);
     });
   });
 


### PR DESCRIPTION
#### 📁 Related issues

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/solid/community-server/issues/new/choose
-->
#458 

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->

**Initial plan, but will not implement now**
Replacing the [`RepresentationMetadata#contentType`](https://github.com/solid/community-server/blob/3b353affb1f0919fdcb66172364234eb59c2e3f6/src/http/representation/RepresentationMetadata.ts#L312-L318) currently in use (as a string) with an object that also contains the parsed parameters would lead to a lot of changes in the codebase (and in testing). The main issue being that the RepresentationMetadata class would no longer consist of only single `<identifier> <predicate> <object>` triples to store metadata. The new `contentType` would need something along the lines of this structure:
```turtle
<> ma:format _:format.
_:format     solid-type:value     "application/json";
             solid-type:parameter _:parameter1.
_:parameter1 rdfs:label           "charset";
             solid-type:value     "utf-8".
```

All internal code that now works on the assumption that they can just set a metadata property with one predicate and one value breaks now. The same thing is true for code that removes this triple/quad by identifying it as the triple using the `<ma:format>` predicate.

**Proposed solution**
After some internal discussion with @joachimvh, we've decided on the following strategy for now:
  * Leave the current `contentType` syntactic sugar on the `RepresentationMetadata` class for now so that we don't break any existing code in the CSS.
  * Add a syntactic sugar for `contentTypeObject` to retrieve a new `ContentType` object with the following structure:
    ```json
    {
       "value": "text/plain",
       "parameters" : {
           "chartset": "utf-8"
       }
    }
    ```
  * On setting the `contentType`, the optional parameter string is also parsed and stored in the RepresentationMetadata like this:
    ```turtle
    <>       solid-meta:ContentTypeParameter _:param1.
    _:param1 rdfs:label                      "charset";
             solid-type:value                "utf-8".
    ````

This allows developers who want, to also request the complete `ContentType` object using `metadata.contentTypeObject` and use the parsed parameters. When assigning a new value to  `metadata.contentType`, the parameters will first be cleared from the metadata. To explicitly remove all parameters and contentType: `metadat.contentType = undefined` does this for you.

I've added extra tests to test the behaviour described above.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.

<!-- Try to check these to the best of your abilities before opening the PR -->
