### PR TITLE
Feat: Respect root path for static assets and HTML links

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ These changes are relevant if you wrote custom modules for the server that depen
 - `YargsCliExtractor` was changed to now take as input an array of parameter objects.
 - `RedirectAllHttpHandler` was removed and fully replaced by `RedirectingHttpHandler`.
 - `SingleThreadedResourceLocker` has been renamed to `MemoryResourceLocker`.
+- Both `TemplateEngine` implementations now take a `baseUrl` parameter as input.
 
 A new interface `SingleThreaded` has been added. This empty interface can be implemented to mark a component as not-threadsafe. When the CSS starts in multithreaded mode, it will error and halt if any SingleThreaded components are instantiated.
 

--- a/config/app/init/initializers/prefilled-root.json
+++ b/config/app/init/initializers/prefilled-root.json
@@ -17,7 +17,10 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/prefilled",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": { "@type": "HandlebarsTemplateEngine" }
+          "templateEngine": {
+            "@type": "HandlebarsTemplateEngine",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+          }
         },
         "args_storageKey": "rootInitialized",
         "args_storage": { "@id": "urn:solid-server:default:SetupStorage" }

--- a/config/app/init/initializers/root.json
+++ b/config/app/init/initializers/root.json
@@ -17,7 +17,10 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/empty",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": { "@type": "HandlebarsTemplateEngine" }
+          "templateEngine": {
+            "@type": "HandlebarsTemplateEngine",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+          }
         },
         "args_storageKey": "rootInitialized",
         "args_storage": { "@id": "urn:solid-server:default:SetupStorage" }

--- a/config/app/setup/handlers/setup.json
+++ b/config/app/setup/handlers/setup.json
@@ -62,7 +62,10 @@
         "@type": "TemplatedResourcesGenerator",
         "templateFolder": "@css:templates/root/empty",
         "factory": { "@type": "ExtensionBasedMapperFactory" },
-        "templateEngine": { "@type": "HandlebarsTemplateEngine" }
+        "templateEngine": {
+          "@type": "HandlebarsTemplateEngine",
+          "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+        }
       },
       "args_storageKey": "rootInitialized",
       "args_storage": { "@id": "urn:solid-server:default:SetupStorage" }

--- a/config/app/setup/handlers/setup.json
+++ b/config/app/setup/handlers/setup.json
@@ -27,12 +27,14 @@
             {
               "comment": "Renders the main setup template.",
               "@type": "EjsTemplateEngine",
-              "template": "@css:templates/setup/index.html.ejs"
+              "template": "@css:templates/setup/index.html.ejs",
+              "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
             },
             {
               "comment": "Will embed the result of the first engine into the main HTML template.",
               "@type": "EjsTemplateEngine",
-              "template": "@css:templates/main.html.ejs"
+              "template": "@css:templates/main.html.ejs",
+              "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
             }
           ]
         }

--- a/config/http/static/default.json
+++ b/config/http/static/default.json
@@ -6,6 +6,7 @@
       "@id": "urn:solid-server:default:StaticAssetHandler",
       "@type": "StaticAssetHandler",
       "options_expires": 86400,
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
       "assets": [
         {
           "StaticAssetHandler:_assets_key": "/favicon.ico",

--- a/config/identity/access/initializers/idp.json
+++ b/config/identity/access/initializers/idp.json
@@ -17,7 +17,10 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/empty",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": { "@type": "HandlebarsTemplateEngine" }
+          "templateEngine": {
+            "@type": "HandlebarsTemplateEngine",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+          }
         },
         "args_storageKey": "idpContainerInitialized",
         "args_storage": { "@id": "urn:solid-server:default:SetupStorage" }

--- a/config/identity/access/initializers/well-known.json
+++ b/config/identity/access/initializers/well-known.json
@@ -17,7 +17,10 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/empty",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": { "@type": "HandlebarsTemplateEngine" }
+          "templateEngine": {
+            "@type": "HandlebarsTemplateEngine",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+          }
         },
         "args_storageKey": "wellKnownContainerInitialized",
         "args_storage": { "@id": "urn:solid-server:default:SetupStorage" }

