### PR TITLE
Simplify key/value storage configuration

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,8 @@ The following changes pertain to the imports in the default configs:
 - ...
 
 The following changes are relevant for v3 custom configs that replaced certain features.
-- ...
+- The key/value storage configs in `config/storage/key-value/*` have been changed to reduce config duplication.
+  All storages there that were only relevant for 1 class have been moved to the config of that class.
 
 ### Interface changes
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.

--- a/config/identity/handler/account-store/default.json
+++ b/config/identity/handler/account-store/default.json
@@ -7,7 +7,9 @@
       "@type": "BaseAccountStore",
       "saltRounds": 10,
       "storage": {
-        "@id": "urn:solid-server:default:AccountStorage"
+        "@type": "EncodingPathStorage",
+        "relativePath": "/idp/accounts/",
+        "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
       },
       "forgotPasswordStorage": {
         "@id": "urn:solid-server:default:ExpiringForgotPasswordStorage"
@@ -17,7 +19,11 @@
       "comment": "Stores expiring data. This class has a `finalize` function that needs to be called after stopping the server.",
       "@id": "urn:solid-server:default:ExpiringForgotPasswordStorage",
       "@type": "WrappedExpiringStorage",
-      "source": { "@id": "urn:solid-server:default:ForgotPasswordStorage" }
+      "source": {
+        "@type": "EncodingPathStorage",
+        "relativePath": "/forgot-password/",
+        "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+      }
     },
     {
       "comment": "Makes sure the expiring storage cleanup timer is stopped when the application needs to stop.",

--- a/config/identity/handler/adapter-factory/webid.json
+++ b/config/identity/handler/adapter-factory/webid.json
@@ -7,7 +7,11 @@
       "@type": "WebIdAdapterFactory",
       "source": {
         "@type": "ExpiringAdapterFactory",
-        "storage": { "@id": "urn:solid-server:default:IdpAdapterStorage" }
+        "storage": {
+          "@type": "EncodingPathStorage",
+          "relativePath": "/idp/adapter/",
+          "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+        }
       },
       "converter": { "@id": "urn:solid-server:default:RepresentationConverter" }
     }

--- a/config/identity/handler/provider-factory/identity.json
+++ b/config/identity/handler/provider-factory/identity.json
@@ -12,7 +12,11 @@
       "args_baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
       "args_oidcPath": "/.oidc",
       "args_interactionHandler": { "@id": "urn:solid-server:auth:password:PromptHandler" },
-      "args_storage": { "@id": "urn:solid-server:default:IdpKeyStorage" },
+      "args_storage": {
+        "@type": "EncodingPathStorage",
+        "relativePath": "/idp/keys/",
+        "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+      },
       "args_errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },
       "args_responseWriter": { "@id": "urn:solid-server:default:ResponseWriter" },
       "config": {

--- a/config/identity/ownership/token.json
+++ b/config/identity/ownership/token.json
@@ -12,7 +12,11 @@
       "comment": "Stores expiring data. This class has a `finalize` function that needs to be called after stopping the server.",
       "@id": "urn:solid-server:default:ExpiringTokenStorage",
       "@type": "WrappedExpiringStorage",
-      "source": { "@id": "urn:solid-server:default:IdpTokenStorage" }
+      "source": {
+        "@type": "EncodingPathStorage",
+        "relativePath": "/idp/tokens/",
+        "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+      }
     },
     {
       "comment": "Makes sure the expiring storage cleanup timer is stopped when the application needs to stop.",

--- a/config/storage/key-value/memory.json
+++ b/config/storage/key-value/memory.json
@@ -1,43 +1,18 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
+  "import": [
+    "files-scs:config/storage/key-value/storages/storages.json"
+  ],
   "@graph": [
     {
-      "comment": "These storage solutions store their data in memory."
-    },
-    {
-      "comment": "Used for internal storage by the locker.",
-      "@id": "urn:solid-server:default:LockStorage",
+      "comment": "Internal value storage. No different from urn:solid-server:default:KeyValueStorage, but required to be consistent with other storage solutions.",
+      "@id": "urn:solid-server:default:BackendKeyValueStorage",
       "@type": "MemoryMapStorage"
     },
     {
-      "comment": "Storage used by the IDP adapter.",
-      "@id": "urn:solid-server:default:IdpAdapterStorage",
+      "comment": "Internal value storage.",
+      "@id": "urn:solid-server:default:KeyValueStorage",
       "@type": "MemoryMapStorage"
-    },
-    {
-      "comment": "Storage used for the IDP keys.",
-      "@id": "urn:solid-server:default:IdpKeyStorage",
-      "@type": "MemoryMapStorage"
-    },
-    {
-      "comment": "Storage used for IDP ownership tokens.",
-      "@id": "urn:solid-server:default:IdpTokenStorage",
-      "@type": "MemoryMapStorage"
-    },
-    {
-      "comment": "Storage used for account management.",
-      "@id": "urn:solid-server:default:AccountStorage",
-      "@type": "MemoryMapStorage"
-    },
-    {
-      "comment": "Storage used by setup components.",
-      "@id": "urn:solid-server:default:SetupStorage",
-      "@type": "MemoryMapStorage"
-    },
-    {
-      "comment": "Storage used for ForgotPassword records",
-      "@id": "urn:solid-server:default:ForgotPasswordStorage",
-      "@type":"MemoryMapStorage"
     }
   ]
 }

--- a/config/storage/key-value/resource-store.json
+++ b/config/storage/key-value/resource-store.json
@@ -1,67 +1,24 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
+  "import": [
+    "files-scs:config/storage/key-value/storages/storages.json"
+  ],
   "@graph": [
     {
-      "comment": "These storage solutions use the specified container in the ResourceStore to store their data."
-    },
-    {
-      "comment": [
-        "This is the internal storage for the locker, which maintains what resources are in use.",
-        "It writes directly to a low-level store, because higher-level storage typically already uses the locker and would thus cause a loop."
-      ],
-      "@id": "urn:solid-server:default:LockStorage",
+      "comment": "A storage that writes directly to a low-level store. This is necessary to prevent infinite loops with stores that also use storage.",
+      "@id": "urn:solid-server:default:BackendKeyValueStorage",
       "@type": "JsonResourceStorage",
       "source": { "@id": "urn:solid-server:default:ResourceStore_Backend" },
       "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/locks/"
+      "container": "/.internal/"
     },
     {
-      "comment": "Storage used by the IDP adapter.",
-      "@id": "urn:solid-server:default:IdpAdapterStorage",
+      "comment": "Internal value storage.",
+      "@id": "urn:solid-server:default:KeyValueStorage",
       "@type": "JsonResourceStorage",
       "source": { "@id": "urn:solid-server:default:ResourceStore" },
       "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/idp/adapter/"
-    },
-    {
-      "comment": "Storage used for the IDP keys.",
-      "@id": "urn:solid-server:default:IdpKeyStorage",
-      "@type": "JsonResourceStorage",
-      "source": { "@id": "urn:solid-server:default:ResourceStore" },
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/idp/keys/"
-    },
-    {
-      "comment": "Storage used for IDP ownership tokens.",
-      "@id": "urn:solid-server:default:IdpTokenStorage",
-      "@type": "JsonResourceStorage",
-      "source": { "@id": "urn:solid-server:default:ResourceStore" },
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/idp/tokens/"
-    },
-    {
-      "comment": "Storage used for account management.",
-      "@id": "urn:solid-server:default:AccountStorage",
-      "@type": "JsonResourceStorage",
-      "source": { "@id": "urn:solid-server:default:ResourceStore" },
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/accounts/"
-    },
-    {
-      "comment": "Storage used for ForgotPassword records",
-      "@id": "urn:solid-server:default:ForgotPasswordStorage",
-      "@type":"JsonResourceStorage",
-      "source": { "@id": "urn:solid-server:default:ResourceStore" },
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/forgot-password/"
-    },
-    {
-      "comment": "Storage used by setup components.",
-      "@id": "urn:solid-server:default:SetupStorage",
-      "@type": "JsonResourceStorage",
-      "source": { "@id": "urn:solid-server:default:ResourceStore" },
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "container": "/.internal/setup/"
+      "container": "/.internal/"
     },
     {
       "comment": "Block external access to the storage containers to avoid exposing internal data.",

--- a/config/storage/key-value/storages/storages.json
+++ b/config/storage/key-value/storages/storages.json
@@ -1,0 +1,54 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Used for internal storage by the locker.",
+      "@id": "urn:solid-server:default:LockStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/locks/",
+      "source": { "@id": "urn:solid-server:default:BackendKeyValueStorage" }
+    },
+    {
+      "comment": "Storage used by the IDP adapter.",
+      "@id": "urn:solid-server:default:IdpAdapterStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/idp/adapter/",
+      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+    },
+    {
+      "comment": "Storage used for the IDP keys.",
+      "@id": "urn:solid-server:default:IdpKeyStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/idp/keys/",
+      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+    },
+    {
+      "comment": "Storage used for IDP ownership tokens.",
+      "@id": "urn:solid-server:default:IdpTokenStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/idp/tokens/",
+      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+    },
+    {
+      "comment": "Storage used for account management.",
+      "@id": "urn:solid-server:default:AccountStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/idp/accounts/",
+      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+    },
+    {
+      "comment": "Storage used for ForgotPassword records",
+      "@id": "urn:solid-server:default:ForgotPasswordStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/forgot-password/",
+      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+    },
+    {
+      "comment": "Storage used by setup components.",
+      "@id": "urn:solid-server:default:SetupStorage",
+      "@type": "EncodingPathStorage",
+      "relativePath": "/setup/",
+      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
+    }
+  ]
+}

--- a/config/storage/key-value/storages/storages.json
+++ b/config/storage/key-value/storages/storages.json
@@ -9,41 +9,6 @@
       "source": { "@id": "urn:solid-server:default:BackendKeyValueStorage" }
     },
     {
-      "comment": "Storage used by the IDP adapter.",
-      "@id": "urn:solid-server:default:IdpAdapterStorage",
-      "@type": "EncodingPathStorage",
-      "relativePath": "/idp/adapter/",
-      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
-    },
-    {
-      "comment": "Storage used for the IDP keys.",
-      "@id": "urn:solid-server:default:IdpKeyStorage",
-      "@type": "EncodingPathStorage",
-      "relativePath": "/idp/keys/",
-      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
-    },
-    {
-      "comment": "Storage used for IDP ownership tokens.",
-      "@id": "urn:solid-server:default:IdpTokenStorage",
-      "@type": "EncodingPathStorage",
-      "relativePath": "/idp/tokens/",
-      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
-    },
-    {
-      "comment": "Storage used for account management.",
-      "@id": "urn:solid-server:default:AccountStorage",
-      "@type": "EncodingPathStorage",
-      "relativePath": "/idp/accounts/",
-      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
-    },
-    {
-      "comment": "Storage used for ForgotPassword records",
-      "@id": "urn:solid-server:default:ForgotPasswordStorage",
-      "@type": "EncodingPathStorage",
-      "relativePath": "/forgot-password/",
-      "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
-    },
-    {
       "comment": "Storage used by setup components.",
       "@id": "urn:solid-server:default:SetupStorage",
       "@type": "EncodingPathStorage",

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,7 @@ export * from './storage/conversion/RepresentationConverter';
 export * from './storage/conversion/TypedRepresentationConverter';
 
 // Storage/KeyValue
+export * from './storage/keyvalue/EncodingPathStorage';
 export * from './storage/keyvalue/ExpiringStorage';
 export * from './storage/keyvalue/JsonFileStorage';
 export * from './storage/keyvalue/JsonResourceStorage';

--- a/src/storage/keyvalue/EncodingPathStorage.ts
+++ b/src/storage/keyvalue/EncodingPathStorage.ts
@@ -1,0 +1,64 @@
+import { ensureTrailingSlash, joinUrl } from '../../util/PathUtil';
+import type { KeyValueStorage } from './KeyValueStorage';
+
+/**
+ * Transforms the keys into relative paths, to be used by the source storage.
+ * Encodes the input key with base64 encoding,
+ * to make sure there are no invalid or special path characters,
+ * and prepends it with the stored relative path.
+ * This can be useful to eventually generate URLs in specific containers
+ * without having to worry about cleaning the input keys.
+ */
+export class EncodingPathStorage<T> implements KeyValueStorage<string, T> {
+  private readonly basePath: string;
+  private readonly source: KeyValueStorage<string, T>;
+
+  public constructor(relativePath: string, source: KeyValueStorage<string, T>) {
+    this.source = source;
+    this.basePath = ensureTrailingSlash(relativePath);
+  }
+
+  public async get(key: string): Promise<T | undefined> {
+    const path = this.keyToPath(key);
+    return this.source.get(path);
+  }
+
+  public async has(key: string): Promise<boolean> {
+    const path = this.keyToPath(key);
+    return this.source.has(path);
+  }
+
+  public async set(key: string, value: T): Promise<this> {
+    const path = this.keyToPath(key);
+    await this.source.set(path, value);
+    return this;
+  }
+
+  public async delete(key: string): Promise<boolean> {
+    const path = this.keyToPath(key);
+    return this.source.delete(path);
+  }
+
+  public async* entries(): AsyncIterableIterator<[string, T]> {
+    for await (const [ path, value ] of this.source.entries()) {
+      const key = this.pathToKey(path);
+      yield [ key, value ];
+    }
+  }
+
+  /**
+   * Converts a key into a path for internal storage.
+   */
+  private keyToPath(key: string): string {
+    const encodedKey = Buffer.from(key).toString('base64');
+    return joinUrl(this.basePath, encodedKey);
+  }
+
+  /**
+   * Converts an internal storage path string into the original path key.
+   */
+  private pathToKey(path: string): string {
+    const buffer = Buffer.from(path.slice(this.basePath.length), 'base64');
+    return buffer.toString('utf-8');
+  }
+}

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -1,34 +1,32 @@
-import { URL } from 'url';
 import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
-import type { Representation } from '../../http/representation/Representation';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
-import { ensureTrailingSlash } from '../../util/PathUtil';
+import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { ensureTrailingSlash, joinUrl } from '../../util/PathUtil';
 import { readableToString } from '../../util/StreamUtil';
-import { LDP } from '../../util/Vocabularies';
 import type { ResourceStore } from '../ResourceStore';
 import type { KeyValueStorage } from './KeyValueStorage';
 
 /**
  * A {@link KeyValueStorage} for JSON-like objects using a {@link ResourceStore} as backend.
  *
- * The keys will be transformed so they can be safely used
- * as a resource name in the given container.
- * Values will be sent as data streams,
- * so how these are stored depends on the underlying store.
+ * Creates a base URL by joining the input base URL with the container string.
+ *
+ * Assumes the input keys can be safely used to generate identifiers,
+ * which will be appended to the stored base URL.
  *
  * All non-404 errors will be re-thrown.
  */
-export class JsonResourceStorage implements KeyValueStorage<string, unknown> {
+export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
   private readonly source: ResourceStore;
   private readonly container: string;
 
   public constructor(source: ResourceStore, baseUrl: string, container: string) {
     this.source = source;
-    this.container = ensureTrailingSlash(new URL(container, baseUrl).href);
+    this.container = ensureTrailingSlash(joinUrl(baseUrl, container));
   }
 
-  public async get(key: string): Promise<unknown | undefined> {
+  public async get(key: string): Promise<T | undefined> {
     try {
       const identifier = this.createIdentifier(key);
       const representation = await this.source.getRepresentation(identifier, { type: { 'application/json': 1 }});
@@ -65,42 +63,15 @@ export class JsonResourceStorage implements KeyValueStorage<string, unknown> {
     }
   }
 
-  public async* entries(): AsyncIterableIterator<[string, unknown]> {
-    // Getting ldp:contains metadata from container to find entries
-    let container: Representation;
-    try {
-      container = await this.source.getRepresentation({ path: this.container }, {});
-    } catch (error: unknown) {
-      // Container might not exist yet, will be created the first time `set` gets called
-      if (!NotFoundHttpError.isInstance(error)) {
-        throw error;
-      }
-      return;
-    }
-
-    // Only need the metadata
-    container.data.destroy();
-    const members = container.metadata.getAll(LDP.terms.contains).map((term): string => term.value);
-    for (const member of members) {
-      const representation = await this.source.getRepresentation({ path: member }, { type: { 'application/json': 1 }});
-      const json = JSON.parse(await readableToString(representation.data));
-      yield [ this.parseMember(member), json ];
-    }
+  public entries(): never {
+    // There is no way of knowing which resources were added, or we should keep track in an index file
+    throw new NotImplementedHttpError();
   }
 
   /**
    * Converts a key into an identifier for internal storage.
    */
   private createIdentifier(key: string): ResourceIdentifier {
-    const buffer = Buffer.from(key);
-    return { path: `${this.container}${buffer.toString('base64')}` };
-  }
-
-  /**
-   * Converts an internal storage identifier string into the original identifier key.
-   */
-  private parseMember(member: string): string {
-    const buffer = Buffer.from(member.slice(this.container.length), 'base64');
-    return buffer.toString('utf-8');
+    return { path: joinUrl(this.container, key) };
   }
 }

--- a/test/unit/storage/keyvalue/EncodingPathStorage.test.ts
+++ b/test/unit/storage/keyvalue/EncodingPathStorage.test.ts
@@ -1,0 +1,33 @@
+import { EncodingPathStorage } from '../../../../src/storage/keyvalue/EncodingPathStorage';
+import type { KeyValueStorage } from '../../../../src/storage/keyvalue/KeyValueStorage';
+
+describe('An EncodingPathStorage', (): void => {
+  const relativePath = '/container/';
+  let map: Map<string, string>;
+  let source: KeyValueStorage<string, unknown>;
+  let storage: EncodingPathStorage<unknown>;
+
+  beforeEach(async(): Promise<void> => {
+    map = new Map<string, string>();
+    source = map as any;
+    storage = new EncodingPathStorage(relativePath, source);
+  });
+
+  it('encodes the input key and joins it with the relativePath to create a new key.', async(): Promise<void> => {
+    const key = 'key';
+    // Base 64 encoding of 'key'
+    const encodedKey = 'a2V5';
+    const generatedPath = `${relativePath}${encodedKey}`;
+    const data = 'data';
+
+    await expect(storage.set(key, data)).resolves.toBe(storage);
+    expect(map.get(generatedPath)).toBe(data);
+
+    await expect(storage.has(key)).resolves.toBe(true);
+    await expect(storage.get(key)).resolves.toBe(data);
+    await expect(storage.entries().next()).resolves.toEqual({ done: false, value: [ key, data ]});
+
+    await expect(storage.delete(key)).resolves.toBe(true);
+    expect([ ...map.keys() ]).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
#### 📁 Related issues

Inspired by the fact that some new storages will be needed for #972

#### ✍️ Description

Creating new key/value storages was always a bit of a hassle as they had to be duplicated in 2 config files. The new solution makes it so you can create a storage in a specific container while still referencing the base storage. This way they only have to be defined once and can be moved to the config where they are needed, as many storages are only used by 1 class. This also makes it easier in the future to quickly create new storages.

A practical advantages of having many different storages is that this makes it easier to find which internal files need to be changed/removed in case of data migration or other related issues.

This PR doesn't change anything to the internal data structure (unless I made a typo somewhere) so should not cause data migration issues. In a future version I probably want to make it so the different classes that use the same setup storage instead all use a different subcontainer.

A more advanced structure that reuses route objects so `/idp/` is only defined once for example might also be an option in the future.
