### PR TITLE
feat: file-based backend fallback for unknown media types

### DIFF
--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -12,7 +12,7 @@ import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMedi
 import { guardStream } from '../../util/GuardedStream';
 import type { Guarded } from '../../util/GuardedStream';
 import { parseContentType } from '../../util/HeaderUtil';
-import { joinFilePath, isContainerIdentifier } from '../../util/PathUtil';
+import { joinFilePath, isContainerIdentifier, isContainerPath } from '../../util/PathUtil';
 import { parseQuads, serializeQuads } from '../../util/QuadUtil';
 import { addResourceMetadata, updateModifiedDate } from '../../util/ResourceUtil';
 import { toLiteral, toNamedTerm } from '../../util/TermUtil';
@@ -159,8 +159,14 @@ export class FileDataAccessor implements DataAccessor {
    */
   private async getFileMetadata(link: ResourceLink, stats: Stats):
   Promise<RepresentationMetadata> {
-    return (await this.getBaseMetadata(link, stats, false))
-      .set(CONTENT_TYPE_TERM, link.contentType);
+    const metadata = await this.getBaseMetadata(link, stats, false);
+    // If the resource is using an unsupported contentType, the original contentType was written to the metadata file.
+    // As a result, we should only set the contentType derived from the file path,
+    // when no previous metadata entry for contentType is present.
+    if (typeof metadata.contentType === 'undefined') {
+      metadata.set(CONTENT_TYPE_TERM, link.contentType);
+    }
+    return metadata;
   }
 
   /**
@@ -188,7 +194,12 @@ export class FileDataAccessor implements DataAccessor {
     metadata.remove(RDF.terms.type, LDP.terms.Container);
     metadata.remove(RDF.terms.type, LDP.terms.BasicContainer);
     metadata.removeAll(DC.terms.modified);
-    metadata.removeAll(CONTENT_TYPE_TERM);
+    // When writing metadata for a document, only remove the content-type when dealing with a supported media type.
+    // A media type is supported if the FileIdentifierMapper can correctly store it.
+    // This allows restoring the appropriate content-type on data read (see getFileMetadata).
+    if (isContainerPath(link.filePath) || typeof link.contentType !== 'undefined') {
+      metadata.removeAll(CONTENT_TYPE_TERM);
+    }
     const quads = metadata.quads();
     const metadataLink = await this.resourceMapper.mapUrlToFilePath(link.identifier, true);
     let wroteMetadata: boolean;

--- a/src/storage/mapping/BaseFileIdentifierMapper.ts
+++ b/src/storage/mapping/BaseFileIdentifierMapper.ts
@@ -23,6 +23,8 @@ export class BaseFileIdentifierMapper implements FileIdentifierMapper {
   protected readonly logger = getLoggerFor(this);
   protected readonly baseRequestURI: string;
   protected readonly rootFilepath: string;
+  // Extension to use as a fallback when the media type is not supported (could be made configurable).
+  protected readonly unknownMediaTypeExtension = 'unknown';
 
   public constructor(base: string, rootFilepath: string) {
     this.baseRequestURI = trimTrailingSlashes(base);
@@ -85,7 +87,10 @@ export class BaseFileIdentifierMapper implements FileIdentifierMapper {
    */
   protected async mapUrlToDocumentPath(identifier: ResourceIdentifier, filePath: string, contentType?: string):
   Promise<ResourceLink> {
-    contentType = await this.getContentTypeFromUrl(identifier, contentType);
+    // Don't try to get content-type from URL when the file path refers to a document with unknown media type.
+    if (!filePath.endsWith(`.${this.unknownMediaTypeExtension}`)) {
+      contentType = await this.getContentTypeFromUrl(identifier, contentType);
+    }
     this.logger.debug(`The path for ${identifier.path} is ${filePath}`);
     return { identifier, filePath, contentType, isMetadata: this.isMetadataPath(filePath) };
   }

--- a/src/storage/mapping/ExtensionBasedMapper.ts
+++ b/src/storage/mapping/ExtensionBasedMapper.ts
@@ -64,10 +64,12 @@ export class ExtensionBasedMapper extends BaseFileIdentifierMapper {
     // If the extension of the identifier matches a different content-type than the one that is given,
     // we need to add a new extension to match the correct type.
     } else if (contentType !== await this.getContentTypeFromPath(filePath)) {
-      const extension: string = mime.extension(contentType) || this.customExtensions[contentType];
+      let extension: string = mime.extension(contentType) || this.customExtensions[contentType];
       if (!extension) {
-        this.logger.warn(`No extension found for ${contentType}`);
-        throw new NotImplementedHttpError(`Unsupported content type ${contentType}`);
+        // When no extension is found for the provided content-type, use a fallback extension.
+        extension = this.unknownMediaTypeExtension;
+        // Signal the fallback by setting the content-type to undefined in the output link.
+        contentType = undefined;
       }
       filePath += `$.${extension}`;
     }

--- a/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
+++ b/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
@@ -125,11 +125,16 @@ describe('An ExtensionBasedMapper', (): void => {
       });
     });
 
-    it('throws 501 if the given content-type is not recognized.', async(): Promise<void> => {
-      const result = mapper.mapUrlToFilePath({ path: `${base}test.txt` }, false, 'fake/data');
-      await expect(result).rejects.toThrow(NotImplementedHttpError);
-      await expect(result).rejects.toThrow('Unsupported content type fake/data');
-    });
+    it('falls back to custom extension for unknown types (for which no custom mapping exists).',
+      async(): Promise<void> => {
+        const result = mapper.mapUrlToFilePath({ path: `${base}test` }, false, 'unknown/content-type');
+        await expect(result).resolves.toEqual({
+          identifier: { path: `${base}test` },
+          filePath: `${rootFilepath}test$.unknown`,
+          contentType: undefined,
+          isMetadata: false,
+        });
+      });
 
     it('supports custom types.', async(): Promise<void> => {
       const customMapper = new ExtensionBasedMapper(base, rootFilepath, { cstm: 'text/custom' });

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -8,7 +8,7 @@ const portNames = [
   'ContentNegotiation',
   'DynamicPods',
   'ExpiringDataCleanup',
-  'FileBackendEncodedSlashHandling',
+  'FileBackend',
   'GlobalQuota',
   'Identity',
   'LpdHandlerWithAuth',


### PR DESCRIPTION
#### 📁 Related issues

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose
-->
#768 

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->
The goal of these changes is to add support for unknown media types when using a file-based backend:

- `mapUrlToDocumentPath` in `ExtensionBasedMapper.ts` no longer throws a NotImplementedHttpError when encountering an unknown media type, but instead falls back to `application/octet-stream` (and .bin extension)
- `writeMetadata` in `FileDataAccessor.ts` retains a metadata entry with the content-type of the request when writing a document that uses an unknown media type (can be detected when the metadata content-type differs from the `ResourceLink` instance that was generated using `mapUrlToDocumentPath`), resulting in this information being written to the metadata file.
- `getFileMetadata` in `FileDataAccessor.ts` uses the content-type stored in the metadata file, if such an entry is present (instead of inferring the content-type based on the path), unless the specific link refers to a metadata resource.

I've updated the `ExtensionBasedMapper.test.ts` unit test and added an integration test (to `FileBackendEncodedSlashHandling.test.ts`, which I renamed to `FileBackend.test.ts` so it can be reused for other integration tests related to the file-backend).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
