### PR TITLE
Use encrypted field to check for TLS

### DIFF
--- a/src/http/UnsecureWebSocketsProtocol.ts
+++ b/src/http/UnsecureWebSocketsProtocol.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import type { TLSSocket } from 'tls';
 import type { WebSocket } from 'ws';
 import { getLoggerFor } from '../logging/LogUtil';
 import type { HttpRequest } from '../server/HttpRequest';
@@ -47,7 +48,7 @@ class WebSocketListener extends EventEmitter {
     // Store the HTTP host and protocol
     const forwarded = parseForwarded(headers);
     this.host = forwarded.host ?? headers.host ?? 'localhost';
-    this.protocol = forwarded.proto === 'https' || (socket as any).secure ? 'https:' : 'http:';
+    this.protocol = forwarded.proto === 'https' || (socket as TLSSocket).encrypted ? 'https:' : 'http:';
   }
 
   private stop(): void {

--- a/src/http/UnsecureWebSocketsProtocol.ts
+++ b/src/http/UnsecureWebSocketsProtocol.ts
@@ -92,10 +92,10 @@ class WebSocketListener extends EventEmitter {
       // Resolve and verify the URL
       const resolved = new URL(path, `${this.protocol}${this.host}`);
       if (resolved.host !== this.host) {
-        throw new Error(`Mismatched host: ${resolved.host} instead of ${this.host}`);
+        throw new Error(`Mismatched host: expected ${this.host} but got ${resolved.host}`);
       }
       if (resolved.protocol !== this.protocol) {
-        throw new Error(`Mismatched protocol: ${resolved.protocol} instead of ${this.protocol}`);
+        throw new Error(`Mismatched protocol: expected ${this.protocol} but got ${resolved.protocol}`);
       }
       // Subscribe to the URL
       const url = resolved.href;

--- a/test/unit/http/UnsecureWebSocketsProtocol.test.ts
+++ b/test/unit/http/UnsecureWebSocketsProtocol.test.ts
@@ -101,7 +101,7 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
       it('send an error message.', (): void => {
         expect(webSocket.messages).toHaveLength(1);
         expect(webSocket.messages.shift())
-          .toBe('error Mismatched host: wrong.example instead of mypod.example');
+          .toBe('error Mismatched host: expected mypod.example but got wrong.example');
       });
     });
 
@@ -113,7 +113,7 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
       it('send an error message.', (): void => {
         expect(webSocket.messages).toHaveLength(1);
         expect(webSocket.messages.shift())
-          .toBe('error Mismatched protocol: http: instead of https:');
+          .toBe('error Mismatched protocol: expected https: but got http:');
       });
     });
   });

--- a/test/unit/http/UnsecureWebSocketsProtocol.test.ts
+++ b/test/unit/http/UnsecureWebSocketsProtocol.test.ts
@@ -25,7 +25,7 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
           'sec-websocket-protocol': 'solid-0.1, other/1.0.0',
         },
         socket: {
-          secure: true,
+          encrypted: true,
         },
       } as any as HttpRequest;
       await protocol.handle({ webSocket, upgradeRequest } as any);


### PR DESCRIPTION
When debugging with @timbl, we noticed that I had used the wrong property name.
This one is correct: https://nodejs.org/api/tls.html#tlssocketencrypted
Tested on a live instance and adjusted unit tests.