### PR TITLE
feat: add test phase for docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and export to docker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: "Test docker image 'latest'"
+        run: |
+          docker run --rm solidproject/community-server:latest --version
+      - name: "Test docker image 'edge'"
+        run: |
+          docker run --rm solidproject/community-server:edge --version
       - name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -221,8 +233,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and export to docker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: "Test docker image 'next'"
+        run: |
+          docker run --rm solidproject/community-server:next --version
       - name: Build and push
-        id: docker_build
         uses: docker/build-push-action@v3
         with:
           context: .


### PR DESCRIPTION
### Related issue

*  #643

### Description

This PR adds an intermediate stage to the CI pipelines. Instead of build-and-push behaviour, it will now follow build-test-push behaviour.

This happens by first loading the generated images in the local docker repository, then trying to successfully start one of those built images (`latest` and `edge` for the main branch, `next` for the versions branch)

If that doesn't return an error, it can continue by pushing the images to the Docker Hub.

See also here: https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md