--- a/config/identity/handler/interaction/routes/forgot-password.json
+++ b/config/identity/handler/interaction/routes/forgot-password.json
@@ -17,7 +17,8 @@
         "args_accountStore": { "@id": "urn:solid-server:auth:password:AccountStore" },
         "args_templateEngine": {
           "@type": "EjsTemplateEngine",
-          "template": "@css:templates/identity/email-password/reset-password-email.html.ejs"
+          "template": "@css:templates/identity/email-password/reset-password-email.html.ejs",
+          "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
         },
         "args_emailSender": { "@id": "urn:solid-server:default:EmailSender" },
         "args_resetRoute": { "@id": "urn:solid-server:auth:password:ResetPasswordRoute" }

--- a/config/identity/handler/interaction/views/html.json
+++ b/config/identity/handler/interaction/views/html.json
@@ -12,12 +12,14 @@
         "engines": [
           {
             "comment": "Will be called with specific templates to generate HTML snippets.",
-            "@type": "EjsTemplateEngine"
+            "@type": "EjsTemplateEngine",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
           },
           {
             "comment": "Will embed the result of the first engine into the main HTML template.",
             "@type": "EjsTemplateEngine",
-            "template": "@css:templates/main.html.ejs"
+            "template": "@css:templates/main.html.ejs",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
           }
         ]
       },

--- a/config/identity/pod/pod-generators/templated.json
+++ b/config/identity/pod/pod-generators/templated.json
@@ -16,6 +16,7 @@
           }
         ]
       },
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
       "configStorage": { "@id": "urn:solid-server:default:PodConfigurationStorage" }
     }
   ]

--- a/config/identity/pod/resource-generators/templated.json
+++ b/config/identity/pod/resource-generators/templated.json
@@ -10,7 +10,8 @@
         "@type": "ExtensionBasedMapperFactory"
       },
       "templateEngine": {
-        "@type": "HandlebarsTemplateEngine"
+        "@type": "HandlebarsTemplateEngine",
+        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
       }
     }
   ]

--- a/config/util/representation-conversion/converters/dynamic-json-template.json
+++ b/config/util/representation-conversion/converters/dynamic-json-template.json
@@ -12,12 +12,14 @@
         "engines": [
           {
             "comment": "Will be called with specific templates to generate HTML snippets.",
-            "@type": "EjsTemplateEngine"
+            "@type": "EjsTemplateEngine",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
           },
           {
             "comment": "Will embed the result of the first engine into the main HTML template.",
             "@type": "EjsTemplateEngine",
-            "template": "@css:templates/main.html.ejs"
+            "template": "@css:templates/main.html.ejs",
+            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
           }
         ]
       }

--- a/config/util/representation-conversion/converters/errors.json
+++ b/config/util/representation-conversion/converters/errors.json
@@ -13,7 +13,10 @@
       "comment": "Converts an error into a Markdown description of its details.",
       "@id": "urn:solid-server:default:ErrorToTemplateConverter",
       "@type": "ErrorToTemplateConverter",
-      "templateEngine": { "@type": "HandlebarsTemplateEngine" }
+      "templateEngine": {
+        "@type": "HandlebarsTemplateEngine",
+        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+      }
     }
   ]
 }

--- a/config/util/representation-conversion/converters/markdown.json
+++ b/config/util/representation-conversion/converters/markdown.json
@@ -7,7 +7,8 @@
       "@type": "MarkdownToHtmlConverter",
       "templateEngine": {
         "@type": "EjsTemplateEngine",
-        "template": "@css:templates/main.html.ejs"
+        "template": "@css:templates/main.html.ejs",
+        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
       }
     },
     {

--- a/config/util/representation-conversion/converters/markdown.json
+++ b/config/util/representation-conversion/converters/markdown.json
@@ -17,7 +17,8 @@
       "@type": "ContainerToTemplateConverter",
       "templateEngine": {
         "@type": "HandlebarsTemplateEngine",
-        "template": "@css:templates/container.md.hbs"
+        "template": "@css:templates/container.md.hbs",
+        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
       },
       "contentType": "text/markdown",
       "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" }

