### PR TITLE
Fix error presentation issues

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,12 +30,17 @@ The following changes are relevant for v3 custom configs that replaced certain f
    - `/ldp/metadata-parser/default.json`
    - `/storage/backend/*-quota-file.json`
    - `/storage/backend/quota/quota-file.json`
+- The `PreferenceParser` has been moved from the `BasicRequestParser` to the `ParsingHttpHandler`.
+  - `/app/setup/handlers/setup.json`
+  - `/identity/handler/default.json`
+  - `/ldp/handler/*`
 
 ### Interface changes
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.
 - `YargsCliExtractor` was changed to now take as input an array of parameter objects.
 - `RedirectAllHttpHandler` was removed and fully replaced by `RedirectingHttpHandler`.
 - `SingleThreadedResourceLocker` has been renamed to `MemoryResourceLocker`.
+- The `PreferenceParser` has been moved from the `BasicRequestParser` to the `ParsingHttpHandler`.
 
 ## V4.0.1
 Freezes the `oidc-provider` dependency to prevent a potential issue with the solid authn client

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,8 @@ The following changes are relevant for v3 custom configs that replaced certain f
   - `/app/setup/handlers/setup.json`
   - `/identity/handler/default.json`
   - `/ldp/handler/*`
+- The `IdentityProviderFactory` inputs have been extended.
+  - `/identity/handler/provider-factory/identity.json`
 
 ### Interface changes
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.
@@ -41,6 +43,7 @@ These changes are relevant if you wrote custom modules for the server that depen
 - `RedirectAllHttpHandler` was removed and fully replaced by `RedirectingHttpHandler`.
 - `SingleThreadedResourceLocker` has been renamed to `MemoryResourceLocker`.
 - The `PreferenceParser` has been moved from the `BasicRequestParser` to the `ParsingHttpHandler`.
+- The `IdentityProviderFactory` now additionally takes a `PreferenceParser` and a `showStackTracke` boolean as input..
 
 ## V4.0.1
 Freezes the `oidc-provider` dependency to prevent a potential issue with the solid authn client

--- a/config/app/setup/handlers/setup.json
+++ b/config/app/setup/handlers/setup.json
@@ -5,6 +5,7 @@
       "comment": "Handles everything related to the first-time server setup.",
       "@id": "urn:solid-server:default:SetupHttpHandler",
       "@type": "ParsingHttpHandler",
+      "args_preferenceParser": { "@id": "urn:solid-server:default:PreferenceParser" },
       "args_requestParser": { "@id": "urn:solid-server:default:RequestParser" },
       "args_metadataCollector": { "@id": "urn:solid-server:default:OperationMetadataCollector" },
       "args_errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },

--- a/config/identity/handler/default.json
+++ b/config/identity/handler/default.json
@@ -21,6 +21,7 @@
       "comment": "Handles IDP input parsing.",
       "@id": "urn:solid-server:default:IdentityProviderParsingHandler",
       "@type": "ParsingHttpHandler",
+      "args_preferenceParser": { "@id": "urn:solid-server:default:PreferenceParser" },
       "args_requestParser": { "@id": "urn:solid-server:default:RequestParser" },
       "args_metadataCollector": { "@id": "urn:solid-server:default:OperationMetadataCollector" },
       "args_errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },

--- a/config/identity/handler/provider-factory/identity.json
+++ b/config/identity/handler/provider-factory/identity.json
@@ -18,6 +18,8 @@
         "relativePath": "/idp/keys/",
         "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
       },
+      "args_preferenceParser": { "@id": "urn:solid-server:default:PreferenceParser" },
+      "args_showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" },
       "args_errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },
       "args_responseWriter": { "@id": "urn:solid-server:default:ResponseWriter" },
       "config": {

--- a/config/ldp/handler/components/preferences.json
+++ b/config/ldp/handler/components/preferences.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server:default:PreferenceParser",
+      "@type": "AcceptPreferenceParser"
+    }
+  ]
+}

--- a/config/ldp/handler/components/request-parser.json
+++ b/config/ldp/handler/components/request-parser.json
@@ -11,7 +11,6 @@
         "args_identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
         "args_includeQueryString": false
       },
-      "args_preferenceParser": { "@type": "AcceptPreferenceParser" },
       "args_metadataParser": { "@id": "urn:solid-server:default:MetadataParser" },
       "args_conditionsParser": { "@type": "BasicConditionsParser" },
       "args_bodyParser": {

--- a/config/ldp/handler/default.json
+++ b/config/ldp/handler/default.json
@@ -5,6 +5,7 @@
     "css:config/ldp/handler/components/error-handler.json",
     "css:config/ldp/handler/components/operation-handler.json",
     "css:config/ldp/handler/components/operation-metadata.json",
+    "css:config/ldp/handler/components/preferences.json",
     "css:config/ldp/handler/components/request-parser.json",
     "css:config/ldp/handler/components/response-writer.json"
   ],
