### PR TITLE
Feat: Have RegexRouterRule take ordered array

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,7 +24,7 @@ The following changes pertain to the imports in the default configs:
 - All default configurations with a file-based backend now use a file-based locker instead of a memory-based one,
   making them threadsafe.
 
-The following changes are relevant for v3 custom configs that replaced certain features.
+The following changes are relevant for v4 custom configs that replaced certain features.
 - `config/app/variables/cli.json` was changed to support the new `YargsCliExtractor` format.
 - `config/util/resource-locker/memory.json` had the locker @type changed from `SingleThreadedResourceLocker` to `MemoryResourceLocker`.
 - The content-length parser has been moved from the default configuration to the quota configurations.
@@ -33,6 +33,9 @@ The following changes are relevant for v3 custom configs that replaced certain f
    - `/storage/backend/quota/quota-file.json`
 - The structure of the init configs has changed significantly to support worker threads.
    - `/app/init/*`
+- RegexPathRouting has changed from a map datastructure to an array datastructure, allowing for fallthrough regex parsing. The change is reflected in the following default configs:
+   - `/storage/backend/regex.json`
+   - `/sparql-file-storage.json`
 
 ### Interface changes
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.

--- a/config/sparql-file-storage.json
+++ b/config/sparql-file-storage.json
@@ -51,16 +51,18 @@
       "@id": "urn:solid-server:default:RouterRule",
       "@type": "RegexRouterRule",
       "base": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "storeMap": [
+      "rules": [
         {
           "comment": "Internal storage data",
-          "RegexRouterRule:_storeMap_key": "^/\\.internal/",
-          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:FileResourceStore" }
+          "@type": "RegexRule",
+          "regex": "^/\\.internal/",
+          "store": { "@id": "urn:solid-server:default:FileResourceStore" }
         },
         {
           "comment": "Send everything else to the SPARQL store.",
-          "RegexRouterRule:_storeMap_key": "^/(?!\\.internal/).*",
-          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:SparqlResourceStore" }
+          "@type": "RegexRule",
+          "regex": ".*",
+          "store": { "@id": "urn:solid-server:default:SparqlResourceStore" }
         }
       ]
     },

--- a/config/storage/backend/regex.json
+++ b/config/storage/backend/regex.json
@@ -21,22 +21,26 @@
       "@id": "urn:solid-server:default:RouterRule",
       "@type": "RegexRouterRule",
       "base": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "storeMap": [
+      "rules": [
         {
-          "RegexRouterRule:_storeMap_key": "^/(\\.acl)?$",
-          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:SparqlResourceStore" }
+          "@type": "RegexRule",
+          "regex": "^/(\\.acl)?$",
+          "store": { "@id": "urn:solid-server:default:SparqlResourceStore" }
         },
         {
-          "RegexRouterRule:_storeMap_key": "/file/",
-          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:FileResourceStore" }
+          "@type": "RegexRule",
+          "regex": "/file/",
+          "store": { "@id": "urn:solid-server:default:FileResourceStore" }
         },
         {
-          "RegexRouterRule:_storeMap_key": "/memory/",
-          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:MemoryResourceStore" }
+          "@type": "RegexRule",
+          "regex": "/memory/",
+          "store": { "@id": "urn:solid-server:default:MemoryResourceStore" }
         },
         {
-          "RegexRouterRule:_storeMap_key": "/sparql/",
-          "RegexRouterRule:_storeMap_value": { "@id": "urn:solid-server:default:SparqlResourceStore" }
+          "@type": "RegexRule",
+          "regex": "/sparql/",
+          "store": { "@id": "urn:solid-server:default:SparqlResourceStore" }
         }
       ]
     },

--- a/test/unit/storage/routing/RegexRouterRule.test.ts
+++ b/test/unit/storage/routing/RegexRouterRule.test.ts
@@ -1,5 +1,5 @@
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
-import { RegexRouterRule } from '../../../../src/storage/routing/RegexRouterRule';
+import { RegexRouterRule, RegexRule } from '../../../../src/storage/routing/RegexRouterRule';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 
@@ -7,29 +7,36 @@ describe('A RegexRouterRule', (): void => {
   const base = 'http://test.com/';
   const store: ResourceStore = 'resourceStore' as any;
 
+  it('can construct a RegexRule utility object.', (): void => {
+    const regex = '/myPath/';
+    const rule = new RegexRule(regex, store);
+    expect(rule.regex).toEqual(new RegExp(regex, 'u'));
+    expect(rule.store).toEqual(store);
+  });
+
   it('rejects identifiers not containing the base.', async(): Promise<void> => {
-    const router = new RegexRouterRule(base, {});
+    const router = new RegexRouterRule(base, []);
     const result = router.canHandle({ identifier: { path: 'http://notTest.com/apple' }});
     await expect(result).rejects.toThrow(BadRequestHttpError);
     await expect(result).rejects.toThrow('Identifiers need to start with http://test.com');
   });
 
   it('rejects identifiers not matching any regex.', async(): Promise<void> => {
-    const router = new RegexRouterRule(base, { pear: store });
+    const router = new RegexRouterRule(base, [ new RegexRule('pear', store) ]);
     const result = router.canHandle({ identifier: { path: `${base}apple/` }});
     await expect(result).rejects.toThrow(NotImplementedHttpError);
     await expect(result).rejects.toThrow('No stored regexes match http://test.com/apple/');
   });
 
   it('accepts identifiers matching any regex.', async(): Promise<void> => {
-    const router = new RegexRouterRule(base, { '^/apple': store });
+    const router = new RegexRouterRule(base, [ new RegexRule('^/apple', store) ]);
     await expect(router.canHandle({ identifier: { path: `${base}apple/` }}))
       .resolves.toBeUndefined();
   });
 
   it('returns the corresponding store.', async(): Promise<void> => {
     const store2: ResourceStore = 'resourceStore2' as any;
-    const router = new RegexRouterRule(base, { '^/apple': store2, '/pear/': store });
+    const router = new RegexRouterRule(base, [ new RegexRule('^/apple', store2), new RegexRule('/pear/', store) ]);
     await expect(router.handle({ identifier: { path: `${base}apple/` }})).resolves.toBe(store2);
   });
 });


### PR DESCRIPTION
#### 📁 Related issues

#302 
#947 

#### ✍️ Description

This PR changes the Regex to ResourceStore mapping from a Map datastructure to an Array datastructure. The idea is that regexes are now tested in a fallthrough order.

This allows for more predictable routing and even allows for a catchall `/.*/` regex at the end as suggested in #947. This change will however not introduce any catching/default behaviour, it will only setup the datastructure to allow this in the future. Any such change would be better introduced as a fix for #947 itself.

~~The first two comments, called `fix: Revert: ...`, are from the parent `fix/#298` branch, once merged, these will be removed after a rebase. So only the latest commit should be reviewed here.~~


### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [x] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [x] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
