### PR TITLE
Prevent cleanup of expiring data from crashing the server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -435,4 +435,5 @@ export * from './util/RecordObject';
 export * from './util/ResourceUtil';
 export * from './util/StreamUtil';
 export * from './util/TermUtil';
+export * from './util/TimerUtil';
 export * from './util/Vocabularies';

--- a/src/storage/keyvalue/EncodingPathStorage.ts
+++ b/src/storage/keyvalue/EncodingPathStorage.ts
@@ -41,6 +41,10 @@ export class EncodingPathStorage<T> implements KeyValueStorage<string, T> {
 
   public async* entries(): AsyncIterableIterator<[string, T]> {
     for await (const [ path, value ] of this.source.entries()) {
+      // The only relevant entries for this storage are those that start with the base path
+      if (!path.startsWith(this.basePath)) {
+        continue;
+      }
       const key = this.pathToKey(path);
       yield [ key, value ];
     }

--- a/src/storage/keyvalue/WrappedExpiringStorage.ts
+++ b/src/storage/keyvalue/WrappedExpiringStorage.ts
@@ -1,6 +1,7 @@
 import type { Finalizable } from '../../init/final/Finalizable';
 import { getLoggerFor } from '../../logging/LogUtil';
 import { InternalServerError } from '../../util/errors/InternalServerError';
+import { setSafeInterval } from '../../util/TimerUtil';
 import type { ExpiringStorage } from './ExpiringStorage';
 import type { KeyValueStorage } from './KeyValueStorage';
 
@@ -23,7 +24,10 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
    */
   public constructor(source: KeyValueStorage<TKey, Expires<TValue>>, timeout = 60) {
     this.source = source;
-    this.timer = setInterval(this.removeExpiredEntries.bind(this), timeout * 60 * 1000);
+    this.timer = setSafeInterval(this.logger,
+      'Failed to remove expired entries',
+      this.removeExpiredEntries.bind(this),
+      timeout * 60 * 1000);
   }
 
   public async get(key: TKey): Promise<TValue | undefined> {

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -84,6 +84,19 @@ export function trimTrailingSlashes(path: string): string {
 }
 
 /**
+ * Makes sure the input path has exactly 1 slash at the beginning.
+ * Multiple slashes will get merged into one.
+ * If there is no slash it will be added.
+ *
+ * @param path - Path to check.
+ *
+ * @returns The potentially changed path.
+ */
+export function ensureLeadingSlash(path: string): string {
+  return path.replace(/^\/*/u, '/');
+}
+
+/**
  * Extracts the extension (without dot) from a path.
  * Custom function since `path.extname` does not work on all cases (e.g. ".acl")
  * @param path - Input path to parse.

--- a/src/util/TimerUtil.ts
+++ b/src/util/TimerUtil.ts
@@ -1,0 +1,23 @@
+import type { Logger } from '../logging/Logger';
+import { createErrorMessage } from './errors/ErrorUtil';
+
+/**
+ * Wraps the callback for {@link setInterval} so errors get caught and logged.
+ * Parameters are identical to the {@link setInterval} parameters starting from the 3rd argument.
+ * The logger and message will be used when the callback throws an error.
+ * Supports asynchronous callback functions.
+ */
+export function setSafeInterval(logger: Logger, message: string, callback: (...cbArgs: any[]) => void, ms?: number,
+  ...args: any[]): NodeJS.Timeout {
+  async function safeCallback(...cbArgs: any[]): Promise<void> {
+    try {
+      // We don't know if the callback is async or not so this way we make sure
+      // the full function execution is done in the try block.
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      return await callback(...cbArgs);
+    } catch (error: unknown) {
+      logger.error(`Error during interval callback: ${message} - ${createErrorMessage(error)}`);
+    }
+  }
+  return setInterval(safeCallback, ms, ...args);
+}

--- a/test/integration/ExpiringDataCleanup.test.ts
+++ b/test/integration/ExpiringDataCleanup.test.ts
@@ -1,0 +1,39 @@
+import fetch from 'cross-fetch';
+import type { App } from '../../src/init/App';
+import { getPort } from '../util/Util';
+import {
+  getDefaultVariables,
+  getTestConfigPath,
+  instantiateFromConfig,
+} from './Config';
+
+jest.useFakeTimers('legacy');
+
+const port = getPort('ExpiringDataCleanup');
+const baseUrl = `http://localhost:${port}/`;
+
+describe('A server with expiring storage', (): void => {
+  let app: App;
+
+  beforeAll(async(): Promise<void> => {
+    const instances = await instantiateFromConfig(
+      'urn:solid-server:test:Instances',
+      getTestConfigPath('server-memory.json'),
+      getDefaultVariables(port, baseUrl),
+    ) as Record<string, any>;
+    ({ app } = instances);
+    await app.start();
+  });
+
+  afterAll(async(): Promise<void> => {
+    await app.stop();
+  });
+
+  it('does not crash after the interval timeout.', async(): Promise<void> => {
+    // Default timeout is 1 hour
+    // This test would fail if something goes wrong in an interval timer
+    jest.advanceTimersByTime(2 * 60 * 60 * 1000);
+    const res = await fetch(baseUrl, { method: 'HEAD' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/test/integration/LockingResourceStore.test.ts
+++ b/test/integration/LockingResourceStore.test.ts
@@ -16,6 +16,8 @@ import { SingleThreadedResourceLocker } from '../../src/util/locking/SingleThrea
 import { WrappedExpiringReadWriteLocker } from '../../src/util/locking/WrappedExpiringReadWriteLocker';
 import { guardedStreamFrom } from '../../src/util/StreamUtil';
 import { PIM, RDF } from '../../src/util/Vocabularies';
+import { flushPromises } from '../util/Util';
+
 jest.useFakeTimers('legacy');
 
 describe('A LockingResourceStore', (): void => {
@@ -67,7 +69,7 @@ describe('A LockingResourceStore', (): void => {
 
     // Wait 1000ms and read
     jest.advanceTimersByTime(1000);
-    await new Promise(setImmediate);
+    await flushPromises();
     expect(representation.data.destroyed).toBe(true);
 
     // Verify a timeout error was thrown
@@ -95,7 +97,7 @@ describe('A LockingResourceStore', (): void => {
 
     // Wait 1000ms and watch the stream be destroyed
     jest.advanceTimersByTime(1000);
-    await new Promise(setImmediate);
+    await flushPromises();
     expect(representation.data.destroyed).toBe(true);
 
     // Verify a timeout error was thrown

--- a/test/integration/RedisResourceLockerIntegration.test.ts
+++ b/test/integration/RedisResourceLockerIntegration.test.ts
@@ -1,7 +1,6 @@
 import fetch from 'cross-fetch';
 import type { App, RedisResourceLocker } from '../../src';
-
-import { describeIf, getPort } from '../util/Util';
+import { describeIf, flushPromises, getPort } from '../util/Util';
 import { getDefaultVariables, getTestConfigPath, instantiateFromConfig } from './Config';
 
 /**
@@ -139,7 +138,7 @@ describeIf('docker', 'A server with a RedisResourceLocker as ResourceLocker', ()
       const lock2 = locker.acquire(identifier);
       const lock3 = locker.acquire(identifier);
 
-      await new Promise((resolve): any => setImmediate(resolve));
+      await flushPromises();
 
       const l2 = lock2.then(async(): Promise<void> => {
         res += 'l2';

--- a/test/unit/init/AppRunner.test.ts
+++ b/test/unit/init/AppRunner.test.ts
@@ -4,6 +4,7 @@ import { AppRunner } from '../../../src/init/AppRunner';
 import type { CliExtractor } from '../../../src/init/cli/CliExtractor';
 import type { SettingsResolver } from '../../../src/init/variables/SettingsResolver';
 import { joinFilePath } from '../../../src/util/PathUtil';
+import { flushPromises } from '../../util/Util';
 
 const app: jest.Mocked<App> = {
   start: jest.fn(),
@@ -315,9 +316,7 @@ describe('AppRunner', (): void => {
       new AppRunner().runCliSync({ argv: [ 'node', 'script' ]});
 
       // Wait until app.start has been called, because we can't await AppRunner.run.
-      await new Promise((resolve): void => {
-        setImmediate(resolve);
-      });
+      await flushPromises();
 
       expect(ComponentsManager.build).toHaveBeenCalledTimes(1);
       expect(ComponentsManager.build).toHaveBeenCalledWith({
@@ -348,9 +347,7 @@ describe('AppRunner', (): void => {
       new AppRunner().runCliSync({ argv: [ 'node', 'script' ]});
 
       // Wait until app.start has been called, because we can't await AppRunner.runCli.
-      await new Promise((resolve): void => {
-        setImmediate(resolve);
-      });
+      await flushPromises();
 
       expect(write).toHaveBeenCalledTimes(1);
       expect(write).toHaveBeenLastCalledWith(expect.stringMatching(/Cause: Fatal/mu));

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -7,6 +7,7 @@ import { LockingResourceStore } from '../../../src/storage/LockingResourceStore'
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
 import type { ExpiringReadWriteLocker } from '../../../src/util/locking/ExpiringReadWriteLocker';
 import { guardedStreamFrom } from '../../../src/util/StreamUtil';
+import { flushPromises } from '../../util/Util';
 
 function emptyFn(): void {
   // Empty
@@ -170,7 +171,7 @@ describe('A LockingResourceStore', (): void => {
     registerEventOrder(representation.data, 'end');
 
     // Provide opportunity for async events
-    await new Promise(setImmediate);
+    await flushPromises();
 
     // Verify the lock was acquired and released at the right time
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);
@@ -187,7 +188,7 @@ describe('A LockingResourceStore', (): void => {
     registerEventOrder(representation.data, 'end');
 
     // Provide opportunity for async events
-    await new Promise(setImmediate);
+    await flushPromises();
 
     // Verify the lock was acquired and released at the right time
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);
@@ -205,7 +206,7 @@ describe('A LockingResourceStore', (): void => {
     registerEventOrder(representation.data, 'close');
 
     // Provide opportunity for async events
-    await new Promise(setImmediate);
+    await flushPromises();
 
     // Verify the lock was acquired and released at the right time
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);
@@ -222,7 +223,7 @@ describe('A LockingResourceStore', (): void => {
     registerEventOrder(representation.data, 'close');
 
     // Provide opportunity for async events
-    await new Promise(setImmediate);
+    await flushPromises();
 
     // Verify the lock was acquired and released at the right time
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);
@@ -241,7 +242,7 @@ describe('A LockingResourceStore', (): void => {
     });
 
     // Provide opportunity for async events
-    await new Promise(setImmediate);
+    await flushPromises();
 
     // Verify the lock was acquired and released at the right time
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);
@@ -258,7 +259,7 @@ describe('A LockingResourceStore', (): void => {
     timeoutTrigger.emit('timeout');
 
     // Provide opportunity for async events
-    await new Promise(setImmediate);
+    await flushPromises();
 
     // Verify the lock was acquired and released at the right time
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);

--- a/test/unit/storage/keyvalue/EncodingPathStorage.test.ts
+++ b/test/unit/storage/keyvalue/EncodingPathStorage.test.ts
@@ -30,4 +30,22 @@ describe('An EncodingPathStorage', (): void => {
     await expect(storage.delete(key)).resolves.toBe(true);
     expect([ ...map.keys() ]).toHaveLength(0);
   });
+
+  it('only returns entries from the source storage matching the relative path.', async(): Promise<void> => {
+    // Base 64 encoding of 'key'
+    const encodedKey = 'a2V5';
+    const generatedPath = `${relativePath}${encodedKey}`;
+    const otherPath = `/otherContainer/${encodedKey}`;
+    const data = 'data';
+
+    map.set(generatedPath, data);
+    map.set(otherPath, data);
+
+    const results = [];
+    for await (const entry of storage.entries()) {
+      results.push(entry);
+    }
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual([ 'key', data ]);
+  });
 });

--- a/test/unit/util/PathUtil.test.ts
+++ b/test/unit/util/PathUtil.test.ts
@@ -7,6 +7,7 @@ import {
   createSubdomainRegexp,
   decodeUriPathComponents,
   encodeUriPathComponents,
+  ensureLeadingSlash,
   ensureTrailingSlash,
   extractScheme,
   getExtension,
@@ -74,6 +75,15 @@ describe('PathUtil', (): void => {
       expect(trimTrailingSlashes('http://test.com/')).toBe('http://test.com');
       expect(trimTrailingSlashes('http://test.com//')).toBe('http://test.com');
       expect(trimTrailingSlashes('http://test.com///')).toBe('http://test.com');
+    });
+  });
+
+  describe('#ensureLeadingSlash', (): void => {
+    it('makes sure there is always exactly 1 slash.', (): void => {
+      expect(ensureLeadingSlash('test')).toBe('/test');
+      expect(ensureLeadingSlash('/test')).toBe('/test');
+      expect(ensureLeadingSlash('//test')).toBe('/test');
+      expect(ensureLeadingSlash('///test')).toBe('/test');
     });
   });
 

--- a/test/unit/util/StreamUtil.test.ts
+++ b/test/unit/util/StreamUtil.test.ts
@@ -8,6 +8,7 @@ import {
   guardedStreamFrom, pipeSafely, transformSafely,
   readableToString, readableToQuads, readJsonStream, getSingleItem,
 } from '../../../src/util/StreamUtil';
+import { flushPromises } from '../../util/Util';
 
 jest.mock('../../../src/logging/LogUtil', (): any => {
   const logger: Logger = { warn: jest.fn(), log: jest.fn() } as any;
@@ -132,7 +133,7 @@ describe('StreamUtil', (): void => {
 
       piped.destroy(new Error('this causes an unpipe!'));
       // Allow events to propagate
-      await new Promise(setImmediate);
+      await flushPromises();
       expect(input.destroyed).toBe(true);
     });
 
@@ -149,7 +150,7 @@ describe('StreamUtil', (): void => {
 
       piped.destroy(new Error('error!'));
       // Allow events to propagate
-      await new Promise(setImmediate);
+      await flushPromises();
       expect(input.destroyed).toBe(false);
     });
 

--- a/test/unit/util/TimerUtil.test.ts
+++ b/test/unit/util/TimerUtil.test.ts
@@ -1,0 +1,59 @@
+import type { Logger } from '../../../src/logging/Logger';
+import { setSafeInterval } from '../../../src/util/TimerUtil';
+import { flushPromises } from '../../util/Util';
+
+jest.useFakeTimers();
+
+describe('TimerUtil', (): void => {
+  describe('#setSafeInterval', (): void => {
+    let logger: jest.Mocked<Logger>;
+    let callback: jest.Mock<(...cbArgs: any[]) => void>;
+
+    beforeEach(async(): Promise<void> => {
+      logger = { error: jest.fn() } as any;
+      callback = jest.fn();
+    });
+
+    it('creates a working interval.', async(): Promise<void> => {
+      const timer = setSafeInterval(logger, 'message', callback, 1000, 'argument');
+
+      jest.advanceTimersByTime(1000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenLastCalledWith('argument');
+      expect(logger.error).toHaveBeenCalledTimes(0);
+
+      clearInterval(timer);
+    });
+
+    it('logs an error if something went wrong in the callback.', async(): Promise<void> => {
+      const timer = setSafeInterval(logger, 'message', callback, 1000, 'argument');
+      callback.mockImplementationOnce((): never => {
+        throw new Error('callback error');
+      });
+
+      jest.advanceTimersByTime(1000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenLastCalledWith('argument');
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenLastCalledWith('Error during interval callback: message - callback error');
+
+      clearInterval(timer);
+    });
+
+    it('correctly handles errors in async callbacks.', async(): Promise<void> => {
+      const promCallback = jest.fn().mockRejectedValue(new Error('callback error'));
+      const timer = setSafeInterval(logger, 'message', promCallback, 1000, 'argument');
+
+      jest.advanceTimersByTime(1000);
+      await flushPromises();
+
+      expect(promCallback).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenLastCalledWith('Error during interval callback: message - callback error');
+
+      clearInterval(timer);
+    });
+  });
+});

--- a/test/unit/util/locking/GreedyReadWriteLocker.test.ts
+++ b/test/unit/util/locking/GreedyReadWriteLocker.test.ts
@@ -5,6 +5,7 @@ import { ForbiddenHttpError } from '../../../../src/util/errors/ForbiddenHttpErr
 import { InternalServerError } from '../../../../src/util/errors/InternalServerError';
 import { GreedyReadWriteLocker } from '../../../../src/util/locking/GreedyReadWriteLocker';
 import type { ResourceLocker } from '../../../../src/util/locking/ResourceLocker';
+import { flushPromises } from '../../../util/Util';
 
 // A simple ResourceLocker that keeps a queue of lock requests
 class MemoryLocker implements ResourceLocker {
@@ -86,7 +87,7 @@ describe('A GreedyReadWriteLocker', (): void => {
     }));
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     emitter.emit('release2');
     await expect(promises[2]).resolves.toBe(2);
@@ -112,12 +113,12 @@ describe('A GreedyReadWriteLocker', (): void => {
     }));
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     emitter.emit('release2');
 
     // Allow time to finish write 2
-    await new Promise(setImmediate);
+    await flushPromises();
 
     emitter.emit('release0');
     emitter.emit('release1');
@@ -140,7 +141,7 @@ describe('A GreedyReadWriteLocker', (): void => {
     }));
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     emitter.emit('release1');
     await expect(promises[1]).resolves.toBe(1);
@@ -178,7 +179,7 @@ describe('A GreedyReadWriteLocker', (): void => {
     });
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     const promAll = Promise.all([ delayedLockWrite, lockRead ]);
 
@@ -213,7 +214,7 @@ describe('A GreedyReadWriteLocker', (): void => {
     });
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     const promAll = Promise.all([ delayedLockWrite, lockRead ]);
 
@@ -260,14 +261,14 @@ describe('A GreedyReadWriteLocker', (): void => {
     });
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     const promAll = Promise.all([ delayedLockWrite, lockRead, delayedLockRead2 ]);
 
     emitter.emit('releaseRead1');
 
     // Allow time to finish read 1
-    await new Promise(setImmediate);
+    await flushPromises();
 
     emitter.emit('releaseRead2');
     await promAll;
@@ -302,7 +303,7 @@ describe('A GreedyReadWriteLocker', (): void => {
     });
 
     // Allow time to attach listeners
-    await new Promise(setImmediate);
+    await flushPromises();
 
     const promAll = Promise.all([ delayedLockRead, lockWrite ]);
 

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -7,6 +7,7 @@ const portNames = [
   'Conditions',
   'ContentNegotiation',
   'DynamicPods',
+  'ExpiringDataCleanup',
   'GlobalQuota',
   'Identity',
   'LpdHandlerWithAuth',

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -45,6 +45,17 @@ export function describeIf(envFlag: string, name: string, fn: () => void): void 
 }
 
 /**
+ * This is needed when you want to wait for all promises to resolve.
+ * Also works when using jest.useFakeTimers().
+ * For more details see the links below
+ *  - https://github.com/facebook/jest/issues/2157
+ *  - https://stackoverflow.com/questions/52177631/jest-timer-and-promise-dont-work-well-settimeout-and-async-function
+ */
+export async function flushPromises(): Promise<void> {
+  return new Promise(jest.requireActual('timers').setImmediate);
+}
+
+/**
  * Mocks (some) functions of the fs system library.
  * It is important that you call `jest.mock('fs');` in your test file before calling this!!!
  *


### PR DESCRIPTION
#### 📁 Related issues

Closes #1247

#### ✍️ Description

Since all storages use the same source storage in the end this is a bit inefficient now since it will iterate multiple times through all its entries, but this happens only once per hour so should be fine. We could always optimize in the future by adding a `path` parameter to the `entries` function if needed.

Also comes with a new utility test function to resolve pending promises.
