### PR TITLE
Fix: Revert to having ConvertingRouterRule support any number of stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
         "cheerio": "^1.0.0-rc.10",
-        "componentsjs-generator": "^3.0.2",
+        "componentsjs-generator": "^3.0.3",
         "eslint": "^8.8.0",
         "eslint-config-es": "4.1.0",
         "eslint-import-resolver-typescript": "^2.5.0",
@@ -5904,9 +5904,9 @@
       }
     },
     "node_modules/componentsjs-generator": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-3.0.2.tgz",
-      "integrity": "sha512-r0u4PJD6oEAmjSX920JZndA5/mb7s4UbwSf1awisEXs5s4zTp0jiOhNG3z6p5lvAHBTZHwIPf83b4yWUU/9TYA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-3.0.3.tgz",
+      "integrity": "sha512-Pv4+tnwAWjOkUpwt6SoD8DWfBdGfxhaqAK3zRvZIgrbPFo4V4bZpXgN8MBYXm1InRGYQeHdNUTGdXYZw0L8GjA==",
       "dev": true,
       "dependencies": {
         "@types/lru-cache": "^5.1.0",
@@ -19760,9 +19760,9 @@
       }
     },
     "componentsjs-generator": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-3.0.2.tgz",
-      "integrity": "sha512-r0u4PJD6oEAmjSX920JZndA5/mb7s4UbwSf1awisEXs5s4zTp0jiOhNG3z6p5lvAHBTZHwIPf83b4yWUU/9TYA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/componentsjs-generator/-/componentsjs-generator-3.0.3.tgz",
+      "integrity": "sha512-Pv4+tnwAWjOkUpwt6SoD8DWfBdGfxhaqAK3zRvZIgrbPFo4V4bZpXgN8MBYXm1InRGYQeHdNUTGdXYZw0L8GjA==",
       "dev": true,
       "requires": {
         "@types/lru-cache": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "cheerio": "^1.0.0-rc.10",
-    "componentsjs-generator": "^3.0.2",
+    "componentsjs-generator": "^3.0.3",
     "eslint": "^8.8.0",
     "eslint-config-es": "4.1.0",
     "eslint-import-resolver-typescript": "^2.5.0",

--- a/src/http/representation/RepresentationPreferences.ts
+++ b/src/http/representation/RepresentationPreferences.ts
@@ -6,8 +6,12 @@
   * "The weight is normalized to a real number in the range 0 through 1,
   * where 0.001 is the least preferred and 1 is the most preferred; a
   * value of 0 means "not acceptable"."
+  *
+  * Because of an open issue in Components.js we cannot use `Record<string, number>` right now.
+  * https://github.com/LinkedSoftwareDependencies/Components-Generator.js/issues/103
   */
-export type ValuePreferences = Record<string, number>;
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+export type ValuePreferences = {[key: string ]: number };
 
 /**
  * A single entry of a {@link ValuePreferences} object.

--- a/src/storage/routing/ConvertingRouterRule.ts
+++ b/src/storage/routing/ConvertingRouterRule.ts
@@ -23,9 +23,9 @@ export class ConvertingRouterRule extends RouterRule {
   private readonly typedStores: ConvertingStoreEntry[];
   private readonly defaultStore: ResourceStore;
 
-  public constructor(typedStore: ConvertingStoreEntry, defaultStore: ResourceStore) {
+  public constructor(typedStores: ConvertingStoreEntry[], defaultStore: ResourceStore) {
     super();
-    this.typedStores = [ typedStore ];
+    this.typedStores = typedStores;
     this.defaultStore = defaultStore;
   }
 

--- a/src/storage/routing/PreferenceSupport.ts
+++ b/src/storage/routing/PreferenceSupport.ts
@@ -14,8 +14,8 @@ export class PreferenceSupport {
   private readonly preferences: RepresentationPreferences;
   private readonly converter: RepresentationConverter;
 
-  public constructor(type: string, converter: RepresentationConverter) {
-    this.preferences = { type: { [type]: 1 }};
+  public constructor(preferences: RepresentationPreferences, converter: RepresentationConverter) {
+    this.preferences = preferences;
     this.converter = converter;
   }
 

--- a/test/unit/storage/routing/PreferenceSupport.test.ts
+++ b/test/unit/storage/routing/PreferenceSupport.test.ts
@@ -6,16 +6,17 @@ import { PreferenceSupport } from '../../../../src/storage/routing/PreferenceSup
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 
 describe('A PreferenceSupport', (): void => {
-  const type = 'internal/quads';
-  const preferences: RepresentationPreferences = { type: { [type]: 1 }};
+  let preferences: RepresentationPreferences;
   let converter: RepresentationConverter;
   let support: PreferenceSupport;
+  const type = 'internal/quads';
   const identifier: ResourceIdentifier = 'identifier' as any;
   const representation: Representation = 'representation' as any;
 
   beforeEach(async(): Promise<void> => {
+    preferences = { type: { [type]: 1 }};
     converter = { canHandle: jest.fn() } as any;
-    support = new PreferenceSupport(type, converter);
+    support = new PreferenceSupport(preferences, converter);
   });
 
   it('returns true if the converter supports the input.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

#298 

#### ✍️ Description

Reverting the commits mentioned in #298 . This is to pave the way for tackling #302 and eventually #947.
All the required fixes in components.js and the generator seem to be in place for this.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
