### PR TITLE
fix: rdf convertors should not read or write plain JSON

### DIFF
--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -13,7 +13,10 @@ import type { RepresentationConverterArgs } from './RepresentationConverter';
  */
 export class RdfToQuadConverter extends BaseTypedRepresentationConverter {
   public constructor() {
-    super(rdfParser.getContentTypes(), INTERNAL_QUADS);
+    const inputTypes = rdfParser.getContentTypes()
+      // ContentType application/json MAY NOT be converted to Quad.
+      .then((types): string[] => types.filter((type): boolean => type !== 'application/json'));
+    super(inputTypes, INTERNAL_QUADS);
   }
 
   public async handle({ representation, identifier }: RepresentationConverterArgs): Promise<Representation> {

--- a/test/unit/storage/conversion/RdfToQuadConverter.test.ts
+++ b/test/unit/storage/conversion/RdfToQuadConverter.test.ts
@@ -18,10 +18,15 @@ describe('A RdfToQuadConverter', (): void => {
   const identifier: ResourceIdentifier = { path: 'path' };
 
   it('supports serializing as quads.', async(): Promise<void> => {
-    const types = await rdfParser.getContentTypes();
-    for (const type of types) {
+    const types = rdfParser.getContentTypes()
+      .then((inputTypes): string[] => inputTypes.filter((type): boolean => type !== 'application/json'));
+    for (const type of await types) {
       await expect(converter.getOutputTypes(type)).resolves.toEqual({ [INTERNAL_QUADS]: 1 });
     }
+  });
+
+  it('may not handle application/json to quad conversion.', async(): Promise<void> => {
+    await expect(converter.getOutputTypes('application/json')).resolves.toEqual({ });
   });
 
   it('can handle turtle to quad conversions.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

* #1242 

#### ✍️ Description

This PR fixes the outstanding issue #1242. This filters out the `application/json` as an input type of the RdfToQuadConverter as suggested. The given reproducer works now and outputs this:

```bash
npm start
echo '{}' | curl -T - -H "Content-Type: application/json" http://localhost:3000/test
curl -H "Accept: text/turtle" http://localhost:3000/test
```
```rdf
<b0> <http://purl.org/dc/terms/title> "NotImplementedHttpError";
    <http://purl.org/dc/terms/description> "No conversion path could be made from application/json to text/turtle:1,internal/*:0.";       
    <urn:npm:solid:community-server:error:stack> "NotImplementedHttpError: No conversion path could be made from application/json to text/turtle:1,internal/*:0.\n    at ChainedConverter.generatePath (C:\\Users\\tdupont\\Workspaces\\CommunitySolidServer\\dist\\storage\\conversion\\ChainedConverter.js:103:19)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)\n    at async ChainedConverter.handle (C:\\Users\\tdupont\\Workspaces\\CommunitySolidServer\\dist\\storage\\conversion\\ChainedConverter.js:49:23)\n    at async C:\\Users\\tdupont\\Workspaces\\CommunitySolidServer\\dist\\storage\\LockingResourceStore.js:70:34\n    at async runWithTimeout (C:\\Users\\tdupont\\Workspaces\\CommunitySolidServer\\dist\\util\\locking\\WrappedExpiringReadWriteLocker.js:51:24)\n    at async GreedyReadWriteLocker.withReadLock (C:\\Users\\tdupont\\Workspaces\\CommunitySolidServer\\dist\\util\\locking\\GreedyReadWriteLocker.js:35:20)".
```

The test cases have also been updated to reflect this change.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
