### PR TITLE
chore: Drop support for Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,12 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - '12.17'
-          - '12.x'
           - '14.2'
           - '14.x'
           - '16.0'
           - '16.x'
-          - '17.x'
+          - '18.0'
+          - '18.x'
     timeout-minutes: 15
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
@@ -67,9 +66,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '12.x'
           - '14.x'
           - '16.x'
+          - '18.x'
     env:
       TEST_DOCKER: true
     services:
@@ -101,9 +100,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '12.x'
           - '14.x'
           - '16.x'
+          - '18.x'
     timeout-minutes: 15
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and get started with Solid immediately.
 
 ## ⚡ Running the server
 To run the server, you will need [Node.js](https://nodejs.org/en/).
-We support versions 12.7 and up.
+We support versions 14.2 and up.
 <br>
 If you do not use Node.js,
 you can run a [Docker](https://www.docker.com/) version instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "typescript": "^4.5.5"
       },
       "engines": {
-        "node": ">=12.17"
+        "node": ">=14.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=12.17"
+    "node": ">=14.2"
   },
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "dist/components/components.jsonld",

--- a/test/integration/Quota.test.ts
+++ b/test/integration/Quota.test.ts
@@ -52,7 +52,7 @@ async function clearInitialFiles(rootFilePath: string, pods: string[]): Promise<
       if (file !== '.meta') {
         const path = joinFilePath(rootFilePath, pod, file);
         if ((await fsPromises.stat(path)).isDirectory()) {
-          await fsPromises.rmdir(path, { recursive: true });
+          await fsPromises.rm(path, { recursive: true });
         } else {
           await fsPromises.unlink(path);
         }

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -164,7 +164,7 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
         const entry = folder[name];
         return typeof entry === 'symbol' ? entry.description ?? 'invalid' : path;
       },
-      async rmdir(path: string): Promise<void> {
+      async rm(path: string): Promise<void> {
         const { folder, name } = getFolder(path);
         if (!folder[name]) {
           throwSystemError('ENOENT');
@@ -278,8 +278,8 @@ export function mockFileSystem(rootFilepath?: string, time?: Date): { data: any 
     async symlink(target: string, path: string): Promise<void> {
       await mockFs.promises.symlink(target, path);
     },
-    async rmdir(path: string): Promise<void> {
-      await mockFs.promises.rmdir(path);
+    async rm(path: string): Promise<void> {
+      await mockFs.promises.rm(path);
     },
     async readdir(path: string): Promise<string[]> {
       return await mockFs.promises.readdir(path);


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1271#issuecomment-1104962095

#### ✍️ Description

Drops support for Node 12 in v5 since Comunica doesn't support it any more.

`rmdir` was deprecated and removed in Node 18.
