### PR TITLE
fix: Accept client WebIDs with a context array

### DIFF
--- a/src/identity/storage/WebIdAdapterFactory.ts
+++ b/src/identity/storage/WebIdAdapterFactory.ts
@@ -51,9 +51,10 @@ export class WebIdAdapter extends PassthroughAdapter {
       let json: any | undefined;
       try {
         json = JSON.parse(data);
+        const contexts = Array.isArray(json['@context']) ? json['@context'] : [ json['@context'] ];
         // We can only parse as simple JSON if the @context is correct
-        if (json['@context'] !== 'https://www.w3.org/ns/solid/oidc-context.jsonld') {
-          throw new Error('Invalid context');
+        if (!contexts.includes('https://www.w3.org/ns/solid/oidc-context.jsonld')) {
+          throw new Error('Missing context https://www.w3.org/ns/solid/oidc-context.jsonld');
         }
       } catch (error: unknown) {
         json = undefined;

--- a/test/unit/identity/storage/WebIdAdapterFactory.test.ts
+++ b/test/unit/identity/storage/WebIdAdapterFactory.test.ts
@@ -85,6 +85,15 @@ describe('A WebIdAdapterFactory', (): void => {
     });
   });
 
+  it('can handle a context array.', async(): Promise<void> => {
+    json['@context'] = [ json['@context'] ];
+    fetchMock.mockResolvedValueOnce({ url: id, status: 200, text: (): string => JSON.stringify(json) });
+    await expect(adapter.find(id)).resolves.toEqual({
+      ...json,
+      token_endpoint_auth_method: 'none',
+    });
+  });
+
   it('errors if there is a client_id mismatch.', async(): Promise<void> => {
     json.client_id = 'someone else';
     fetchMock.mockResolvedValueOnce({ url: id, status: 200, text: (): string => JSON.stringify(json) });


### PR DESCRIPTION
#### ✍️ Description

Fixes an issue where client WebIDs were rejected if the `@context` was an array instead of a string.
