### PR TITLE
Chore: replacing Renovate with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     # Ignore <major releases
     ignore:
       - dependency-name: "*"
-        update_types: ["version-update:semver-minor", "version-update:semver-patch"]
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "docker"
     directory: /
     schedule: 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,8 @@ updates:
       timezone: "Europe/Brussels"
     open-pull-requests-limit: 6
     target-branch: "versions/5.0.0"
-    # Ignore <major releases
     ignore:
+      # Ignore <major releases
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       # Sticking with Husky 4.x

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,27 +4,44 @@ updates:
     directory: /
     schedule: 
       interval: "daily"
-      time: "00:00"
+      time: "02:13"
       timezone: "Europe/Brussels"
-    open-pull-requests-limit: 6
+    labels:
+      - "github-actions"
+      - ":gear: dependencies"
   - package-ecosystem: "npm"
     directory: /
     schedule: 
       interval: "daily"
-      time: "00:00"
+      time: "03:35"
       timezone: "Europe/Brussels"
-    open-pull-requests-limit: 6
     target-branch: "versions/5.0.0"
     ignore:
-      # Ignore <major releases
+      # Ignore minor and patch version updates
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       # Sticking with Husky 4.x
       - dependency-name: "husky"
+    labels:
+      - "npm"
+      - ":gear: dependencies"
+  - package-ecosystem: "npm"
+    directory: /
+    schedule: 
+      interval: "daily"
+      time: "03:54"
+      timezone: "Europe/Brussels"
+    open-pull-requests-limit: 0
+    labels:
+      - "npm"
+      - "security"
+      - ":gear: dependencies"
   - package-ecosystem: "docker"
     directory: /
     schedule: 
       interval: "daily"
-      time: "00:00"
+      time: "04:22"
       timezone: "Europe/Brussels"
-    open-pull-requests-limit: 6
+    labels:
+      - "docker"
+      - ":gear: dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,17 +25,6 @@ updates:
     labels:
       - "npm"
       - ":gear: dependencies"
-  - package-ecosystem: "npm"
-    directory: /
-    schedule: 
-      interval: "daily"
-      time: "03:54"
-      timezone: "Europe/Brussels"
-    open-pull-requests-limit: 0
-    labels:
-      - "npm"
-      - "security"
-      - ":gear: dependencies"
   - package-ecosystem: "docker"
     directory: /
     schedule: 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,18 @@ updates:
     directory: /
     schedule: 
       interval: "daily"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 6
   - package-ecosystem: "npm"
     directory: /
     schedule: 
       interval: "daily"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 6
+    # Ignore <major releases
+    ignore:
+      - dependency-name: "*"
+        update_types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "docker"
     directory: /
     schedule: 
       interval: "daily"
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 6

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      # Sticking with Husky 4.x
+      - dependency-name: "husky"
   - package-ecosystem: "docker"
     directory: /
     schedule: 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: /
     schedule: 
       interval: "daily"
+      time: "00:00"
+      timezone: "Europe/Brussels"
     open-pull-requests-limit: 6
   - package-ecosystem: "npm"
     directory: /
     schedule: 
       interval: "daily"
+      time: "00:00"
+      timezone: "Europe/Brussels"
     open-pull-requests-limit: 6
     target-branch: "versions/5.0.0"
     # Ignore <major releases
@@ -21,4 +25,6 @@ updates:
     directory: /
     schedule: 
       interval: "daily"
+      time: "00:00"
+      timezone: "Europe/Brussels"
     open-pull-requests-limit: 6

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule: 
       interval: "daily"
     open-pull-requests-limit: 6
+    target-branch: "versions/5.0.0"
     # Ignore <major releases
     ignore:
       - dependency-name: "*"

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -27,5 +27,5 @@ Steps to follow:
  * Do a GitHub release.
  * `npm publish`
  * Rename the `versions/x.0.0` branch to the next version.
