### PR TITLE
Fix: allow http client ids that are subdomains of localhost

### DIFF
--- a/src/identity/storage/WebIdAdapterFactory.ts
+++ b/src/identity/storage/WebIdAdapterFactory.ts
@@ -39,8 +39,8 @@ export class WebIdAdapter extends PassthroughAdapter {
     // so no extra checks are needed from our side.
     if (!payload && this.name === 'Client' && hasScheme(id, 'http', 'https')) {
       this.logger.debug(`Looking for payload data at ${id}`);
-      // All checks based on https://solid.github.io/authentication-panel/solid-oidc/#clientids-webid
-      if (!/^https:|^http:\/\/localhost(?::\d+)?(?:\/|$)/u.test(id)) {
+      // All checks based on https://solid.github.io/solid-oidc/#issue-d41d8cd9%E2%91%A1
+      if (!/^https:|^http:\/\/(?:([^/]+)\.)?localhost(?::\d+)?(?:\/|$)/u.test(id)) {
         throw new Error(`SSL is required for client_id authentication unless working locally.`);
       }
       const response = await fetch(id);


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1306

#### ✍️ Description

Allows uris that use http and are subdomains of localhost to be treated as secure client ids.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
