### PR TITLE
Fix: Rewrite request with a root path to OIDC Provider

### DIFF
--- a/src/identity/OidcHttpHandler.ts
+++ b/src/identity/OidcHttpHandler.ts
@@ -18,6 +18,13 @@ export class OidcHttpHandler extends HttpHandler {
 
   public async handle({ request, response }: HttpHandlerInput): Promise<void> {
     const provider = await this.providerFactory.getProvider();
+
+    // Rewrite requests to allow hosting on root paths
+    const path = new URL(provider.issuer).pathname;
+    if (path.length > 1 && request.url!.startsWith(`${path}.well-known/openid-configuration`)) {
+      request.url = '/.well-known/openid-configuration';
+    }
+
     this.logger.debug(`Sending request to oidc-provider: ${request.url}`);
     // Even though the typings do not indicate this, this is a Promise that needs to be awaited.
     // Otherwise, the `BaseHttpServerFactory` will write a 404 before the OIDC library could handle the response.

--- a/src/identity/OidcHttpHandler.ts
+++ b/src/identity/OidcHttpHandler.ts
@@ -22,7 +22,7 @@ export class OidcHttpHandler extends HttpHandler {
     // Rewrite requests to allow hosting on root paths
     const path = new URL(provider.issuer).pathname;
     if (path.length > 1 && request.url!.startsWith(`${path}.well-known/openid-configuration`)) {
-      request.url = '/.well-known/openid-configuration';
+      request.url = request.url!.replace(path, '/');
     }
 
     this.logger.debug(`Sending request to oidc-provider: ${request.url}`);

--- a/templates/root/prefilled/index.html
+++ b/templates/root/prefilled/index.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <a href="/"><img src="/.well-known/css/images/solid.svg" alt="[Solid logo]" /></a>
+    <a href="./"><img src="/.well-known/css/images/solid.svg" alt="[Solid logo]" /></a>
     <h1>Community Solid Server</h1>
   </header>
   <main>
@@ -22,7 +22,7 @@
 
     <h2 id="users">Getting started as a <em>user</em></h2>
     <p>
-      <a href="/idp/register/">Sign up for an account</a>
+      <a href="./idp/register/">Sign up for an account</a>
       to get started with your own Pod and WebID.
     </p>
     <p>

--- a/test/unit/identity/OidcHttpHandler.test.ts
+++ b/test/unit/identity/OidcHttpHandler.test.ts
@@ -42,4 +42,14 @@ describe('An OidcHttpHandler', (): void => {
     expect(provider.callback.mock.results[0].value).toHaveBeenCalledTimes(1);
     expect(provider.callback.mock.results[0].value).toHaveBeenLastCalledWith(request, response);
   });
+
+  it('respects query parameters when rewriting requests.', async(): Promise<void> => {
+    Object.assign(provider, { issuer: 'http://localhost:3000/path/' });
+    request.url = '/path/.well-known/openid-configuration?param1=value1';
+    await expect(handler.handle({ request, response })).resolves.toBeUndefined();
+    expect(request.url).toBe('/.well-known/openid-configuration?param1=value1');
+    expect(provider.callback).toHaveBeenCalledTimes(1);
+    expect(provider.callback.mock.results[0].value).toHaveBeenCalledTimes(1);
+    expect(provider.callback.mock.results[0].value).toHaveBeenLastCalledWith(request, response);
+  });
 });

--- a/test/unit/identity/OidcHttpHandler.test.ts
+++ b/test/unit/identity/OidcHttpHandler.test.ts
@@ -5,7 +5,9 @@ import type { HttpRequest } from '../../../src/server/HttpRequest';
 import type { HttpResponse } from '../../../src/server/HttpResponse';
 
 describe('An OidcHttpHandler', (): void => {
-  const request: HttpRequest = {} as any;
+  const request: HttpRequest = {
+    url: '/.well-known/openid-configuration',
+  } as any;
   const response: HttpResponse = {} as any;
   let provider: jest.Mocked<Provider>;
   let providerFactory: jest.Mocked<ProviderFactory>;
@@ -14,17 +16,28 @@ describe('An OidcHttpHandler', (): void => {
   beforeEach(async(): Promise<void> => {
     provider = {
       callback: jest.fn().mockReturnValue(jest.fn()),
+      issuer: 'http://localhost:3000/',
     } as any;
 
     providerFactory = {
       getProvider: jest.fn().mockResolvedValue(provider),
-    };
+    } as any;
 
     handler = new OidcHttpHandler(providerFactory);
   });
 
   it('sends all requests to the OIDC library.', async(): Promise<void> => {
     await expect(handler.handle({ request, response })).resolves.toBeUndefined();
+    expect(provider.callback).toHaveBeenCalledTimes(1);
+    expect(provider.callback.mock.results[0].value).toHaveBeenCalledTimes(1);
+    expect(provider.callback.mock.results[0].value).toHaveBeenLastCalledWith(request, response);
+  });
+
+  it('rewrites the request when using base URL with root path.', async(): Promise<void> => {
+    Object.assign(provider, { issuer: 'http://localhost:3000/path/' });
+    request.url = '/path/.well-known/openid-configuration';
+    await expect(handler.handle({ request, response })).resolves.toBeUndefined();
+    expect(request.url).toBe('/.well-known/openid-configuration');
     expect(provider.callback).toHaveBeenCalledTimes(1);
     expect(provider.callback.mock.results[0].value).toHaveBeenCalledTimes(1);
     expect(provider.callback.mock.results[0].value).toHaveBeenLastCalledWith(request, response);


### PR DESCRIPTION
#### 📁 Related issues

#1110

#### ✍️ Description

When a root path is used in the base URL, requests to the OIDC provider get rewritten:
`/path/.well-known/openid-configuration` becomes `/.well-known/openid-configuration` before getting passed to the Provider.

Also some links in the setup html page now honor that subpath (`./idp/register` and `./` in the header)

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [x] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