- * Update `.github/workflows/schedule.yml` to point at the new branch.
+ * Update `.github/workflows/schedule.yml` and `.github/dependabot.yml` to point at the new branch.
  * Potentially upgrade the recipes at https://github.com/CommunitySolidServer/recipes

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -3,30 +3,29 @@
 This is only relevant if you are a developer with push access responsible for doing a new release.
 
 Steps to follow:
-
-* Merge `main` into `versions/x.0.0`.
-* Verify if there are issues when upgrading an existing installation to the new version.
-  * Can the data still be accessed?
-  * Does authentication still work?
-  * Is there an issue upgrading the recipes at <https://github.com/CommunitySolidServer/recipes>
-  * None of the above has to be blocking per se, but should be noted in the release notes if relevant.
-* Verify that the RELEASE_NOTES.md are correct.
-* Update all Components.js references to the new version.
-  * All contexts in all configs to
+ * Merge `main` into `versions/x.0.0`.
+ * Verify if there are issues when upgrading an existing installation to the new version.
+   * Can the data still be accessed?
+   * Does authentication still work?
+   * Is there an issue upgrading the recipes at https://github.com/CommunitySolidServer/recipes
+   * None of the above has to be blocking per se, but should be noted in the release notes if relevant.
+ * Verify that the RELEASE_NOTES.md are correct.
+ * Update all Components.js references to the new version.
+   * All contexts in all configs to 
      `https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^x.0.0/components/context.jsonld`.
-  * Update all `lsd` entries in `package.json` to the new version.
-  * Commit this with `chore: Update configs to vx.0.0`.
-* `npm version major -m "Release version %s of the npm package."`
-  * This will update the `package.json`, generate a tag, and generate the new entries in `CHANGELOG.md`.
-* Manually edit the `CHANGELOG.md`.
-  * First reverse the list of new entries so they go from old to new.
-  * Put all entries in matching categories, look at the previous release for reference.
-    * Most `chore` and `docs` entries can probably be removed.
-  * Make sure there are 2 newlines between this and the previous section.
-* `git push --follow-tags`
-* Merge `versions/x.0.0` into `main` and push.
-* Do a GitHub release.
-* `npm publish`
-* Rename the `versions/x.0.0` branch to the next version.
-* Update `.github/workflows/schedule.yml` and `.github/dependabot.yml` to point at the new branch.
-* Potentially upgrade the recipes at <https://github.com/CommunitySolidServer/recipes>
+   * Update all `lsd` entries in `package.json` to the new version.
+   * Commit this with `chore: Update configs to vx.0.0`.
+ * `npm version major -m "Release version %s of the npm package."`
+   * This will update the `package.json`, generate a tag, and generate the new entries in `CHANGELOG.md`.
+ * Manually edit the `CHANGELOG.md`.
+   * First reverse the list of new entries so they go from old to new.
+   * Put all entries in matching categories, look at the previous release for reference.
+     * Most `chore` and `docs` entries can probably be removed.
+   * Make sure there are 2 newlines between this and the previous section.
+ * `git push --follow-tags`
+ * Merge `versions/x.0.0` into `main` and push.
+ * Do a GitHub release.
+ * `npm publish`
+ * Rename the `versions/x.0.0` branch to the next version.
+ * Update `.github/workflows/schedule.yml` to point at the new branch.
+ * Potentially upgrade the recipes at https://github.com/CommunitySolidServer/recipes

--- a/documentation/release.md
+++ b/documentation/release.md
@@ -3,29 +3,30 @@
 This is only relevant if you are a developer with push access responsible for doing a new release.
 
 Steps to follow:
- * Merge `main` into `versions/x.0.0`.
- * Verify if there are issues when upgrading an existing installation to the new version.
-   * Can the data still be accessed?
-   * Does authentication still work?
-   * Is there an issue upgrading the recipes at https://github.com/CommunitySolidServer/recipes
-   * None of the above has to be blocking per se, but should be noted in the release notes if relevant.
- * Verify that the RELEASE_NOTES.md are correct.
- * Update all Components.js references to the new version.
-   * All contexts in all configs to 
+
+* Merge `main` into `versions/x.0.0`.
+* Verify if there are issues when upgrading an existing installation to the new version.
+  * Can the data still be accessed?
+  * Does authentication still work?
+  * Is there an issue upgrading the recipes at <https://github.com/CommunitySolidServer/recipes>
+  * None of the above has to be blocking per se, but should be noted in the release notes if relevant.
+* Verify that the RELEASE_NOTES.md are correct.
+* Update all Components.js references to the new version.
+  * All contexts in all configs to
      `https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^x.0.0/components/context.jsonld`.
