### PR TITLE
Refactor: use fs-extra instead of fs to simplify file access

### DIFF
--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -105,7 +105,6 @@ export class FileDataAccessor implements DataAccessor {
   public async writeContainer(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
     const link = await this.resourceMapper.mapUrlToFilePath(identifier, false);
     try {
-      // TODO: this seems to work when running the server but tests fail.
       await ensureDir(link.filePath);
     } catch (error: unknown) {
       // Don't throw if directory already exists

--- a/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
+++ b/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
@@ -8,7 +8,7 @@ import type {
 import { ensureTrailingSlash, trimTrailingSlashes } from '../../../../src/util/PathUtil';
 import { readableToString } from '../../../../src/util/StreamUtil';
 import { HandlebarsTemplateEngine } from '../../../../src/util/templates/HandlebarsTemplateEngine';
-import { mockFs } from '../../../util/Util';
+import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 
@@ -52,7 +52,7 @@ describe('A TemplatedResourcesGenerator', (): void => {
   const webId = 'http://alice/#profile';
 
   beforeEach(async(): Promise<void> => {
-    cache = mockFs(rootFilePath);
+    cache = mockFileSystem(rootFilePath);
   });
 
   it('fills in a template with the given options.', async(): Promise<void> => {

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -9,7 +9,7 @@ import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import type { IdentifierStrategy } from '../../../src/util/identifiers/IdentifierStrategy';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { PIM, RDF } from '../../../src/util/Vocabularies';
-import { mockFs } from '../../util/Util';
+import { mockFileSystem } from '../../util/Util';
 
 jest.mock('fs');
 
@@ -24,7 +24,7 @@ describe('PodQuotaStrategy', (): void => {
 
   beforeEach((): void => {
     jest.restoreAllMocks();
-    mockFs(rootFilePath, new Date());
+    mockFileSystem(rootFilePath, new Date());
     mockSize = { amount: 2000, unit: UNIT_BYTES };
     identifierStrategy = new SingleRootIdentifierStrategy(base);
     mockReporter = {

--- a/test/unit/quota/QuotaStrategy.test.ts
+++ b/test/unit/quota/QuotaStrategy.test.ts
@@ -4,7 +4,7 @@ import { UNIT_BYTES } from '../../../src/storage/size-reporter/Size';
 import type { Size } from '../../../src/storage/size-reporter/Size';
 import type { SizeReporter } from '../../../src/storage/size-reporter/SizeReporter';
 import { guardedStreamFrom, pipeSafely } from '../../../src/util/StreamUtil';
-import { mockFs } from '../../util/Util';
+import { mockFileSystem } from '../../util/Util';
 
 jest.mock('fs');
 
@@ -26,7 +26,7 @@ describe('A QuotaStrategy', (): void => {
 
   beforeEach((): void => {
     jest.restoreAllMocks();
-    mockFs(rootFilePath, new Date());
+    mockFileSystem(rootFilePath, new Date());
     mockSize = { amount: 2000, unit: UNIT_BYTES };
     mockReporter = {
       getSize: jest.fn().mockResolvedValue({ unit: mockSize.unit, amount: 50 }),

--- a/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
@@ -9,7 +9,6 @@ import { guardedStreamFrom } from '../../../../src/util/StreamUtil';
 import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../../util/Util';
 
-jest.mock('fs');
 jest.mock('fs-extra');
 
 describe('AtomicFileDataAccessor', (): void => {
@@ -60,27 +59,27 @@ describe('AtomicFileDataAccessor', (): void => {
         data.emit('error', new Error('error'));
         return null;
       });
-      jest.requireMock('fs').promises.stat = jest.fn((): any => ({
+      jest.requireMock('fs-extra').stat = jest.fn((): any => ({
         isFile: (): boolean => false,
       }));
       await expect(accessor.writeDocument({ path: `${base}res.ttl` }, data, metadata)).rejects.toThrow('error');
     });
 
     it('should throw when renaming / moving the file goes wrong.', async(): Promise<void> => {
-      jest.requireMock('fs').promises.rename = jest.fn((): any => {
+      jest.requireMock('fs-extra').rename = jest.fn((): any => {
         throw new Error('error');
       });
-      jest.requireMock('fs').promises.stat = jest.fn((): any => ({
+      jest.requireMock('fs-extra').stat = jest.fn((): any => ({
         isFile: (): boolean => true,
       }));
       await expect(accessor.writeDocument({ path: `${base}res.ttl` }, data, metadata)).rejects.toThrow('error');
     });
 
     it('should (on error) not unlink the temp file if it does not exist.', async(): Promise<void> => {
-      jest.requireMock('fs').promises.rename = jest.fn((): any => {
+      jest.requireMock('fs-extra').rename = jest.fn((): any => {
         throw new Error('error');
       });
-      jest.requireMock('fs').promises.stat = jest.fn((): any => ({
+      jest.requireMock('fs-extra').stat = jest.fn((): any => ({
         isFile: (): boolean => false,
       }));
       await expect(accessor.writeDocument({ path: `${base}res.ttl` }, data, metadata)).rejects.toThrow('error');
@@ -88,10 +87,10 @@ describe('AtomicFileDataAccessor', (): void => {
 
     it('should throw when renaming / moving the file goes wrong and the temp file does not exist.',
       async(): Promise<void> => {
-        jest.requireMock('fs').promises.rename = jest.fn((): any => {
+        jest.requireMock('fs-extra').rename = jest.fn((): any => {
           throw new Error('error');
         });
-        jest.requireMock('fs').promises.stat = jest.fn();
+        jest.requireMock('fs-extra').stat = jest.fn();
         await expect(accessor.writeDocument({ path: `${base}res.ttl` }, data, metadata)).rejects.toThrow('error');
       });
   });

--- a/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
@@ -9,6 +9,7 @@ import { guardedStreamFrom } from '../../../../src/util/StreamUtil';
 import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../../util/Util';
 
+jest.mock('fs');
 jest.mock('fs-extra');
 
 describe('AtomicFileDataAccessor', (): void => {

--- a/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
@@ -7,7 +7,7 @@ import { APPLICATION_OCTET_STREAM } from '../../../../src/util/ContentTypes';
 import type { Guarded } from '../../../../src/util/GuardedStream';
 import { guardedStreamFrom } from '../../../../src/util/StreamUtil';
 import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
-import { mockFs } from '../../../util/Util';
+import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 
@@ -20,7 +20,7 @@ describe('AtomicFileDataAccessor', (): void => {
   let data: Guarded<Readable>;
 
   beforeEach(async(): Promise<void> => {
-    cache = mockFs(rootFilePath, new Date());
+    cache = mockFileSystem(rootFilePath, new Date());
     accessor = new AtomicFileDataAccessor(
       new ExtensionBasedMapper(base, rootFilePath),
       rootFilePath,

--- a/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/AtomicFileDataAccessor.test.ts
@@ -10,6 +10,7 @@ import { CONTENT_TYPE } from '../../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
+jest.mock('fs-extra');
 
 describe('AtomicFileDataAccessor', (): void => {
   const rootFilePath = 'uploads';

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -249,7 +249,7 @@ describe('A FileDataAccessor', (): void => {
 
     it('errors if there is a problem deleting the old metadata file.', async(): Promise<void> => {
       cache.data = { resource: 'data', 'resource.meta': 'metadata!' };
-      jest.requireMock('fs-extra').unlink = (): any => {
+      jest.requireMock('fs-extra').remove = (): any => {
         throw new Error('error');
       };
       await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata))
@@ -303,7 +303,7 @@ describe('A FileDataAccessor', (): void => {
 
     it('throws an error if there is an issue deleting the original file.', async(): Promise<void> => {
       cache.data = { 'resource$.ttl': '<this> <is> <data>.' };
-      jest.requireMock('fs-extra').unlink = (): any => {
+      jest.requireMock('fs-extra').remove = (): any => {
         const error = new Error('error') as SystemError;
         error.code = 'EISDIR';
         error.syscall = 'unlink';
@@ -396,6 +396,9 @@ describe('A FileDataAccessor', (): void => {
 
     it('throws error if there is a problem with deleting existing metadata.', async(): Promise<void> => {
       cache.data = { resource: 'apple', 'resource.meta': {}};
+      jest.requireMock('fs-extra').remove = (): any => {
+        throw new Error('error');
+      };
       await expect(accessor.deleteResource({ path: `${base}resource` })).rejects.toThrow();
     });
 

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -84,7 +84,7 @@ describe('A FileDataAccessor', (): void => {
     });
 
     it('throws an error if something else went wrong.', async(): Promise<void> => {
-      jest.requireMock('fs').promises.lstat = (): any => {
+      jest.requireMock('fs-extra').lstat = (): any => {
         throw new Error('error');
       };
       await expect(accessor.getMetadata({ path: base })).rejects.toThrow('error');
@@ -249,7 +249,7 @@ describe('A FileDataAccessor', (): void => {
 
     it('errors if there is a problem deleting the old metadata file.', async(): Promise<void> => {
       cache.data = { resource: 'data', 'resource.meta': 'metadata!' };
-      jest.requireMock('fs').promises.unlink = (): any => {
+      jest.requireMock('fs-extra').unlink = (): any => {
         throw new Error('error');
       };
       await expect(accessor.writeDocument({ path: `${base}resource` }, data, metadata))
@@ -303,7 +303,7 @@ describe('A FileDataAccessor', (): void => {
 
     it('throws an error if there is an issue deleting the original file.', async(): Promise<void> => {
       cache.data = { 'resource$.ttl': '<this> <is> <data>.' };
-      jest.requireMock('fs').promises.unlink = (): any => {
+      jest.requireMock('fs-extra').unlink = (): any => {
         const error = new Error('error') as SystemError;
         error.code = 'EISDIR';
         error.syscall = 'unlink';

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -15,7 +15,7 @@ import { isContainerPath } from '../../../../src/util/PathUtil';
 import { guardedStreamFrom, readableToString } from '../../../../src/util/StreamUtil';
 import { toLiteral } from '../../../../src/util/TermUtil';
 import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../../../src/util/Vocabularies';
-import { mockFs } from '../../../util/Util';
+import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 jest.mock('fs-extra');
@@ -33,7 +33,7 @@ describe('A FileDataAccessor', (): void => {
   let data: Guarded<Readable>;
 
   beforeEach(async(): Promise<void> => {
-    cache = mockFs(rootFilePath, now);
+    cache = mockFileSystem(rootFilePath, now);
     accessor = new FileDataAccessor(new ExtensionBasedMapper(base, rootFilePath));
 
     metadata = new RepresentationMetadata(APPLICATION_OCTET_STREAM);

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -18,6 +18,7 @@ import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../../../
 import { mockFs } from '../../../util/Util';
 
 jest.mock('fs');
+jest.mock('fs-extra');
 
 const rootFilePath = 'uploads';
 const now = new Date();
@@ -332,7 +333,7 @@ describe('A FileDataAccessor', (): void => {
     });
 
     it('throws other errors when making a directory.', async(): Promise<void> => {
-      jest.requireMock('fs').promises.mkdir = (): any => {
+      jest.requireMock('fs-extra').ensureDir = (): any => {
         throw new Error('error');
       };
       await expect(accessor.writeContainer({ path: base }, metadata)).rejects.toThrow('error');

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -67,6 +67,13 @@ describe('A FileDataAccessor', (): void => {
       const stream = await accessor.getData({ path: `${base}resource` });
       await expect(readableToString(stream)).resolves.toBe('data');
     });
+
+    it('throws an error if something else went wrong.', async(): Promise<void> => {
+      jest.requireMock('fs-extra').stat = (): any => {
+        throw new Error('error');
+      };
+      await expect(accessor.getData({ path: `${base}resource` })).rejects.toThrow('error');
+    });
   });
 
   describe('getting metadata', (): void => {

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -17,6 +17,7 @@ import { toLiteral } from '../../../../src/util/TermUtil';
 import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../../util/Util';
 
+jest.mock('fs');
 jest.mock('fs-extra');
 
 const rootFilePath = 'uploads';

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -17,7 +17,6 @@ import { toLiteral } from '../../../../src/util/TermUtil';
 import { CONTENT_TYPE, DC, LDP, POSIX, RDF, SOLID_META, XSD } from '../../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../../util/Util';
 
-jest.mock('fs');
 jest.mock('fs-extra');
 
 const rootFilePath = 'uploads';

--- a/test/unit/storage/keyvalue/JsonFileStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonFileStorage.test.ts
@@ -1,7 +1,7 @@
 import type { ResourceIdentifier } from '../../../../src/http/representation/ResourceIdentifier';
 import { JsonFileStorage } from '../../../../src/storage/keyvalue/JsonFileStorage';
 import type { ReadWriteLocker } from '../../../../src/util/locking/ReadWriteLocker';
-import { mockFs } from '../../../util/Util';
+import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 
@@ -13,7 +13,7 @@ describe('A JsonFileStorage', (): void => {
   let storage: JsonFileStorage;
 
   beforeEach(async(): Promise<void> => {
-    cache = mockFs(rootFilePath);
+    cache = mockFileSystem(rootFilePath);
     locker = {
       withReadLock:
         jest.fn(async(identifier: ResourceIdentifier, whileLocked: () => any): Promise<any> => await whileLocked()),

--- a/test/unit/storage/keyvalue/JsonFileStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonFileStorage.test.ts
@@ -4,6 +4,7 @@ import type { ReadWriteLocker } from '../../../../src/util/locking/ReadWriteLock
 import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
+jest.mock('fs-extra');
 
 describe('A JsonFileStorage', (): void => {
   const rootFilePath = 'files/';

--- a/test/unit/storage/size-reporter/FileSizeReporter.test.ts
+++ b/test/unit/storage/size-reporter/FileSizeReporter.test.ts
@@ -5,7 +5,7 @@ import type { FileIdentifierMapper, ResourceLink } from '../../../../src/storage
 import { FileSizeReporter } from '../../../../src/storage/size-reporter/FileSizeReporter';
 import { UNIT_BYTES } from '../../../../src/storage/size-reporter/Size';
 import { joinFilePath } from '../../../../src/util/PathUtil';
-import { mockFs } from '../../../util/Util';
+import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 
@@ -28,7 +28,7 @@ describe('A FileSizeReporter', (): void => {
   );
 
   beforeEach(async(): Promise<void> => {
-    mockFs(fileRoot);
+    mockFileSystem(fileRoot);
   });
 
   it('should work without the ignoreFolders constructor parameter.', async(): Promise<void> => {

--- a/test/unit/util/templates/TemplateEngine.test.ts
+++ b/test/unit/util/templates/TemplateEngine.test.ts
@@ -1,6 +1,6 @@
 import { resolveAssetPath } from '../../../../src/util/PathUtil';
 import { getTemplateFilePath, readTemplate } from '../../../../src/util/templates/TemplateEngine';
-import { mockFs } from '../../../util/Util';
+import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 
@@ -10,7 +10,7 @@ describe('TemplateEngine', (): void => {
     const templatePath = 'other';
 
     beforeEach(async(): Promise<void> => {
-      const { data } = mockFs(resolveAssetPath(''));
+      const { data } = mockFileSystem(resolveAssetPath(''));
       Object.assign(data, {
         'template.xyz': '{{template}}',
         other: {
@@ -45,7 +45,7 @@ describe('TemplateEngine', (): void => {
     const templatePath = 'other';
 
     beforeEach(async(): Promise<void> => {
-      const { data } = mockFs(resolveAssetPath(''));
+      const { data } = mockFileSystem(resolveAssetPath(''));
       Object.assign(data, {
         'template.xyz': '{{template}}',
         other: {

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -221,6 +221,18 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
   };
 
   const mockFsExtra = {
+    async readJson(path: string): Promise<NodeJS.Dict<unknown>> {
+      const { folder, name } = getFolder(path);
+      if (!folder[name]) {
+        throwSystemError('ENOENT');
+      }
+      return JSON.parse(folder[name]);
+    },
+    async writeJson(path: string, json: NodeJS.Dict<unknown>): Promise<void> {
+      const { folder, name } = getFolder(path);
+      const data = JSON.stringify(json, null, 2);
+      folder[name] = data;
+    },
     async ensureDir(path: string): Promise<void> {
       const { folder, name } = getFolder(path);
       folder[name] = {};

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -329,6 +329,11 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
       const { folder, name } = getFolder(path);
       folder[name] = {};
     },
+    async remove(path: string): Promise<void> {
+      const { folder, name } = getFolder(path);
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete folder[name];
+    },
   };
 
   const fs = jest.requireMock('fs');

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -60,7 +60,7 @@ export function describeIf(envFlag: string, name: string, fn: () => void): void 
  * @param rootFilepath - The name of the root folder in which fs will start.
  * @param time - The date object to use for time functions (currently only mtime from lstats)
  */
-export function mockFs(rootFilepath?: string, time?: Date): { data: any } {
+export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any } {
   const cache: { data: any } = { data: {}};
 
   rootFilepath = rootFilepath ?? 'folder';
@@ -97,7 +97,7 @@ export function mockFs(rootFilepath?: string, time?: Date): { data: any } {
     return { folder, name };
   }
 
-  const mock = {
+  const mockFs = {
     createReadStream(path: string): any {
       const { folder, name } = getFolder(path);
       return Readable.from([ folder[name] ]);
@@ -218,6 +218,9 @@ export function mockFs(rootFilepath?: string, time?: Date): { data: any } {
         delete folder[name];
       },
     },
+  };
+
+  const mockFsExtra = {
     async stat(path: string): Promise<Stats> {
       return this.lstat(await this.realpath(path));
     },
@@ -329,10 +332,10 @@ export function mockFs(rootFilepath?: string, time?: Date): { data: any } {
   };
 
   const fs = jest.requireMock('fs');
-  Object.assign(fs, mock);
+  Object.assign(fs, mockFs);
 
   const fsExtra = jest.requireMock('fs-extra');
-  Object.assign(fsExtra, mock);
+  Object.assign(fsExtra, mockFsExtra);
 
   return cache;
 }

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -270,17 +270,8 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
       return await mockFs.promises.readdir(path);
     },
     async* opendir(path: string): AsyncIterableIterator<Dirent> {
-      const { folder, name } = getFolder(path);
-      if (!folder[name]) {
-        throwSystemError('ENOENT');
-      }
-      for (const [ child, entry ] of Object.entries(folder[name])) {
-        yield {
-          name: child,
-          isFile: (): boolean => typeof entry === 'string',
-          isDirectory: (): boolean => typeof entry === 'object',
-          isSymbolicLink: (): boolean => typeof entry === 'symbol',
-        } as Dirent;
+      for await (const entry of mockFs.promises.opendir(path)) {
+        yield entry;
       }
     },
     async mkdir(path: string): Promise<void> {

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -339,7 +339,7 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
       if (!folder[name]) {
         throwSystemError('ENOENT');
       }
-      if (!(await this.lstat(path)).isFile()) {
+      if (!(await mockFsExtra.lstat(path)).isFile()) {
         throwSystemError('EISDIR');
       }
 

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -221,6 +221,15 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
   };
 
   const mockFsExtra = {
+    async ensureDir(path: string): Promise<void> {
+      const { folder, name } = getFolder(path);
+      folder[name] = {};
+    },
+    async remove(path: string): Promise<void> {
+      const { folder, name } = getFolder(path);
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete folder[name];
+    },
     createReadStream(path: string): any {
       const { folder, name } = getFolder(path);
       return Readable.from([ folder[name] ]);
@@ -337,15 +346,6 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
       const { folder: folderDest, name: nameDest } = getFolder(destination);
       folderDest[nameDest] = folder[name];
 
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete folder[name];
-    },
-    async ensureDir(path: string): Promise<void> {
-      const { folder, name } = getFolder(path);
-      folder[name] = {};
-    },
-    async remove(path: string): Promise<void> {
-      const { folder, name } = getFolder(path);
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete folder[name];
     },


### PR DESCRIPTION
#### 📁 Related issues

#1175 

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose
-->

#### ✍️ Description
This PR is a WIP
As suggested in the relevant issue, this PR aims to use `fs-extra` instead of `fs` in order to simplify the code for file access.
`fs-extra`. By itself it is already a drop-in replacement for `fs` as all functions of it are attached.

Classes that could be targeted:
- src/storage/accessors/FileDataAccessor.ts
- src/storage/mapping/BaseFileIdentifierMapper.ts
- src/storage/mapping/ExtensionBasedMapper.ts

Is it desireable to change all imports of `fs` to `fs-extra` as it is a full replacement?
