### PR TITLE
Dynamically generate Allow and Accept-Patch/Put/Post headers

### DIFF
--- a/.componentsignore
+++ b/.componentsignore
@@ -1,5 +1,6 @@
 [
   "Adapter",
+  "BaseHttpError",
   "BasicConditions",
   "BasicRepresentation",
   "Error",

--- a/config/http/middleware/handlers/cors.json
+++ b/config/http/middleware/handlers/cors.json
@@ -18,6 +18,9 @@
       "options_preflightContinue": true,
       "options_exposedHeaders": [
         "Accept-Patch",
+        "Accept-Post",
+        "Accept-Put",
+        "Allow",
         "ETag",
         "Last-Modified",
         "Link",

--- a/config/ldp/metadata-writer/default.json
+++ b/config/ldp/metadata-writer/default.json
@@ -1,6 +1,7 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
   "import": [
+    "files-scs:config/ldp/metadata-writer/writers/allow-accept.json",
     "files-scs:config/ldp/metadata-writer/writers/constant.json",
     "files-scs:config/ldp/metadata-writer/writers/link-rel.json",
     "files-scs:config/ldp/metadata-writer/writers/mapped.json",
@@ -14,6 +15,7 @@
       "@id": "urn:solid-server:default:MetadataWriter",
       "@type": "ParallelHandler",
       "handlers": [
+        { "@id": "urn:solid-server:default:MetadataWriter_AllowAccept" },
         { "@id": "urn:solid-server:default:MetadataWriter_Constant" },
         { "@id": "urn:solid-server:default:MetadataWriter_Mapped" },
         { "@id": "urn:solid-server:default:MetadataWriter_Modified" },

--- a/config/ldp/metadata-writer/writers/allow-accept.json
+++ b/config/ldp/metadata-writer/writers/allow-accept.json
@@ -1,0 +1,14 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^3.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Adds Allow and Accept-[Method] headers.",
+      "@id": "urn:solid-server:default:MetadataWriter_AllowAccept",
+      "@type": "AllowAcceptHeaderWriter",
+      "supportedMethods": [ "OPTIONS", "HEAD", "GET", "PATCH", "POST", "PUT", "DELETE" ],
+      "acceptTypes_patch": [ "text/n3", "application/sparql-update" ],
+      "acceptTypes_put": [ "*/*" ],
+      "acceptTypes_post": [ "*/*" ]
+    }
+  ]
+}

--- a/config/ldp/metadata-writer/writers/constant.json
+++ b/config/ldp/metadata-writer/writers/constant.json
@@ -7,14 +7,6 @@
       "@type": "ConstantMetadataWriter",
       "headers": [
         {
-          "ConstantMetadataWriter:_headers_key": "Accept-Patch",
-          "ConstantMetadataWriter:_headers_value": "application/sparql-update, text/n3"
-        },
-        {
-          "ConstantMetadataWriter:_headers_key": "Allow",
-          "ConstantMetadataWriter:_headers_value": "OPTIONS, HEAD, GET, PATCH, POST, PUT, DELETE"
-        },
-        {
           "ConstantMetadataWriter:_headers_key": "MS-Author-Via",
           "ConstantMetadataWriter:_headers_value": "SPARQL"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "lodash.orderby": "^4.6.0",
         "marked": "^4.0.12",
         "mime-types": "^2.1.34",
-        "n3": "^1.13.0",
+        "n3": "^1.16.0",
         "nodemailer": "^6.7.2",
         "oidc-provider": "^7.10.6",
         "pump": "^3.0.0",
@@ -11585,9 +11585,9 @@
       "peer": true
     },
     "node_modules/n3": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.13.0.tgz",
-      "integrity": "sha512-GMB4ypBfnuf6mmwbtyN6Whc8TfuVDedxc4n+3wsacQH/h0+RjaEobGMhlWrFLDsqVbT94XA6+q9yysMO5SadKA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.0.tgz",
+      "integrity": "sha512-gE5KF07yhGXhEdAVru5QUqC4fKltA4sMwgASWpOrZSwn8fi8cuLHYPjRl9pR5WhQL96lhaNMZwT8enRIayVfLg==",
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -24025,9 +24025,9 @@
       "peer": true
     },
     "n3": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.13.0.tgz",
-      "integrity": "sha512-GMB4ypBfnuf6mmwbtyN6Whc8TfuVDedxc4n+3wsacQH/h0+RjaEobGMhlWrFLDsqVbT94XA6+q9yysMO5SadKA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.0.tgz",
+      "integrity": "sha512-gE5KF07yhGXhEdAVru5QUqC4fKltA4sMwgASWpOrZSwn8fi8cuLHYPjRl9pR5WhQL96lhaNMZwT8enRIayVfLg==",
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "lodash.orderby": "^4.6.0",
     "marked": "^4.0.12",
     "mime-types": "^2.1.34",
-    "n3": "^1.13.0",
+    "n3": "^1.16.0",
     "nodemailer": "^6.7.2",
     "oidc-provider": "^7.10.6",
     "pump": "^3.0.0",

--- a/src/http/output/metadata/AllowAcceptHeaderWriter.ts
+++ b/src/http/output/metadata/AllowAcceptHeaderWriter.ts
@@ -1,0 +1,139 @@
+import type { HttpResponse } from '../../../server/HttpResponse';
+import { MethodNotAllowedHttpError } from '../../../util/errors/MethodNotAllowedHttpError';
+import { NotFoundHttpError } from '../../../util/errors/NotFoundHttpError';
+import { UnsupportedMediaTypeHttpError } from '../../../util/errors/UnsupportedMediaTypeHttpError';
+import { addHeader } from '../../../util/HeaderUtil';
+import { isContainerPath } from '../../../util/PathUtil';
+import { LDP, PIM, RDF, SOLID_ERROR } from '../../../util/Vocabularies';
+import type { RepresentationMetadata } from '../../representation/RepresentationMetadata';
+import { MetadataWriter } from './MetadataWriter';
+
+// Only PUT and PATCH can be used to create a new resource
+const NEW_RESOURCE_ALLOWED_METHODS = new Set([ 'PUT', 'PATCH' ]);
+
+/**
+ * Generates Allow, Accept-Patch, Accept-Post, and Accept-Put headers.
+ * The resulting values depend on the choses input methods and types.
+ * The input metadata also gets used to remove methods from that list
+ * if they are not valid in the given situation.
+ */
+export class AllowAcceptHeaderWriter extends MetadataWriter {
+  private readonly supportedMethods: string[];
+  private readonly acceptTypes: { patch: string[]; post: string[]; put: string[] };
+
+  public constructor(supportedMethods: string[], acceptTypes: { patch?: string[]; post?: string[]; put?: string[] }) {
+    super();
+    this.supportedMethods = supportedMethods;
+    this.acceptTypes = { patch: [], post: [], put: [], ...acceptTypes };
+  }
+
+  public async handle(input: { response: HttpResponse; metadata: RepresentationMetadata }): Promise<void> {
+    const { response, metadata } = input;
+
+    // Filter out methods which are not allowed
+    const allowedMethods = this.filterAllowedMethods(metadata);
+
+    // Generate the Allow headers (if required)
+    const generateAllow = this.generateAllow(allowedMethods, response, metadata);
+
+    // Generate Accept-[Method] headers (if required)
+    this.generateAccept(allowedMethods, generateAllow, response, metadata);
+  }
+
+  /**
+   * Starts from the stored set of methods and removes all those that are not allowed based on the metadata.
+   */
+  private filterAllowedMethods(metadata: RepresentationMetadata): Set<string> {
+    const disallowedMethods = new Set(metadata.getAll(SOLID_ERROR.terms.disallowedMethod)
+      .map((term): string => term.value));
+    const allowedMethods = new Set(this.supportedMethods.filter((method): boolean => !disallowedMethods.has(method)));
+
+    // POST is only allowed on containers.
+    // Metadata only has the resource URI in case it has resource metadata.
+    if (this.isPostAllowed(metadata)) {
+      allowedMethods.delete('POST');
+    }
+
+    if (!this.isDeleteAllowed(metadata)) {
+      allowedMethods.delete('DELETE');
+    }
+
+    // If we are sure the resource does not exist: only keep methods that can create a new resource.
+    if (metadata.has(SOLID_ERROR.terms.errorResponse, NotFoundHttpError.uri)) {
+      for (const method of allowedMethods) {
+        if (!NEW_RESOURCE_ALLOWED_METHODS.has(method)) {
+          allowedMethods.delete(method);
+        }
+      }
+    }
+
+    return allowedMethods;
+  }
+
+  /**
+   * POST is only allowed on containers.
+   * The metadata URI is only valid in case there is resource metadata,
+   * otherwise it is just a blank node.
+   */
+  private isPostAllowed(metadata: RepresentationMetadata): boolean {
+    return metadata.has(RDF.terms.type, LDP.terms.Resource) && !isContainerPath(metadata.identifier.value);
+  }
+
+  /**
+   * DELETE is allowed if the target exists,
+   * is not a container,
+   * or is an empty container that isn't a storage.
+   *
+   * Note that the identifier value check only works if the metadata is not about an error.
+   */
+  private isDeleteAllowed(metadata: RepresentationMetadata): boolean {
+    if (!isContainerPath(metadata.identifier.value)) {
+      return true;
+    }
+
+    const isStorage = metadata.has(RDF.terms.type, PIM.terms.Storage);
+    const isEmpty = metadata.has(LDP.terms.contains);
+    return !isStorage && !isEmpty;
+  }
+
+  /**
+   * Generates the Allow header if required.
+   * It only needs to get added for successful GET/HEAD requests, 404s, or 405s.
+   * The spec only requires it for GET/HEAD requests and 405s.
+   * In the case of other error messages we can't deduce what the request method was,
+   * so we do not add the header as we don't have enough information.
+   */
+  private generateAllow(methods: Set<string>, response: HttpResponse, metadata: RepresentationMetadata): boolean {
+    const methodDisallowed = metadata.has(SOLID_ERROR.terms.errorResponse, MethodNotAllowedHttpError.uri);
+    // 405s indicate the target resource exists.
+    // This is a heuristic, but one that should always be correct in our case.
+    const resourceExists = methodDisallowed || metadata.has(RDF.terms.type, LDP.terms.Resource);
+    const generateAllow = resourceExists || metadata.has(SOLID_ERROR.terms.errorResponse, NotFoundHttpError.uri);
+    if (generateAllow) {
+      addHeader(response, 'Allow', [ ...methods ].join(', '));
+    }
+    return generateAllow;
+  }
+
+  /**
+   * Generates the Accept-[Method] headers if required.
+   * Will be added if the Allow header was added, or in case of a 415 error.
+   * Specific Accept-[Method] headers will only be added if the method is in the `methods` set.
+   */
+  private generateAccept(methods: Set<string>, generateAllow: boolean, response: HttpResponse,
+    metadata: RepresentationMetadata): void {
+    const typeWasUnsupported = metadata.has(SOLID_ERROR.terms.errorResponse, UnsupportedMediaTypeHttpError.uri);
+    const generateAccept = generateAllow || typeWasUnsupported;
+    if (generateAccept) {
+      if (methods.has('PATCH')) {
+        addHeader(response, 'Accept-Patch', this.acceptTypes.patch.join(', '));
+      }
+      if (methods.has('POST')) {
+        addHeader(response, 'Accept-Post', this.acceptTypes.post.join(', '));
+      }
+      if (methods.has('PUT')) {
+        addHeader(response, 'Accept-Put', this.acceptTypes.put.join(', '));
+      }
+    }
+  }
+}

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -258,6 +258,20 @@ export class RepresentationMetadata {
   }
 
   /**
+   * Verifies if a specific triple can be found in the metadata.
+   * Undefined parameters are interpreted as wildcards.
+   */
+  public has(
+    predicate: NamedNode | string | null = null,
+    object: NamedNode | BlankNode | Literal | string | null = null,
+    graph: MetadataGraph | null = null,
+  ): boolean {
+    // This works with N3.js but at the time of writing the typings have not been updated yet.
+    // If you see this line of code check if the typings are already correct and update this if so.
+    return (this.store.has as any)(this.id, predicate, object, graph);
+  }
+
+  /**
    * Finds all object values matching the given predicate and/or graph.
    * @param predicate - Optional predicate to get the values for.
    * @param graph - Optional graph where to get from.

--- a/src/identity/interaction/BaseInteractionHandler.ts
+++ b/src/identity/interaction/BaseInteractionHandler.ts
@@ -22,7 +22,7 @@ export abstract class BaseInteractionHandler extends InteractionHandler {
     await super.canHandle(input);
     const { method } = input.operation;
     if (method !== 'GET' && method !== 'POST') {
-      throw new MethodNotAllowedHttpError('Only GET/POST requests are supported.');
+      throw new MethodNotAllowedHttpError([ method ], 'Only GET/POST requests are supported.');
     }
   }
 
@@ -30,7 +30,7 @@ export abstract class BaseInteractionHandler extends InteractionHandler {
     switch (input.operation.method) {
       case 'GET': return this.handleGet(input);
       case 'POST': return this.handlePost(input);
-      default: throw new MethodNotAllowedHttpError();
+      default: throw new MethodNotAllowedHttpError([ input.operation.method ]);
     }
   }
 

--- a/src/identity/interaction/HtmlViewHandler.ts
+++ b/src/identity/interaction/HtmlViewHandler.ts
@@ -39,7 +39,7 @@ export class HtmlViewHandler extends InteractionHandler {
 
   public async canHandle({ operation }: InteractionHandlerInput): Promise<void> {
     if (operation.method !== 'GET') {
-      throw new MethodNotAllowedHttpError();
+      throw new MethodNotAllowedHttpError([ operation.method ]);
     }
     if (!this.templates[operation.target.path]) {
       throw new NotFoundHttpError();

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ export * from './http/output/error/RedirectingErrorHandler';
 export * from './http/output/error/SafeErrorHandler';
 
 // HTTP/Output/Metadata
+export * from './http/output/metadata/AllowAcceptHeaderWriter';
 export * from './http/output/metadata/ConstantMetadataWriter';
 export * from './http/output/metadata/LinkRelMetadataWriter';
 export * from './http/output/metadata/MappedMetadataWriter';

--- a/src/init/setup/SetupHttpHandler.ts
+++ b/src/init/setup/SetupHttpHandler.ts
@@ -68,7 +68,7 @@ export class SetupHttpHandler extends OperationHttpHandler {
     switch (operation.method) {
       case 'GET': return this.handleGet(operation);
       case 'POST': return this.handlePost(operation);
-      default: throw new MethodNotAllowedHttpError();
+      default: throw new MethodNotAllowedHttpError([ operation.method ]);
     }
   }
 

--- a/src/server/ParsingHttpHandler.ts
+++ b/src/server/ParsingHttpHandler.ts
@@ -6,6 +6,7 @@ import type { ResponseWriter } from '../http/output/ResponseWriter';
 import type { RepresentationPreferences } from '../http/representation/RepresentationPreferences';
 import { getLoggerFor } from '../logging/LogUtil';
 import { assertError } from '../util/errors/ErrorUtil';
+import { HttpError } from '../util/errors/HttpError';
 import type { HttpHandlerInput } from './HttpHandler';
 import { HttpHandler } from './HttpHandler';
 import type { OperationHttpHandler } from './OperationHttpHandler';
@@ -73,6 +74,10 @@ export class ParsingHttpHandler extends HttpHandler {
     } catch (error: unknown) {
       assertError(error);
       result = await this.errorHandler.handleSafe({ error, preferences });
+      if (HttpError.isInstance(error) && result.metadata) {
+        const quads = error.generateMetadata(result.metadata.identifier);
+        result.metadata.addQuads(quads);
+      }
     }
 
     if (result) {

--- a/src/server/util/RouterHandler.ts
+++ b/src/server/util/RouterHandler.ts
@@ -47,7 +47,7 @@ export class RouterHandler extends HttpHandler {
       throw new BadRequestHttpError('Cannot handle request without a method');
     }
     if (!this.allMethods && !this.allowedMethods.includes(request.method)) {
-      throw new MethodNotAllowedHttpError(`${request.method} is not allowed.`);
+      throw new MethodNotAllowedHttpError([ request.method ], `${request.method} is not allowed.`);
     }
     const pathName = await getRelativeUrl(this.baseUrl, request, this.targetExtractor);
     if (!this.allowedPathNamesRegEx.some((regex): boolean => regex.test(pathName))) {

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -155,7 +155,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     // that are not supported by the target resource."
     // https://solid.github.io/specification/protocol#reading-writing-resources
     if (!isContainerPath(parentMetadata.identifier.value)) {
-      throw new MethodNotAllowedHttpError('The given path is not a container.');
+      throw new MethodNotAllowedHttpError([ 'POST' ], 'The given path is not a container.');
     }
 
     this.validateConditions(conditions, parentMetadata);
@@ -240,14 +240,15 @@ export class DataAccessorBasedStore implements ResourceStore {
     // the server MUST respond with the 405 status code."
     // https://solid.github.io/specification/protocol#deleting-resources
     if (this.isRootStorage(metadata)) {
-      throw new MethodNotAllowedHttpError('Cannot delete a root storage container.');
+      throw new MethodNotAllowedHttpError([ 'DELETE' ], 'Cannot delete a root storage container.');
     }
     if (this.auxiliaryStrategy.isAuxiliaryIdentifier(identifier) &&
       this.auxiliaryStrategy.isRequiredInRoot(identifier)) {
       const subjectIdentifier = this.auxiliaryStrategy.getSubjectIdentifier(identifier);
       const parentMetadata = await this.accessor.getMetadata(subjectIdentifier);
       if (this.isRootStorage(parentMetadata)) {
-        throw new MethodNotAllowedHttpError(`Cannot delete ${identifier.path} from a root storage container.`);
+        throw new MethodNotAllowedHttpError([ 'DELETE' ],
+          `Cannot delete ${identifier.path} from a root storage container.`);
       }
     }
 

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -141,6 +141,7 @@ export const SOLID = createUriAndTermNamespace('http://www.w3.org/ns/solid/terms
 );
 
 export const SOLID_ERROR = createUriAndTermNamespace('urn:npm:solid:community-server:error:',
+  'errorResponse',
   'stack',
 );
 

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -141,6 +141,7 @@ export const SOLID = createUriAndTermNamespace('http://www.w3.org/ns/solid/terms
 );
 
 export const SOLID_ERROR = createUriAndTermNamespace('urn:npm:solid:community-server:error:',
+  'disallowedMethod',
   'errorResponse',
   'stack',
 );

--- a/src/util/errors/BadRequestHttpError.ts
+++ b/src/util/errors/BadRequestHttpError.ts
@@ -1,24 +1,20 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(400, 'BadRequestHttpError');
 
 /**
  * An error thrown when incoming data is not supported.
  * Probably because an {@link AsyncHandler} returns false on the canHandle call.
  */
-export class BadRequestHttpError extends HttpError {
+export class BadRequestHttpError extends BaseHttpError {
   /**
    * Default message is 'The given input is not supported by the server configuration.'.
    * @param message - Optional, more specific, message.
    * @param options - Optional error options.
    */
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(400,
-      'BadRequestHttpError',
-      message ?? 'The given input is not supported by the server configuration.',
-      options);
-  }
-
-  public static isInstance(error: any): error is BadRequestHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 400;
+    super(message ?? 'The given input is not supported by the server configuration.', options);
   }
 }

