### PR TITLE
fix: remove workaround for cli parameters being turned into string

### DIFF
--- a/src/init/cluster/ClusterManager.ts
+++ b/src/init/cluster/ClusterManager.ts
@@ -49,12 +49,8 @@ export class ClusterManager {
   private readonly workers: number;
   private readonly clusterMode: ClusterMode;
 
-  public constructor(workers: number | string) {
+  public constructor(workers: number) {
     const cores = cpus().length;
-    // Workaround for https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1182
-    if (typeof workers === 'string') {
-      workers = Number.parseInt(workers, 10);
-    }
 
     if (workers <= -cores) {
       throw new InternalServerError('Invalid workers value (should be in the interval ]-num_cores, +∞).');

--- a/test/unit/init/cluster/ClusterManager.test.ts
+++ b/test/unit/init/cluster/ClusterManager.test.ts
@@ -30,7 +30,7 @@ describe('A ClusterManager', (): void => {
   });
 
   it('can handle workers input as string.', (): void => {
-    const cm = new ClusterManager('4');
+    const cm = new ClusterManager(4);
     expect(cm.isSingleThreaded()).toBeFalsy();
   });
 
@@ -46,14 +46,14 @@ describe('A ClusterManager', (): void => {
   });
 
   it('errors on invalid workers amount.', (): void => {
-    expect((): ClusterManager => new ClusterManager('10')).toBeDefined();
-    expect((): ClusterManager => new ClusterManager('2')).toBeDefined();
-    expect((): ClusterManager => new ClusterManager('1')).toBeDefined();
-    expect((): ClusterManager => new ClusterManager('0')).toBeDefined();
-    expect((): ClusterManager => new ClusterManager('-1')).toBeDefined();
-    expect((): ClusterManager => new ClusterManager('-5')).toBeDefined();
-    expect((): ClusterManager => new ClusterManager('-6')).toThrow('Invalid workers value');
-    expect((): ClusterManager => new ClusterManager('-10')).toThrow('Invalid workers value');
+    expect((): ClusterManager => new ClusterManager(10)).toBeDefined();
+    expect((): ClusterManager => new ClusterManager(2)).toBeDefined();
+    expect((): ClusterManager => new ClusterManager(1)).toBeDefined();
+    expect((): ClusterManager => new ClusterManager(0)).toBeDefined();
+    expect((): ClusterManager => new ClusterManager(-1)).toBeDefined();
+    expect((): ClusterManager => new ClusterManager(-5)).toBeDefined();
+    expect((): ClusterManager => new ClusterManager(-6)).toThrow('Invalid workers value');
+    expect((): ClusterManager => new ClusterManager(-10)).toThrow('Invalid workers value');
   });
 
   it('has an isPrimary() that works.', (): void => {


### PR DESCRIPTION
Now that [PR1333](https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1333) has been merged and thus #1182 has been fixed, the signature of ClusterManager's constructor no longer needs to account for `workers` of type `string`.