-   * Update all `lsd` entries in `package.json` to the new version.
-   * Commit this with `chore: Update configs to vx.0.0`.
- * `npm version major -m "Release version %s of the npm package."`
-   * This will update the `package.json`, generate a tag, and generate the new entries in `CHANGELOG.md`.
- * Manually edit the `CHANGELOG.md`.
-   * First reverse the list of new entries so they go from old to new.
-   * Put all entries in matching categories, look at the previous release for reference.
-     * Most `chore` and `docs` entries can probably be removed.
-   * Make sure there are 2 newlines between this and the previous section.
- * `git push --follow-tags`
- * Merge `versions/x.0.0` into `main` and push.
- * Do a GitHub release.
- * `npm publish`
- * Rename the `versions/x.0.0` branch to the next version.
- * Update `.github/workflows/schedule.yml` to point at the new branch.
- * Potentially upgrade the recipes at https://github.com/CommunitySolidServer/recipes
+  * Update all `lsd` entries in `package.json` to the new version.
+  * Commit this with `chore: Update configs to vx.0.0`.
+* `npm version major -m "Release version %s of the npm package."`
+  * This will update the `package.json`, generate a tag, and generate the new entries in `CHANGELOG.md`.
+* Manually edit the `CHANGELOG.md`.
+  * First reverse the list of new entries so they go from old to new.
+  * Put all entries in matching categories, look at the previous release for reference.
+    * Most `chore` and `docs` entries can probably be removed.
+  * Make sure there are 2 newlines between this and the previous section.
+* `git push --follow-tags`
+* Merge `versions/x.0.0` into `main` and push.
+* Do a GitHub release.
+* `npm publish`
+* Rename the `versions/x.0.0` branch to the next version.
+* Update `.github/workflows/schedule.yml` and `.github/dependabot.yml` to point at the new branch.
+* Potentially upgrade the recipes at <https://github.com/CommunitySolidServer/recipes>

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "github>rubensworks/renovate-presets:js"
-  ]
-}


### PR DESCRIPTION
#### 📁 Related issues

#731 

#### ✍️ Description
This PR further builds out our Dependabot setup so Renovate can be retired and we have all version management in one place.

**Notable changes:**
Security updates are checked against the default branch for all packages (npm, docker and github actions). Version updates for docker and github actions are performed against the default branch as well.

Version updates for npm are checked against the versions branch, configured through `target-branch: "versions/5.0.0"` option, this will have to be updated on release (along with the workflow files). These version updates are limited to major versions, patch and minor updates will have no effect (unless when triggered by security updates)

All checks are done nightly, 00:00 Europe/Brussels, so we have fresh PRs with our morning coffee ☕

Husky has already been added to the ignored dependencies for updates, as we are sticking with 4.x (see discussion in [https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1135#discussion_r804627870_](https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1135#discussion_r804627870_))

On my fork, 2 version updates are triggered, potentially these can be ignored (types seems to be a big bump so I'm guessing this is intentional).
<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->
![image](https://user-images.githubusercontent.com/4209558/166460014-c584cecc-f377-4eb8-89b4-b6500c6c6a54.png)

**Some options we might still explore:**

- Schedules for security vs version updates can be different, e.g. daily security updates and weekly version updates, right now all are daily (or nightly rather)
- Add assignees and/or reviewer to PRs
- Default labels are **dependencies** and the package manager like **npm**. We have **:gear: dependencies** and **⏳ has dependency** setup and right now, the PRs get that second label automatically.


### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [x] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [x] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
