### PR TITLE
fix: logging component logs as coming from a worker

### DIFF
--- a/src/logging/LazyLoggerFactory.ts
+++ b/src/logging/LazyLoggerFactory.ts
@@ -1,3 +1,4 @@
+import cluster from 'cluster';
 import { WrappingLogger } from './Logger';
 import type { Logger } from './Logger';
 import type { LoggerFactory } from './LoggerFactory';
@@ -51,7 +52,7 @@ class TemporaryLoggerFactory implements LoggerFactory {
     }
     // Emit all buffered log messages
     for (const { logger, level, message } of this.buffer.splice(0, this.buffer.length)) {
-      logger.log(level, message);
+      logger.log(level, message, { isPrimary: cluster.isMaster, pid: process.pid });
     }
   }
 }

--- a/src/logging/Logger.ts
+++ b/src/logging/Logger.ts
@@ -38,7 +38,7 @@ export interface Logger extends SimpleLogger {
    * @param message - The message to log.
    * @param meta - Optional metadata to include in the log message.
    */
-  log: (level: LogLevel, message: string) => Logger;
+  log: (level: LogLevel, message: string, meta?: LogMetadata) => Logger;
 
   /**
    * Log a message at the 'error' level.

--- a/test/unit/logging/LazyLoggerFactory.test.ts
+++ b/test/unit/logging/LazyLoggerFactory.test.ts
@@ -53,13 +53,13 @@ describe('LazyLoggerFactory', (): void => {
 
     const wrappedA = dummyLoggerFactory.createLogger.mock.results[0].value as jest.Mocked<Logger>;
     expect(wrappedA.log).toHaveBeenCalledTimes(2);
-    expect(wrappedA.log).toHaveBeenNthCalledWith(1, 'warn', 'message1', undefined);
-    expect(wrappedA.log).toHaveBeenNthCalledWith(2, 'error', 'message4', undefined);
+    expect(wrappedA.log).toHaveBeenNthCalledWith(1, 'warn', 'message1', expect.any(Object));
+    expect(wrappedA.log).toHaveBeenNthCalledWith(2, 'error', 'message4', expect.any(Object));
 
     const wrappedB = dummyLoggerFactory.createLogger.mock.results[1].value as jest.Mocked<Logger>;
     expect(wrappedB.log).toHaveBeenCalledTimes(2);
-    expect(wrappedB.log).toHaveBeenNthCalledWith(1, 'warn', 'message2', undefined);
-    expect(wrappedB.log).toHaveBeenNthCalledWith(2, 'error', 'message3', undefined);
+    expect(wrappedB.log).toHaveBeenNthCalledWith(1, 'warn', 'message2', expect.any(Object));
+    expect(wrappedB.log).toHaveBeenNthCalledWith(2, 'error', 'message3', expect.any(Object));
   });
 
   it('does not store more messages than the buffer limit.', (): void => {
@@ -84,6 +84,8 @@ describe('LazyLoggerFactory', (): void => {
     expect(wrappedA.log).toHaveBeenCalledTimes(50);
     expect(wrappedB.log).toHaveBeenCalledTimes(49);
     expect(warningLogger.log).toHaveBeenCalledTimes(1);
-    expect(warningLogger.log).toHaveBeenCalledWith('warn', 'Memory-buffered logging limit of 100 reached', undefined);
+    expect(warningLogger.log).toHaveBeenCalledWith(
+      'warn', 'Memory-buffered logging limit of 100 reached', expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
#### 📁 Related issues
#1325 

#### ✍️ Description

Fixes the bug where LazyLoggers are not properly sending the metadata object along, resulting in `{W-???}` in the logs.