--- a/config/util/representation-conversion/default.json
+++ b/config/util/representation-conversion/default.json
@@ -7,7 +7,8 @@
     "css:config/util/representation-conversion/converters/form-to-json.json",
     "css:config/util/representation-conversion/converters/markdown.json",
     "css:config/util/representation-conversion/converters/quad-to-rdf.json",
-    "css:config/util/representation-conversion/converters/rdf-to-quad.json"
+    "css:config/util/representation-conversion/converters/rdf-to-quad.json",
+    "css:config/util/variables/default.json"
   ],
   "@graph": [
     {

--- a/config/util/representation-conversion/default.json
+++ b/config/util/representation-conversion/default.json
@@ -7,8 +7,7 @@
     "css:config/util/representation-conversion/converters/form-to-json.json",
     "css:config/util/representation-conversion/converters/markdown.json",
     "css:config/util/representation-conversion/converters/quad-to-rdf.json",
-    "css:config/util/representation-conversion/converters/rdf-to-quad.json",
-    "css:config/util/variables/default.json"
+    "css:config/util/representation-conversion/converters/rdf-to-quad.json"
   ],
   "@graph": [
     {

--- a/src/pods/generate/TemplatedPodGenerator.ts
+++ b/src/pods/generate/TemplatedPodGenerator.ts
@@ -31,6 +31,7 @@ export class TemplatedPodGenerator implements PodGenerator {
   private readonly variableHandler: VariableHandler;
   private readonly configStorage: KeyValueStorage<string, unknown>;
   private readonly configTemplatePath: string;
+  private readonly baseUrl: string;
 
   /**
    * @param storeFactory - Factory used for Components.js instantiation.
@@ -39,10 +40,11 @@ export class TemplatedPodGenerator implements PodGenerator {
    * @param configTemplatePath - Where to find the configuration templates.
    */
   public constructor(storeFactory: ComponentsJsFactory, variableHandler: VariableHandler,
-    configStorage: KeyValueStorage<string, unknown>, configTemplatePath?: string) {
+    configStorage: KeyValueStorage<string, unknown>, baseUrl: string, configTemplatePath?: string) {
     this.storeFactory = storeFactory;
     this.variableHandler = variableHandler;
     this.configStorage = configStorage;
+    this.baseUrl = baseUrl;
     this.configTemplatePath = configTemplatePath ?? DEFAULT_CONFIG_PATH;
   }
 
@@ -75,7 +77,11 @@ export class TemplatedPodGenerator implements PodGenerator {
     variables[TEMPLATE_VARIABLE.templateConfig] = joinFilePath(this.configTemplatePath, settings.template);
 
     const store: ResourceStore =
-      await this.storeFactory.generate(variables[TEMPLATE_VARIABLE.templateConfig]!, TEMPLATE.ResourceStore, variables);
+      await this.storeFactory.generate(
+        variables[TEMPLATE_VARIABLE.templateConfig]!,
+        TEMPLATE.ResourceStore,
+        { ...variables, 'urn:solid-server:default:variable:baseUrl': this.baseUrl },
+      );
     this.logger.debug(`Generating store ${identifier.path} with variables ${JSON.stringify(variables)}`);
 
     // Store the variables permanently

--- a/src/server/middleware/StaticAssetHandler.ts
+++ b/src/server/middleware/StaticAssetHandler.ts
@@ -36,18 +36,17 @@ export class StaticAssetHandler extends HttpHandler {
 
     for (const [ url, path ] of Object.entries(assets)) {
       this.mappings[url.replace(/^\//u, rootPath)] = resolveAssetPath(path);
-      this.logger.debug(url.replace(/^\//u, rootPath));
     }
-    this.pathMatcher = this.createPathMatcher(assets);
+    this.pathMatcher = this.createPathMatcher();
     this.expires = Number.isInteger(options.expires) ? Math.max(0, options.expires!) : 0;
   }
 
   /**
    * Creates a regular expression that matches the URL paths.
    */
-  private createPathMatcher(assets: Record<string, string>): RegExp {
+  private createPathMatcher(): RegExp {
     // Sort longest paths first to ensure the longest match has priority
-    const paths = Object.keys(assets)
+    const paths = Object.keys(this.mappings)
       .sort((pathA, pathB): number => pathB.length - pathA.length);
 
     // Collect regular expressions for files and folders separately

--- a/src/server/middleware/StaticAssetHandler.ts
+++ b/src/server/middleware/StaticAssetHandler.ts
@@ -29,11 +29,14 @@ export class StaticAssetHandler extends HttpHandler {
    *  where URL paths ending in a slash are interpreted as entire folders.
    * @param options - Cache expiration time in seconds.
    */
-  public constructor(assets: Record<string, string>, options: { expires?: number } = {}) {
+  public constructor(assets: Record<string, string>, baseUrl: string, options: { expires?: number } = {}) {
     super();
     this.mappings = {};
+    const rootPath = new URL(baseUrl).pathname;
+
     for (const [ url, path ] of Object.entries(assets)) {
-      this.mappings[url] = resolveAssetPath(path);
+      this.mappings[url.replace(/^\//u, rootPath)] = resolveAssetPath(path);
+      this.logger.debug(url.replace(/^\//u, rootPath));
     }
     this.pathMatcher = this.createPathMatcher(assets);
     this.expires = Number.isInteger(options.expires) ? Math.max(0, options.expires!) : 0;

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -98,7 +98,7 @@ export function ensureLeadingSlash(path: string): string {
 }
 
 /**
- * Makes sure the input path has no slashes at the end.
+ * Makes sure the input path has no slashes at the beginning.
  *
  * @param path - Path to check.
  *

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -98,6 +98,17 @@ export function ensureLeadingSlash(path: string): string {
 }
 
 /**
+ * Makes sure the input path has no slashes at the end.
+ *
+ * @param path - Path to check.
+ *
+ * @returns The potentially changed path.
+ */
+export function trimLeadingSlashes(path: string): string {
+  return path.replace(/^\/+/u, '');
+}
+
+/**
  * Extracts the extension (without dot) from a path.
  * Custom function since `path.extname` does not work on all cases (e.g. ".acl")
  * @param path - Input path to parse.

--- a/src/util/templates/EjsTemplateEngine.ts
+++ b/src/util/templates/EjsTemplateEngine.ts
@@ -11,7 +11,7 @@ import Dict = NodeJS.Dict;
  */
 export class EjsTemplateEngine<T extends Dict<any> = Dict<any>> implements TemplateEngine<T> {
   private readonly applyTemplate: Promise<TemplateFunction>;
-  private readonly rootPath: string;
+  private readonly baseUrl: string;
 
   /**
    * @param template - The default template @range {json}
@@ -19,7 +19,7 @@ export class EjsTemplateEngine<T extends Dict<any> = Dict<any>> implements Templ
   public constructor(baseUrl: string, template?: Template) {
     // EJS requires the `filename` parameter to be able to include partial templates
     const filename = getTemplateFilePath(template);
-    this.rootPath = new URL(baseUrl).pathname;
+    this.baseUrl = baseUrl;
 
     this.applyTemplate = readTemplate(template)
       .then((templateString: string): TemplateFunction => compile(templateString, { filename }));
@@ -28,10 +28,7 @@ export class EjsTemplateEngine<T extends Dict<any> = Dict<any>> implements Templ
   public async render(contents: T): Promise<string>;
   public async render<TCustom = T>(contents: TCustom, template: Template): Promise<string>;
   public async render<TCustom = T>(contents: TCustom, template?: Template): Promise<string> {
-    const options = { ...contents, filename: getTemplateFilePath(template), rootPath: this.rootPath };
-    return template ?
-      render(await readTemplate(template),
-        options) :
-      (await this.applyTemplate)(options);
+    const options = { ...contents, filename: getTemplateFilePath(template), baseUrl: this.baseUrl };
+    return template ? render(await readTemplate(template), options) : (await this.applyTemplate)(options);
   }
 }

--- a/src/util/templates/EjsTemplateEngine.ts
+++ b/src/util/templates/EjsTemplateEngine.ts
@@ -11,13 +11,16 @@ import Dict = NodeJS.Dict;
  */
 export class EjsTemplateEngine<T extends Dict<any> = Dict<any>> implements TemplateEngine<T> {
   private readonly applyTemplate: Promise<TemplateFunction>;
+  private readonly rootPath: string;
 
   /**
    * @param template - The default template @range {json}
    */
-  public constructor(template?: Template) {
+  public constructor(baseUrl: string, template?: Template) {
     // EJS requires the `filename` parameter to be able to include partial templates
     const filename = getTemplateFilePath(template);
+    this.rootPath = new URL(baseUrl).pathname;
+
     this.applyTemplate = readTemplate(template)
       .then((templateString: string): TemplateFunction => compile(templateString, { filename }));
   }
@@ -25,7 +28,10 @@ export class EjsTemplateEngine<T extends Dict<any> = Dict<any>> implements Templ
   public async render(contents: T): Promise<string>;
   public async render<TCustom = T>(contents: TCustom, template: Template): Promise<string>;
   public async render<TCustom = T>(contents: TCustom, template?: Template): Promise<string> {
-    const options = { ...contents, filename: getTemplateFilePath(template) };
-    return template ? render(await readTemplate(template), options) : (await this.applyTemplate)(options);
+    const options = { ...contents, filename: getTemplateFilePath(template), rootPath: this.rootPath };
+    return template ?
+      render(await readTemplate(template),
+        options) :
+      (await this.applyTemplate)(options);
   }
 }

--- a/src/util/templates/EjsTemplateEngine.ts
+++ b/src/util/templates/EjsTemplateEngine.ts
@@ -14,6 +14,7 @@ export class EjsTemplateEngine<T extends Dict<any> = Dict<any>> implements Templ
   private readonly baseUrl: string;
 
   /**
+   * @param baseUrl - Base URL of the server.
    * @param template - The default template @range {json}
    */
   public constructor(baseUrl: string, template?: Template) {

--- a/src/util/templates/HandlebarsTemplateEngine.ts
+++ b/src/util/templates/HandlebarsTemplateEngine.ts
@@ -12,6 +12,7 @@ import Dict = NodeJS.Dict;
 export class HandlebarsTemplateEngine<T extends Dict<any> = Dict<any>> implements TemplateEngine<T> {
   private readonly applyTemplate: Promise<TemplateDelegate>;
   private readonly baseUrl: string;
+
   /**
    * @param template - The default template @range {json}
    */

--- a/src/util/templates/HandlebarsTemplateEngine.ts
+++ b/src/util/templates/HandlebarsTemplateEngine.ts
@@ -11,11 +11,12 @@ import Dict = NodeJS.Dict;
  */
 export class HandlebarsTemplateEngine<T extends Dict<any> = Dict<any>> implements TemplateEngine<T> {
   private readonly applyTemplate: Promise<TemplateDelegate>;
-
+  private readonly baseUrl: string;
   /**
    * @param template - The default template @range {json}
    */
-  public constructor(template?: Template) {
+  public constructor(baseUrl: string, template?: Template) {
+    this.baseUrl = baseUrl;
     this.applyTemplate = readTemplate(template)
       .then((templateString: string): TemplateDelegate => compile(templateString));
   }
@@ -24,6 +25,6 @@ export class HandlebarsTemplateEngine<T extends Dict<any> = Dict<any>> implement
   public async render<TCustom = T>(contents: TCustom, template: Template): Promise<string>;
   public async render<TCustom = T>(contents: TCustom, template?: Template): Promise<string> {
     const applyTemplate = template ? compile(await readTemplate(template)) : await this.applyTemplate;
-    return applyTemplate(contents);
+    return applyTemplate({ ...contents, baseUrl: this.baseUrl });
   }
 }

--- a/src/util/templates/HandlebarsTemplateEngine.ts
+++ b/src/util/templates/HandlebarsTemplateEngine.ts
@@ -14,6 +14,7 @@ export class HandlebarsTemplateEngine<T extends Dict<any> = Dict<any>> implement
   private readonly baseUrl: string;
 
   /**
+   * @params baseUrl - Base URL of the server.
    * @param template - The default template @range {json}
    */
   public constructor(baseUrl: string, template?: Template) {

--- a/templates/config/defaults.json
+++ b/templates/config/defaults.json
@@ -3,7 +3,8 @@
   "import": [
     "css:config/util/auxiliary/acl.json",
     "css:config/util/index/default.json",
-    "css:config/util/representation-conversion/default.json"
+    "css:config/util/representation-conversion/default.json",
+    "css:config/util/variables/default.json"
   ],
   "@graph": [
     {

--- a/templates/main.html.ejs
+++ b/templates/main.html.ejs
@@ -4,8 +4,8 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title><%= extractTitle(htmlBody) %></title>
-  <link rel="stylesheet" href="/.well-known/css/styles/main.css" type="text/css">
-  <script type="text/javascript" src="/.well-known/css/scripts/util.js"></script>
+  <link rel="stylesheet" href="<%= rootPath -%>.well-known/css/styles/main.css" type="text/css">
+  <script type="text/javascript" src="<%= rootPath -%>.well-known/css/scripts/util.js"></script>
 </head>
 <body>
   <header>

--- a/templates/main.html.ejs
+++ b/templates/main.html.ejs
@@ -9,7 +9,7 @@
 </head>
 <body>
   <header>
-    <a href="/"><img src="/.well-known/css/images/solid.svg" alt="[Solid logo]" /></a>
+    <a href="<%= rootPath %>"><img src="<%= rootPath -%>.well-known/css/images/solid.svg" alt="[Solid logo]" /></a>
     <h1>Community Solid Server</h1>
   </header>
   <main>

--- a/templates/main.html.ejs
+++ b/templates/main.html.ejs
@@ -4,12 +4,12 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title><%= extractTitle(htmlBody) %></title>
-  <link rel="stylesheet" href="<%= rootPath -%>.well-known/css/styles/main.css" type="text/css">
-  <script type="text/javascript" src="<%= rootPath -%>.well-known/css/scripts/util.js"></script>
+  <link rel="stylesheet" href="<%= baseUrl -%>.well-known/css/styles/main.css" type="text/css">
+  <script type="text/javascript" src="<%= baseUrl -%>.well-known/css/scripts/util.js"></script>
 </head>
 <body>
   <header>
-    <a href="<%= rootPath %>"><img src="<%= rootPath -%>.well-known/css/images/solid.svg" alt="[Solid logo]" /></a>
+    <a href="<%= baseUrl %>"><img src="<%= baseUrl -%>.well-known/css/images/solid.svg" alt="[Solid logo]" /></a>
     <h1>Community Solid Server</h1>
   </header>
   <main>

--- a/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
+++ b/test/unit/pods/generate/TemplatedResourcesGenerator.test.ts
@@ -48,7 +48,7 @@ async function genToArray<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 describe('A TemplatedResourcesGenerator', (): void => {
   const rootFilePath = '/templates/pod';
   // Using handlebars engine since it's smaller than any possible dummy
-  const generator = new TemplatedResourcesGenerator(rootFilePath, new DummyFactory(), new HandlebarsTemplateEngine());
+  const generator = new TemplatedResourcesGenerator(rootFilePath, new DummyFactory(), new HandlebarsTemplateEngine('http://test.com/'));
   let cache: { data: any };
   const template = '<{{webId}}> a <http://xmlns.com/foaf/0.1/Person>.';
   const location = { path: 'http://test.com/alice/' };

--- a/test/unit/server/middleware/StaticAssetHandler.test.ts
+++ b/test/unit/server/middleware/StaticAssetHandler.test.ts
@@ -20,7 +20,7 @@ describe('A StaticAssetHandler', (): void => {
     '/foo/bar/folder1/': '/assets/folders/1/',
     '/foo/bar/folder2/': '/assets/folders/2',
     '/foo/bar/folder2/subfolder/': '/assets/folders/3',
-  });
+  }, 'http://localhost:3000');
 
   afterEach(jest.clearAllMocks);
 
@@ -217,7 +217,7 @@ describe('A StaticAssetHandler', (): void => {
     jest.spyOn(Date, 'now').mockReturnValue(0);
     const cachedHandler = new StaticAssetHandler({
       '/foo/bar/style': '/assets/styles/bar.css',
-    }, {
+    }, 'http://localhost:3000', {
       expires: 86400,
     });
     const request = { method: 'GET', url: '/foo/bar/style' };

--- a/test/unit/util/templates/EjsTemplateEngine.test.ts
+++ b/test/unit/util/templates/EjsTemplateEngine.test.ts
@@ -11,7 +11,7 @@ describe('A EjsTemplateEngine', (): void => {
   let templateEngine: EjsTemplateEngine;
 
   beforeEach((): void => {
-    templateEngine = new EjsTemplateEngine(defaultTemplate);
+    templateEngine = new EjsTemplateEngine('http://localhost:3000', defaultTemplate);
   });
 
   it('uses the default template when no template was passed.', async(): Promise<void> => {

--- a/test/unit/util/templates/HandlebarsTemplateEngine.test.ts
+++ b/test/unit/util/templates/HandlebarsTemplateEngine.test.ts
@@ -10,7 +10,7 @@ describe('A HandlebarsTemplateEngine', (): void => {
   let templateEngine: HandlebarsTemplateEngine;
 
   beforeEach((): void => {
-    templateEngine = new HandlebarsTemplateEngine(template);
+    templateEngine = new HandlebarsTemplateEngine('http://localhost:3000/', template);
   });
 
   it('uses the default template when no template was passed.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

#1110 

#### ✍️ Description

- Added baseUrl as constructor parameter to the `EjsTemplateEngine` (+ changed configs to pass that variable)
- Engine will now extract path from the baseUrl and pass this as `rootPath` variable to templates
- Templates use the `rootPath` variable instead of `/` root
- `StaticAssetHandler` is also passed baseUrl variable, the url paths passed to it from config are then also prepended with the `rootPath` extracted from baseUrl (root `/` replace with `rootPath`)

Perhaps there is a better way of passing this `baseUrl` or better yet `rootPath` variable directly or is this fine?

#### Standing issues
**Failing integration test**
Right now  the `integration/DynamicPodTests` are failing... probably because of the config changes, though I can't seem to pinpoint the exact problem.

For example, output of one test:
```
  ● A dynamic pod server with template config memory.json › should not be able to create a pod with the same name.

    expect(received).resolves.toContain(expected) // indexOf

    Expected substring: "There already is a pod at http://localhost:6002/alice/"
    Received string:    "{\"name\":\"ConflictHttpError\",\"message\":\"There already is a folder that corresponds to http://localhost:6002/alice/\",\"statusCode\":409,\"errorCode\":\"H409\",\"stack\":\"ConflictHttpError: There already is a folder that corresponds to http://localhost:6002/alice/\\n    at RootFilePathHandler.handle (/home/jveessen/solid/CommunitySolidServer/src/pods/generate/variables/RootFilePathHandler.ts:29:13)\\n    at async Promise.all (index 1)\\n    at TemplatedPodGenerator.generate (/home/jveessen/solid/CommunitySolidServer/src/pods/generate/TemplatedPodGenerator.ts:59:5)\\n    at ConfigPodManager.createPod (/home/jveessen/solid/CommunitySolidServer/src/pods/ConfigPodManager.ts:44:19)\\n    at RegistrationManager.register (/home/jveessen/solid/CommunitySolidServer/src/identity/interaction/email-password/util/RegistrationManager.ts:216:9)\\n    at RegistrationHandler.handlePost (/home/jveessen/solid/CommunitySolidServer/src/identity/interaction/email-password/handler/RegistrationHandler.ts:43:21)\\n    at LocationInteractionHandler.handle (/home/jveessen/solid/CommunitySolidServer/src/identity/interaction/LocationInteractionHandler.ts:39:14)\\n    at ControlHandler.handle (/home/jveessen/solid/CommunitySolidServer/src/identity/interaction/ControlHandler.ts:34:20)\\n    at IdentityProviderHttpHand[CommunitySolidServer]: update status from run "all-tests-1": 261 files
```

**Target branch**
Also I initially started this branch from `main` as I though it was just a fix, but having to change constructor args and configs I think this is breaking so probably have to rebase to `versions/5.0.0`

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