@@ -13,6 +14,7 @@
       "comment": "The main entry point into the main Solid behaviour.",
       "@id": "urn:solid-server:default:LdpHandler",
       "@type": "ParsingHttpHandler",
+      "args_preferenceParser": { "@id": "urn:solid-server:default:PreferenceParser" },
       "args_requestParser": { "@id": "urn:solid-server:default:RequestParser" },
       "args_metadataCollector": { "@id": "urn:solid-server:default:OperationMetadataCollector" },
       "args_errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },

--- a/src/http/input/BasicRequestParser.ts
+++ b/src/http/input/BasicRequestParser.ts
@@ -1,4 +1,3 @@
-import type { HttpRequest } from '../../server/HttpRequest';
 import { InternalServerError } from '../../util/errors/InternalServerError';
 import type { Operation } from '../Operation';
 import { RepresentationMetadata } from '../representation/RepresentationMetadata';
@@ -6,7 +5,7 @@ import type { BodyParser } from './body/BodyParser';
 import type { ConditionsParser } from './conditions/ConditionsParser';
 import type { TargetExtractor } from './identifier/TargetExtractor';
 import type { MetadataParser } from './metadata/MetadataParser';
-import type { PreferenceParser } from './preferences/PreferenceParser';
+import type { RequestParserInput } from './RequestParser';
 import { RequestParser } from './RequestParser';
 
 /**
@@ -14,7 +13,6 @@ import { RequestParser } from './RequestParser';
  */
 export interface BasicRequestParserArgs {
   targetExtractor: TargetExtractor;
-  preferenceParser: PreferenceParser;
   metadataParser: MetadataParser;
   conditionsParser: ConditionsParser;
   bodyParser: BodyParser;
@@ -22,28 +20,29 @@ export interface BasicRequestParserArgs {
 
 /**
  * Creates an {@link Operation} from an incoming {@link HttpRequest} by aggregating the results
- * of a {@link TargetExtractor}, {@link PreferenceParser}, {@link MetadataParser},
+ * of a {@link TargetExtractor}, {@link MetadataParser},
  * {@link ConditionsParser} and {@link BodyParser}.
  */
 export class BasicRequestParser extends RequestParser {
-  private readonly targetExtractor!: TargetExtractor;
-  private readonly preferenceParser!: PreferenceParser;
-  private readonly metadataParser!: MetadataParser;
-  private readonly conditionsParser!: ConditionsParser;
-  private readonly bodyParser!: BodyParser;
+  private readonly targetExtractor: TargetExtractor;
+  private readonly metadataParser: MetadataParser;
+  private readonly conditionsParser: ConditionsParser;
+  private readonly bodyParser: BodyParser;
 
   public constructor(args: BasicRequestParserArgs) {
     super();
-    Object.assign(this, args);
+    this.targetExtractor = args.targetExtractor;
+    this.metadataParser = args.metadataParser;
+    this.conditionsParser = args.conditionsParser;
+    this.bodyParser = args.bodyParser;
   }
 
-  public async handle(request: HttpRequest): Promise<Operation> {
+  public async handle({ request, preferences }: RequestParserInput): Promise<Operation> {
     const { method } = request;
     if (!method) {
       throw new InternalServerError('No method specified on the HTTP request');
     }
     const target = await this.targetExtractor.handleSafe({ request });
-    const preferences = await this.preferenceParser.handleSafe({ request });
     const metadata = new RepresentationMetadata(target);
     await this.metadataParser.handleSafe({ request, metadata });
     const conditions = await this.conditionsParser.handleSafe(request);

--- a/src/http/input/RequestParser.ts
+++ b/src/http/input/RequestParser.ts
@@ -1,8 +1,15 @@
 import type { HttpRequest } from '../../server/HttpRequest';
 import { AsyncHandler } from '../../util/handlers/AsyncHandler';
 import type { Operation } from '../Operation';
+import type { RepresentationPreferences } from '../representation/RepresentationPreferences';
+
+export interface RequestParserInput {
+  request: HttpRequest;
+  preferences: RepresentationPreferences;
+}
 
 /**
  * Converts an incoming HttpRequest to an Operation.
+ * Preferences should already have been parsed and passed along.
  */
-export abstract class RequestParser extends AsyncHandler<HttpRequest, Operation> {}
+export abstract class RequestParser extends AsyncHandler<RequestParserInput, Operation> {}

--- a/test/integration/RequestParser.test.ts
+++ b/test/integration/RequestParser.test.ts
@@ -6,21 +6,20 @@ import { RawBodyParser } from '../../src/http/input/body/RawBodyParser';
 import { BasicConditionsParser } from '../../src/http/input/conditions/BasicConditionsParser';
 import { OriginalUrlExtractor } from '../../src/http/input/identifier/OriginalUrlExtractor';
 import { ContentTypeParser } from '../../src/http/input/metadata/ContentTypeParser';
-import { AcceptPreferenceParser } from '../../src/http/input/preferences/AcceptPreferenceParser';
 import { RepresentationMetadata } from '../../src/http/representation/RepresentationMetadata';
 import type { HttpRequest } from '../../src/server/HttpRequest';
 import { BasicConditions } from '../../src/storage/BasicConditions';
 import { guardedStreamFrom } from '../../src/util/StreamUtil';
 
 describe('A BasicRequestParser with simple input parsers', (): void => {
+  const preferences = { type: { 'text/turtle': 0.8 }, language: { 'en-gb': 1, en: 0.5 }};
   const identifierStrategy = new SingleRootIdentifierStrategy('http://test.com/');
   const targetExtractor = new OriginalUrlExtractor({ identifierStrategy });
-  const preferenceParser = new AcceptPreferenceParser();
   const metadataParser = new ContentTypeParser();
   const conditionsParser = new BasicConditionsParser();
   const bodyParser = new RawBodyParser();
   const requestParser = new BasicRequestParser(
-    { targetExtractor, preferenceParser, metadataParser, conditionsParser, bodyParser },
+    { targetExtractor, metadataParser, conditionsParser, bodyParser },
   );
 
   it('can parse an incoming request.', async(): Promise<void> => {
@@ -37,14 +36,11 @@ describe('A BasicRequestParser with simple input parsers', (): void => {
       host: 'test.com',
     };
 
-    const result = await requestParser.handle(request);
+    const result = await requestParser.handle({ request, preferences });
     expect(result).toEqual({
       method: 'POST',
       target: { path: 'http://test.com/' },
-      preferences: {
-        type: { 'text/turtle': 0.8 },
-        language: { 'en-gb': 1, en: 0.5 },
-      },
+      preferences,
       conditions: new BasicConditions({
         unmodifiedSince: new Date('2015-10-21T07:28:00.000Z'),
         notMatchesETag: [ '12345' ],

--- a/test/unit/server/ParsingHttpHandler.test.ts
+++ b/test/unit/server/ParsingHttpHandler.test.ts
@@ -1,3 +1,4 @@
+import type { PreferenceParser } from '../../../src/http/input/preferences/PreferenceParser';
 import type { RequestParser } from '../../../src/http/input/RequestParser';
 import type { OperationMetadataCollector } from '../../../src/http/ldp/metadata/OperationMetadataCollector';
 import type { Operation } from '../../../src/http/Operation';
@@ -20,6 +21,7 @@ describe('A ParsingHttpHandler', (): void => {
   const body = new BasicRepresentation();
   const operation: Operation = { method: 'GET', target: { path: 'http://test.com/foo' }, preferences, body };
   const errorResponse = new ResponseDescription(400);
+  let preferenceParser: jest.Mocked<PreferenceParser>;
   let requestParser: jest.Mocked<RequestParser>;
   let metadataCollector: jest.Mocked<OperationMetadataCollector>;
   let errorHandler: jest.Mocked<ErrorHandler>;
@@ -28,6 +30,7 @@ describe('A ParsingHttpHandler', (): void => {
   let handler: ParsingHttpHandler;
 
   beforeEach(async(): Promise<void> => {
+    preferenceParser = { handleSafe: jest.fn().mockResolvedValue(preferences) } as any;
     requestParser = { handleSafe: jest.fn().mockResolvedValue(operation) } as any;
     metadataCollector = { handleSafe: jest.fn() } as any;
     errorHandler = { handleSafe: jest.fn().mockResolvedValue(errorResponse) } as any;
@@ -38,7 +41,7 @@ describe('A ParsingHttpHandler', (): void => {
     } as any;
 
     handler = new ParsingHttpHandler(
-      { requestParser, metadataCollector, errorHandler, responseWriter, operationHandler: source },
+      { preferenceParser, requestParser, metadataCollector, errorHandler, responseWriter, operationHandler: source },
     );
   });
 


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1148#issuecomment-1122466386

#### ✍️ Description

Fixes several issues I still had with how we showed errors to the users. There were still several cases where the user would get a text representation of the error, even if they requested HTML or something else. This PR fixes all of those cases (I think).

The `PreferenceParser` has been extracted from the `BasicRequestParser` and moved to the `ParsingHttpHandler`. This way we can parse the preferences before any error gets thrown by, for example, an invalid N3 Patch body that gets parsed.

The `IdentityProviderFactory` now also takes a `PreferenceParser` as input so it can correctly create a representation for OIDC errors. The extra error metadata that gets added now only gets added if the `showStackTrace` parameter has been set to true to make sure we don't leak too much information. Although that is not (yet) super relevant due to https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1182 .