--- a/src/util/errors/ConflictHttpError.ts
+++ b/src/util/errors/ConflictHttpError.ts
@@ -1,14 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(409, 'ConflictHttpError');
+
 /**
  * An error thrown when a request conflict with current state of the server.
  */
-export class ConflictHttpError extends HttpError {
+export class ConflictHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(409, 'ConflictHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is ConflictHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 409;
+    super(message, options);
   }
 }

--- a/src/util/errors/ForbiddenHttpError.ts
+++ b/src/util/errors/ForbiddenHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(403, 'ForbiddenHttpError');
 
 /**
  * An error thrown when an agent is not allowed to access data.
  */
-export class ForbiddenHttpError extends HttpError {
+export class ForbiddenHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(403, 'ForbiddenHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is ForbiddenHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 403;
+    super(message, options);
   }
 }

--- a/src/util/errors/FoundHttpError.ts
+++ b/src/util/errors/FoundHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { RedirectHttpError } from './RedirectHttpError';
+import { generateRedirectHttpErrorClass } from './RedirectHttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateRedirectHttpErrorClass(302, 'FoundHttpError');
 
 /**
  * Error used for resources that have been moved temporarily.
  */
-export class FoundHttpError extends RedirectHttpError {
+export class FoundHttpError extends BaseHttpError {
   public constructor(location: string, message?: string, options?: HttpErrorOptions) {
-    super(302, location, 'FoundHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is FoundHttpError {
-    return RedirectHttpError.isInstance(error) && error.statusCode === 302;
+    super(location, message, options);
   }
 }

--- a/src/util/errors/HttpError.ts
+++ b/src/util/errors/HttpError.ts
@@ -1,4 +1,9 @@
+import { DataFactory } from 'n3';
+import type { NamedNode, Quad, Quad_Subject } from 'rdf-js';
+import { toNamedTerm } from '../TermUtil';
+import { SOLID_ERROR } from '../Vocabularies';
 import { isError } from './ErrorUtil';
+import quad = DataFactory.quad;
 
 export interface HttpErrorOptions {
   cause?: unknown;
@@ -7,12 +12,18 @@ export interface HttpErrorOptions {
 }
 
 /**
+ * Returns a URI that is unique for the given status code.
+ */
+export function generateHttpErrorUri(statusCode: number): NamedNode {
+  return toNamedTerm(`${SOLID_ERROR.namespace}H${statusCode}`);
+}
+
+/**
  * A class for all errors that could be thrown by Solid.
  * All errors inheriting from this should fix the status code thereby hiding the HTTP internals from other components.
  */
-export class HttpError extends Error implements HttpErrorOptions {
-  protected static readonly statusCode: number;
-  public readonly statusCode: number;
+export class HttpError<T extends number = number> extends Error implements HttpErrorOptions {
+  public readonly statusCode: T;
   public readonly cause?: unknown;
   public readonly errorCode: string;
   public readonly details?: NodeJS.Dict<unknown>;
@@ -24,7 +35,7 @@ export class HttpError extends Error implements HttpErrorOptions {
    * @param message - Error message.
    * @param options - Optional options.
    */
-  public constructor(statusCode: number, name: string, message?: string, options: HttpErrorOptions = {}) {
+  public constructor(statusCode: T, name: string, message?: string, options: HttpErrorOptions = {}) {
     super(message);
     this.statusCode = statusCode;
     this.name = name;
@@ -36,4 +47,62 @@ export class HttpError extends Error implements HttpErrorOptions {
   public static isInstance(error: any): error is HttpError {
     return isError(error) && typeof (error as any).statusCode === 'number';
   }
+
+  /**
+   * Returns quads representing metadata relevant to this error.
+   */
+  public generateMetadata(subject: Quad_Subject | string): Quad[] {
+    // The reason we have this here instead of the generate function below
+    // is because we still want errors created with `new HttpError` to be treated identical
+    // as errors created with the constructor of the error class corresponding to that specific status code.
+    return [
+      quad(toNamedTerm(subject), SOLID_ERROR.terms.errorResponse, generateHttpErrorUri(this.statusCode)),
+    ];
+  }
+}
+
+/**
+ * Interface describing what an HttpError class should look like.
+ * This helps us make sure all HttpError classes have the same utility static functions.
+ */
+export interface HttpErrorClass<TCode extends number = number> {
+  new(message?: string, options?: HttpErrorOptions): HttpError<TCode>;
+
+  /**
+   * The status code corresponding to this error class.
+   */
+  readonly statusCode: TCode;
+  /**
+   * A unique URI identifying this error class.
+   */
+  readonly uri: NamedNode;
+  /**
+   * Checks if the given error is an instance of this class.
+   */
+  readonly isInstance: (error: any) => error is HttpError<TCode>;
+}
+
+/**
+ * Generates a new HttpError class with the given status code and name.
+ * In general, status codes are used to uniquely identify error types,
+ * so there should be no 2 classes with the same value there.
+ *
+ * To make sure Components.js can work with these newly generated classes,
+ * the generated class should be called `BaseHttpError` as that name is an entry in `.componentsignore`.
+ * The actual class should then extend `BaseHttpError` and have a correct constructor,
+ * so the Components.js generator can generate the correct components JSON-LD file during build.
+ */
+export function generateHttpErrorClass<TCode extends number>(statusCode: TCode, name: string): HttpErrorClass<TCode> {
+  return class SpecificHttpError extends HttpError<TCode> {
+    public static readonly statusCode = statusCode;
+    public static readonly uri = generateHttpErrorUri(statusCode);
+
+    public constructor(message?: string, options?: HttpErrorOptions) {
+      super(statusCode, name, message, options);
+    }
+
+    public static isInstance(error: any): error is SpecificHttpError {
+      return HttpError.isInstance(error) && error.statusCode === statusCode;
+    }
+  };
 }

--- a/src/util/errors/InternalServerError.ts
+++ b/src/util/errors/InternalServerError.ts
@@ -1,14 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(500, 'InternalServerError');
+
 /**
  * A generic error message, given when an unexpected condition was encountered and no more specific message is suitable.
  */
-export class InternalServerError extends HttpError {
+export class InternalServerError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(500, 'InternalServerError', message, options);
-  }
-
-  public static isInstance(error: any): error is InternalServerError {
-    return HttpError.isInstance(error) && error.statusCode === 500;
+    super(message, options);
   }
 }

--- a/src/util/errors/MethodNotAllowedHttpError.ts
+++ b/src/util/errors/MethodNotAllowedHttpError.ts
@@ -1,14 +1,32 @@
+import { DataFactory } from 'n3';
+import type { Quad, Quad_Subject } from 'rdf-js';
+import { toNamedTerm, toObjectTerm } from '../TermUtil';
+import { SOLID_ERROR } from '../Vocabularies';
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+import quad = DataFactory.quad;
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(405, 'MethodNotAllowedHttpError');
+
 /**
  * An error thrown when data was found for the requested identifier, but is not supported by the target resource.
+ * Can keep track of the methods that are not allowed.
  */
-export class MethodNotAllowedHttpError extends HttpError {
-  public constructor(message?: string, options?: HttpErrorOptions) {
-    super(405, 'MethodNotAllowedHttpError', message, options);
+export class MethodNotAllowedHttpError extends BaseHttpError {
+  public readonly methods: Readonly<string[]>;
+
+  public constructor(methods: string[] = [], message?: string, options?: HttpErrorOptions) {
+    super(message ?? `${methods} are not allowed.`, options);
+    this.methods = methods;
   }
 
-  public static isInstance(error: any): error is MethodNotAllowedHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 405;
+  public generateMetadata(subject: Quad_Subject | string): Quad[] {
+    const term = toNamedTerm(subject);
+    const quads = super.generateMetadata(term);
+    for (const method of this.methods) {
+      quads.push(quad(term, SOLID_ERROR.terms.disallowedMethod, toObjectTerm(method, true)));
+    }
+    return quads;
   }
 }

--- a/src/util/errors/MovedPermanentlyHttpError.ts
+++ b/src/util/errors/MovedPermanentlyHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { RedirectHttpError } from './RedirectHttpError';
+import { generateRedirectHttpErrorClass } from './RedirectHttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateRedirectHttpErrorClass(301, 'MovedPermanentlyHttpError');
 
 /**
  * Error used for resources that have been moved permanently.
  */
-export class MovedPermanentlyHttpError extends RedirectHttpError {
+export class MovedPermanentlyHttpError extends BaseHttpError {
   public constructor(location: string, message?: string, options?: HttpErrorOptions) {
-    super(301, location, 'MovedPermanentlyHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is MovedPermanentlyHttpError {
-    return RedirectHttpError.isInstance(error) && error.statusCode === 301;
+    super(location, message, options);
   }
 }

--- a/src/util/errors/NotFoundHttpError.ts
+++ b/src/util/errors/NotFoundHttpError.ts
@@ -1,14 +1,15 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(404, 'NotFoundHttpError');
+
 /**
  * An error thrown when no data was found for the requested identifier.
  */
-export class NotFoundHttpError extends HttpError {
+export class NotFoundHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(404, 'NotFoundHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is NotFoundHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 404;
+    super(message, options);
   }
 }
+

--- a/src/util/errors/NotImplementedHttpError.ts
+++ b/src/util/errors/NotImplementedHttpError.ts
@@ -1,16 +1,15 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(501, 'NotImplementedHttpError');
 
 /**
  * The server either does not recognize the request method, or it lacks the ability to fulfil the request.
  * Usually this implies future availability (e.g., a new feature of a web-service API).
  */
-export class NotImplementedHttpError extends HttpError {
+export class NotImplementedHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(501, 'NotImplementedHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is NotImplementedHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 501;
+    super(message, options);
   }
 }

--- a/src/util/errors/PayloadHttpError.ts
+++ b/src/util/errors/PayloadHttpError.ts
@@ -1,23 +1,19 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(413, 'PayloadHttpError');
 
 /**
- * An error thrown when data exceeded the pre configured quota
+ * An error thrown when data exceeded the preconfigured quota
  */
-export class PayloadHttpError extends HttpError {
+export class PayloadHttpError extends BaseHttpError {
   /**
    * Default message is 'Storage quota was exceeded.'.
    * @param message - Optional, more specific, message.
    * @param options - Optional error options.
    */
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(413,
-      'PayloadHttpError',
-      message ?? 'Storage quota was exceeded.',
-      options);
-  }
-
-  public static isInstance(error: any): error is PayloadHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 413;
+    super(message ?? 'Storage quota was exceeded.', options);
   }
 }

--- a/src/util/errors/PreconditionFailedHttpError.ts
+++ b/src/util/errors/PreconditionFailedHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(412, 'PreconditionFailedHttpError');
 
 /**
  * An error thrown when access was denied due to the conditions on the request.
  */
-export class PreconditionFailedHttpError extends HttpError {
+export class PreconditionFailedHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(412, 'PreconditionFailedHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is PreconditionFailedHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 412;
+    super(message, options);
   }
 }

--- a/src/util/errors/RedirectHttpError.ts
+++ b/src/util/errors/RedirectHttpError.ts
@@ -1,14 +1,14 @@
-import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import type { HttpErrorClass, HttpErrorOptions } from './HttpError';
+import { generateHttpErrorClass, HttpError } from './HttpError';
 
 /**
- * Abstract class representing a 3xx redirect.
+ * An error corresponding to a 3xx status code.
+ * Includes the location it redirects to.
  */
-export abstract class RedirectHttpError extends HttpError {
+export class RedirectHttpError<TCode extends number = number> extends HttpError<TCode> {
   public readonly location: string;
 
-  protected constructor(statusCode: number, location: string, name: string, message?: string,
-    options?: HttpErrorOptions) {
+  public constructor(statusCode: TCode, name: string, location: string, message?: string, options?: HttpErrorOptions) {
     super(statusCode, name, message, options);
     this.location = location;
   }
@@ -16,4 +16,39 @@ export abstract class RedirectHttpError extends HttpError {
   public static isInstance(error: any): error is RedirectHttpError {
     return HttpError.isInstance(error) && typeof (error as any).location === 'string';
   }
+}
+
+/**
+ * Interface describing what a {@link RedirectHttpError} class should look like.
+ * Makes sure a `location` value is always needed.
+ */
+export interface RedirectHttpErrorClass<TCode extends number = number> extends Omit<HttpErrorClass<TCode>, 'new'> {
+  new(location: string, message?: string, options?: HttpErrorOptions): RedirectHttpError<TCode>;
+}
+
+/**
+ * Generates a {@link RedirectHttpErrorClass}, similar to how {@link generateHttpErrorClass} works.
+ * The difference is that here a `location` field also gets set and the `getInstance` method
+ * also uses the {@link RedirectHttpError.isInstance} function.
+ */
+export function generateRedirectHttpErrorClass<TCode extends number>(
+  code: TCode,
+  name: string,
+): RedirectHttpErrorClass<TCode> {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const BaseClass = generateHttpErrorClass(code, name);
+
+  // Need to extend `BaseClass` instead of `RedirectHttpError` to have the required static methods
+  return class SpecificRedirectHttpError extends BaseClass implements RedirectHttpError {
+    public readonly location: string;
+
+    public constructor(location: string, message?: string, options?: HttpErrorOptions) {
+      super(message, options);
+      this.location = location;
+    }
+
+    public static isInstance(error: any): error is SpecificRedirectHttpError {
+      return RedirectHttpError.isInstance(error) && error.statusCode === code;
+    }
+  };
 }

--- a/src/util/errors/UnauthorizedHttpError.ts
+++ b/src/util/errors/UnauthorizedHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(401, 'UnauthorizedHttpError');
 
 /**
  * An error thrown when an agent is not authorized.
  */
-export class UnauthorizedHttpError extends HttpError {
+export class UnauthorizedHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(401, 'UnauthorizedHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is UnauthorizedHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 401;
+    super(message, options);
   }
 }

--- a/src/util/errors/UnprocessableEntityHttpError.ts
+++ b/src/util/errors/UnprocessableEntityHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(422, 'UnprocessableEntityHttpError');
 
 /**
  * An error thrown when the server understands the content-type but can't process the instructions.
  */
-export class UnprocessableEntityHttpError extends HttpError {
+export class UnprocessableEntityHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(422, 'UnprocessableEntityHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is UnprocessableEntityHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 422;
+    super(message, options);
   }
 }

--- a/src/util/errors/UnsupportedMediaTypeHttpError.ts
+++ b/src/util/errors/UnsupportedMediaTypeHttpError.ts
@@ -1,15 +1,14 @@
 import type { HttpErrorOptions } from './HttpError';
-import { HttpError } from './HttpError';
+import { generateHttpErrorClass } from './HttpError';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const BaseHttpError = generateHttpErrorClass(415, 'UnsupportedMediaTypeHttpError');
 
 /**
  * An error thrown when the media type of incoming data is not supported by a parser.
  */
-export class UnsupportedMediaTypeHttpError extends HttpError {
+export class UnsupportedMediaTypeHttpError extends BaseHttpError {
   public constructor(message?: string, options?: HttpErrorOptions) {
-    super(415, 'UnsupportedMediaTypeHttpError', message, options);
-  }
-
-  public static isInstance(error: any): error is UnsupportedMediaTypeHttpError {
-    return HttpError.isInstance(error) && error.statusCode === 415;
+    super(message, options);
   }
 }

--- a/test/integration/Middleware.test.ts
+++ b/test/integration/Middleware.test.ts
@@ -93,10 +93,12 @@ describe('An http server with middleware', (): void => {
     expect(res.header).toEqual(expect.objectContaining({ 'access-control-allow-origin': 'test.com' }));
   });
 
-  it('exposes the Accept-Patch header via CORS.', async(): Promise<void> => {
+  it('exposes the Accept-[Method] header via CORS.', async(): Promise<void> => {
     const res = await request(server).get('/').expect(200);
     const exposed = res.header['access-control-expose-headers'];
     expect(exposed.split(/\s*,\s*/u)).toContain('Accept-Patch');
+    expect(exposed.split(/\s*,\s*/u)).toContain('Accept-Post');
+    expect(exposed.split(/\s*,\s*/u)).toContain('Accept-Put');
   });
 
   it('exposes the Last-Modified and ETag headers via CORS.', async(): Promise<void> => {

--- a/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
+++ b/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
@@ -1,0 +1,115 @@
+import { createResponse } from 'node-mocks-http';
+import { AllowAcceptHeaderWriter } from '../../../../../src/http/output/metadata/AllowAcceptHeaderWriter';
+import type { MetadataRecord } from '../../../../../src/http/representation/RepresentationMetadata';
+import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
+import type { HttpResponse } from '../../../../../src/server/HttpResponse';
+import { MethodNotAllowedHttpError } from '../../../../../src/util/errors/MethodNotAllowedHttpError';
+import { NotFoundHttpError } from '../../../../../src/util/errors/NotFoundHttpError';
+import { UnsupportedMediaTypeHttpError } from '../../../../../src/util/errors/UnsupportedMediaTypeHttpError';
+import { LDP, PIM, RDF, SOLID_ERROR } from '../../../../../src/util/Vocabularies';
+
+describe('An AllowAcceptHeaderWriter', (): void => {
+  const document = new RepresentationMetadata({ path: 'http://example.com/foo/bar' },
+    { [RDF.type]: LDP.terms.Resource });
+  const emptyContainer = new RepresentationMetadata({ path: 'http://example.com/foo/' },
+    { [RDF.type]: [ LDP.terms.Resource, LDP.terms.Container ]});
+  const fullContainer = new RepresentationMetadata({ path: 'http://example.com/foo/' },
+    {
+      [RDF.type]: [ LDP.terms.Resource, LDP.terms.Container ],
+      [LDP.contains]: [ document.identifier ],
+      // Typescript doesn't find the correct constructor without the cast
+    } as MetadataRecord);
+  const storageContainer = new RepresentationMetadata({ path: 'http://example.com/foo/' },
+    { [RDF.type]: [ LDP.terms.Resource, LDP.terms.Container, PIM.terms.Storage ]});
+  const error404 = new RepresentationMetadata({ [SOLID_ERROR.errorResponse]: NotFoundHttpError.uri });
+  const error405 = new RepresentationMetadata(
+    { [SOLID_ERROR.errorResponse]: MethodNotAllowedHttpError.uri, [SOLID_ERROR.disallowedMethod]: 'PUT' },
+  );
+  const error415 = new RepresentationMetadata({ [SOLID_ERROR.errorResponse]: UnsupportedMediaTypeHttpError.uri });
+  let response: HttpResponse;
+  let writer: AllowAcceptHeaderWriter;
+
+  beforeEach(async(): Promise<void> => {
+    response = createResponse();
+
+    writer = new AllowAcceptHeaderWriter(
+      [ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH', 'DELETE' ],
+      { patch: [ 'text/n3', 'application/sparql-update' ], post: [ '*/*' ], put: [ '*/*' ]},
+    );
+  });
+
+  it('returns all methods except POST for a document.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: document })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set((headers.allow as string).split(', ')))
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'PATCH', 'DELETE' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBeUndefined();
+  });
+
+  it('returns all methods for an empty container.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: emptyContainer })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set((headers.allow as string).split(', ')))
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH', 'DELETE' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBe('*/*');
+  });
+
+  it('returns all methods except DELETE for a non-empty container.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: fullContainer })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set((headers.allow as string).split(', ')))
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBe('*/*');
+  });
+
+  it('returns all methods except DELETE for a storage container.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: storageContainer })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set((headers.allow as string).split(', ')))
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBe('*/*');
+  });
+
+  it('returns PATCH and PUT if the target does not exist.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: error404 })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set((headers.allow as string).split(', ')))
+      .toEqual(new Set([ 'PUT', 'PATCH' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBeUndefined();
+  });
+
+  it('removes methods that are not allowed by a 405 error.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: error405 })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set((headers.allow as string).split(', ')))
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH', 'DELETE' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBeUndefined();
+    expect(headers['accept-post']).toBe('*/*');
+  });
+
+  it('only returns Accept- headers in case of a 415.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: error415 })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(headers.allow).toBeUndefined();
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBe('*/*');
+  });
+});

--- a/test/unit/http/representation/RepresentationMetadata.test.ts
+++ b/test/unit/http/representation/RepresentationMetadata.test.ts
@@ -248,6 +248,13 @@ describe('A RepresentationMetadata', (): void => {
       );
     });
 
+    it('can check the existence of a triple.', async(): Promise<void> => {
+      expect(metadata.has(namedNode('has'), literal('data'))).toBe(true);
+      expect(metadata.has(namedNode('has'))).toBe(true);
+      expect(metadata.has(undefined, literal('data'))).toBe(true);
+      expect(metadata.has(namedNode('has'), literal('wrongData'))).toBe(false);
+    });
+
     it('can get all values for a predicate.', async(): Promise<void> => {
       expect(metadata.getAll(namedNode('has'))).toEqualRdfTermArray(
         [ literal('data'), literal('moreData'), literal('data') ],

--- a/test/unit/util/errors/HttpError.test.ts
+++ b/test/unit/util/errors/HttpError.test.ts
@@ -23,7 +23,6 @@ describe('HttpError', (): void => {
     [ 'UnauthorizedHttpError', 401, UnauthorizedHttpError ],
     [ 'ForbiddenHttpError', 403, ForbiddenHttpError ],
     [ 'NotFoundHttpError', 404, NotFoundHttpError ],
-    [ 'MethodNotAllowedHttpError', 405, MethodNotAllowedHttpError ],
     [ 'ConflictHttpError', 409, ConflictHttpError ],
     [ 'PreconditionFailedHttpError', 412, PreconditionFailedHttpError ],
     [ 'PayloadHttpError', 413, PayloadHttpError ],
@@ -81,6 +80,34 @@ describe('HttpError', (): void => {
       const subject = namedNode('subject');
       expect(instance.generateMetadata(subject)).toBeRdfIsomorphic([
         quad(subject, SOLID_ERROR.terms.errorResponse, constructor.uri),
+      ]);
+    });
+  });
+
+  // Separate test due to different constructor
+  describe('MethodNotAllowedHttpError', (): void => {
+    const options = {
+      cause: new Error('cause'),
+      errorCode: 'E1234',
+      details: { some: 'detail' },
+    };
+    const instance = new MethodNotAllowedHttpError([ 'GET' ], 'my message', options);
+
+    it('is valid.', async(): Promise<void> => {
+      expect(new MethodNotAllowedHttpError().methods).toHaveLength(0);
+      expect(MethodNotAllowedHttpError.isInstance(instance)).toBe(true);
+      expect(MethodNotAllowedHttpError.uri).toEqualRdfTerm(generateHttpErrorUri(405));
+      expect(instance.name).toBe('MethodNotAllowedHttpError');
+      expect(instance.statusCode).toBe(405);
+      expect(instance.message).toBe('my message');
+      expect(instance.cause).toBe(options.cause);
+      expect(instance.errorCode).toBe(options.errorCode);
+      expect(new MethodNotAllowedHttpError([ 'GET' ]).errorCode).toBe(`H${405}`);
+
+      const subject = namedNode('subject');
+      expect(instance.generateMetadata(subject)).toBeRdfIsomorphic([
+        quad(subject, SOLID_ERROR.terms.errorResponse, MethodNotAllowedHttpError.uri),
+        quad(subject, SOLID_ERROR.terms.disallowedMethod, literal('GET')),
       ]);
     });
   });

--- a/test/unit/util/errors/RedirectHttpError.test.ts
+++ b/test/unit/util/errors/RedirectHttpError.test.ts
@@ -1,16 +1,23 @@
 import { FoundHttpError } from '../../../../src/util/errors/FoundHttpError';
 import type { HttpErrorOptions } from '../../../../src/util/errors/HttpError';
+import { generateHttpErrorUri } from '../../../../src/util/errors/HttpError';
 import { MovedPermanentlyHttpError } from '../../../../src/util/errors/MovedPermanentlyHttpError';
 import { RedirectHttpError } from '../../../../src/util/errors/RedirectHttpError';
+import type { RedirectHttpErrorClass } from '../../../../src/util/errors/RedirectHttpError';
 
+// Used to make sure the RedirectHttpError constructor also gets called in a test.
 class FixedRedirectHttpError extends RedirectHttpError {
+  public static readonly statusCode = 0;
+  public static readonly uri = generateHttpErrorUri(0);
+
   public constructor(location: string, message?: string, options?: HttpErrorOptions) {
-    super(0, location, '', message, options);
+    super(0, 'RedirectHttpError', location, message, options);
   }
 }
 
 describe('RedirectHttpError', (): void => {
-  const errors: [string, number, typeof FixedRedirectHttpError][] = [
+  const errors: [string, number, RedirectHttpErrorClass][] = [
+    [ 'RedirectHttpError', 0, FixedRedirectHttpError ],
     [ 'MovedPermanentlyHttpError', 301, MovedPermanentlyHttpError ],
     [ 'FoundHttpError', 302, FoundHttpError ],
   ];

--- a/test/util/FetchUtil.ts
+++ b/test/util/FetchUtil.ts
@@ -17,7 +17,7 @@ export async function getResource(url: string,
   expect(response.status).toBe(200);
   expect(response.headers.get('link')).toContain(`<${LDP.Resource}>; rel="type"`);
   expect(response.headers.get('link')).toContain(`<${url}.acl>; rel="acl"`);
-  expect(response.headers.get('accept-patch')).toBe('application/sparql-update, text/n3');
+  expect(response.headers.get('accept-patch')).toBe('text/n3, application/sparql-update');
   expect(response.headers.get('ms-author-via')).toBe('SPARQL');
 
   if (isContainer) {


### PR DESCRIPTION
#### 📁 Related issues

Closes #577, #572

#### ✍️ Description

Minor issues still remaining:
 * If an error gets thrown the identifier of the target resource does not reach the metadata writer so we can't make conclusions based on that (matters for `Allow: POST`). Would require a small change in some interfaces to also pass that along should there be a need for that in the future.
 * In case of errors we also don't know if the target resource exists with similar issues as above. We should be covering all cases from the spec correctly though.
 * In case of a SPARQL endpoint, the `Accept-Put` and `Accept-Post` headers will still say `*/*` even though we only accept RDF there. Could be fixed by setting the values of those in the config that defines the `DataAccessor` that is used, but this might complicate it a bit for people wanting to create configs for new data accessors, or that want to disable those headers for some reason so I left it on `*/*` for everything for now. But is fixable if really needed.

This PR also introduces a change to how error classes are generated to make sure they all have the same static functions which makes it easier to add new static functions or new error classes. We could do `export const NotFoundHttpError = generateHttpErrorClass(404, 'NotFoundHttpError');`, but that way Components.js is unable to deduce the constructor parameters, so each class still has to define its constructor to get around that.
