### PR TITLE
chore(deps): bump componentsjs from 5.1.0 to 5.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5906,9 +5906,9 @@
       "dev": true
     },
     "node_modules/componentsjs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.1.0.tgz",
-      "integrity": "sha512-Ev2xgnBub9NEIa6Yt9fz48TvUBceO2IE9CqxE9jtujAHplyk+0PxIBaGeTaD1tVK+DrtK5Gs5ChcTKfdDY2hMA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.2.0.tgz",
+      "integrity": "sha512-ZOMwhYh5knlaYRfrPyhP2u4F62WNkswTbT48bw6V/f1u7vqXVc5dNcKSxMpyxdOBGVZbydq9XOuoK1KlHCDKGw==",
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",
@@ -20742,9 +20742,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.1.0.tgz",
-      "integrity": "sha512-Ev2xgnBub9NEIa6Yt9fz48TvUBceO2IE9CqxE9jtujAHplyk+0PxIBaGeTaD1tVK+DrtK5Gs5ChcTKfdDY2hMA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.2.0.tgz",
+      "integrity": "sha512-ZOMwhYh5knlaYRfrPyhP2u4F62WNkswTbT48bw6V/f1u7vqXVc5dNcKSxMpyxdOBGVZbydq9XOuoK1KlHCDKGw==",
       "requires": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "arrayify-stream": "^2.0.0",
     "async-lock": "^1.3.0",
     "bcrypt": "^5.0.1",
-    "componentsjs": "^5.1.0",
+    "componentsjs": "^5.2.0",
     "cors": "^2.8.5",
     "cross-fetch": "^3.1.5",
     "ejs": "^3.1.6",

--- a/test/integration/RedisLocker.test.ts
+++ b/test/integration/RedisLocker.test.ts
@@ -5,7 +5,7 @@ import type { App } from '../../src';
 import type { RedisLocker } from '../../src/util/locking/RedisLocker';
 import type { RedisReadWriteLock, RedisResourceLock } from '../../src/util/locking/scripts/RedisLuaScripts';
 import { REDIS_LUA_SCRIPTS } from '../../src/util/locking/scripts/RedisLuaScripts';
-import { describeIf, flushPromises, getPort } from '../util/Util';
+import { describeIf, getPort } from '../util/Util';
 import { getDefaultVariables, getTestConfigPath, instantiateFromConfig } from './Config';
 /**
  * Test the general functionality of the server using a RedisLocker with Read-Write strategy.
@@ -190,65 +190,47 @@ describeIf('docker', 'A server with a RedisLocker', (): void => {
 
     it('can acquire the same readLock simultaneously.', async(): Promise<void> => {
       let res = '';
-      const emitter = new EventEmitter();
-      const unlocks = [ 0, 1, 2 ].map((num): Promise<any> =>
-        new Promise<any>((resolve): any => emitter.on(`release${num}`, resolve)));
+      let countdown = 3;
+      const releaseSignal = new EventEmitter();
+      releaseSignal.on('countdown', (): void => {
+        countdown -= 1;
+        // Start releasing locks after 3 inits of the promises below
+        if (countdown === 0) {
+          [ 1, 0, 2 ].forEach((num): unknown => releaseSignal.emit(`release${num}`));
+        }
+      });
       const promises = [ 0, 1, 2 ].map((num): Promise<any> =>
-        locker.withReadLock(identifier, async(): Promise<number> => {
+        locker.withReadLock(identifier, async(): Promise<void> => {
           res += `l${num}`;
-          await unlocks[num];
+          await new Promise<void>((resolve): any => {
+            releaseSignal.on(`release${num}`, resolve);
+            releaseSignal.emit('countdown');
+          });
           res += `r${num}`;
-          return num;
         }));
 
-      await flushPromises();
-
-      emitter.emit('release1');
-      await flushPromises();
-      await expect(promises[1]).resolves.toBe(1);
-      emitter.emit('release0');
-      await flushPromises();
-      await expect(promises[0]).resolves.toBe(0);
-      emitter.emit('release2');
-      await flushPromises();
-      await expect(promises[2]).resolves.toBe(2);
-
-      expect(res).toContain('l0l1l2');
-      expect(res).toContain('r1r0r2');
+      await Promise.all(promises);
+      expect(res).toBe('l0l1l2r1r0r2');
     });
 
     it('cannot acquire the same writeLock simultaneously.', async(): Promise<void> => {
       let res = '';
-      const emitter = new EventEmitter();
-      const unlocks = [ 0, 1, 2 ].map((num): Promise<any> =>
-        new Promise<any>((resolve): any => emitter.on(`release${num}`, resolve)));
-      const promises = [ 0, 1, 2 ].map((num): Promise<any> =>
-        locker.withWriteLock(identifier, async(): Promise<number> => num));
 
-      const l1 = promises[1].then(async(): Promise<void> => {
-        res += 'l1';
-        await unlocks[1];
-        res += 'r1';
-      });
-      const l0 = promises[0].then(async(): Promise<void> => {
+      await expect(locker.withWriteLock(identifier, async(): Promise<void> => {
         res += 'l0';
-        await unlocks[0];
+        await expect(locker.withWriteLock(identifier, (): void => {
+          res += 'l1';
+          res += 'r1';
+        })).rejects.toThrow();
         res += 'r0';
-      });
-      const l2 = promises[2].then(async(): Promise<void> => {
+      })).resolves.toBeUndefined();
+
+      await expect(locker.withWriteLock(identifier, async(): Promise<void> => {
         res += 'l2';
-        await unlocks[2];
         res += 'r2';
-      });
+      })).resolves.toBeUndefined();
 
-      emitter.emit('release1');
-      emitter.emit('release0');
-      emitter.emit('release2');
-      await Promise.all([ l0, l1, l2 ]);
-
-      expect(res).toContain('l0r0');
-      expect(res).toContain('l1r1');
-      expect(res).toContain('l2r2');
+      expect(res).toBe('l0r0l2r2');
     });
   });
 

--- a/test/integration/config/server-redis-lock.json
+++ b/test/integration/config/server-redis-lock.json
@@ -47,7 +47,7 @@
     {
       "@id": "urn:solid-server:default:RedisLocker",
       "@type": "RedisLocker",
-      "attemptSettings_retryCount": 29,
+      "attemptSettings_retryCount": 1,
       "attemptSettings_retryDelay": 100,
       "attemptSettings_retryJitter": 0
     }


### PR DESCRIPTION
#### 📁 Related issues

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose
-->
#1182 

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->
Fixes default CLI values being converted to strings, by updating the Components.js dependency to version 5.2.0 (which includes [PR 95](https://github.com/LinkedSoftwareDependencies/Components.js/pull/95)).

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
