### PR TITLE
chore(deps): bump @solid/access-token-verifier from 2.0.0 to 2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@comunica/query-sparql": "^2.2.1",
         "@rdfjs/types": "^1.1.0",
-        "@solid/access-token-verifier": "^2.0.0",
+        "@solid/access-token-verifier": "^2.0.3",
         "@types/async-lock": "^1.1.3",
         "@types/bcrypt": "^5.0.0",
         "@types/cors": "^2.8.12",
@@ -35,7 +35,7 @@
         "arrayify-stream": "^2.0.0",
         "async-lock": "^1.3.0",
         "bcrypt": "^5.0.1",
-        "componentsjs": "^5.1.0",
+        "componentsjs": "^5.2.0",
         "cors": "^2.8.5",
         "cross-fetch": "^3.1.5",
         "ejs": "^3.1.6",
@@ -3727,13 +3727,13 @@
       }
     },
     "node_modules/@solid/access-token-verifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-2.0.0.tgz",
-      "integrity": "sha512-KW+lRj384Z1Cvff1UrPVz2g2usmuM44QuAsDoXSV1GI8jv+6/vLWBpGK8igt7Ac2D/24d+Ksq5yj2IvqxXojsA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-2.0.3.tgz",
+      "integrity": "sha512-4mOE7av85m7Wl8cR0N2ocG+Jrx8dQSSTUk2Qt/75KDsCrBHRiG8nUyOQmkZsWPB+deqn5SAnl9Qjg0dMLfKkyA==",
       "dependencies": {
-        "jose": "^4.7.0",
+        "jose": "^4.8.1",
         "lru-cache": "^6.0.0",
-        "n3": "^1.16.1",
+        "n3": "^1.16.2",
         "node-fetch": "^2.6.7",
         "ts-guards": "^0.5.1"
       }
@@ -11855,9 +11855,9 @@
       "dev": true
     },
     "node_modules/n3": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.1.tgz",
-      "integrity": "sha512-XhCtfs9pR8TRydTRHdy7arkeJlLB2NscJix6NMe4eP+3RLWv7bxusECt2gNmmRGKvII5j+Pzl+Fx8Ny0NX3UNg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.2.tgz",
+      "integrity": "sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==",
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -19011,13 +19011,13 @@
       }
     },
     "@solid/access-token-verifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-2.0.0.tgz",
-      "integrity": "sha512-KW+lRj384Z1Cvff1UrPVz2g2usmuM44QuAsDoXSV1GI8jv+6/vLWBpGK8igt7Ac2D/24d+Ksq5yj2IvqxXojsA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@solid/access-token-verifier/-/access-token-verifier-2.0.3.tgz",
+      "integrity": "sha512-4mOE7av85m7Wl8cR0N2ocG+Jrx8dQSSTUk2Qt/75KDsCrBHRiG8nUyOQmkZsWPB+deqn5SAnl9Qjg0dMLfKkyA==",
       "requires": {
-        "jose": "^4.7.0",
+        "jose": "^4.8.1",
         "lru-cache": "^6.0.0",
-        "n3": "^1.16.1",
+        "n3": "^1.16.2",
         "node-fetch": "^2.6.7",
         "ts-guards": "^0.5.1"
       }
@@ -25287,9 +25287,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.1.tgz",
-      "integrity": "sha512-XhCtfs9pR8TRydTRHdy7arkeJlLB2NscJix6NMe4eP+3RLWv7bxusECt2gNmmRGKvII5j+Pzl+Fx8Ny0NX3UNg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.2.tgz",
+      "integrity": "sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==",
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "dependencies": {
     "@comunica/query-sparql": "^2.2.1",
     "@rdfjs/types": "^1.1.0",
-    "@solid/access-token-verifier": "^2.0.0",
+    "@solid/access-token-verifier": "^2.0.3",
     "@types/async-lock": "^1.1.3",
     "@types/bcrypt": "^5.0.0",
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
#### 📁 Related issues

The iat claim check might be too strict, see: https://gitter.im/CommunitySolidServer/community?at=62b98c670a522647988321e0.

See also: https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1012.

#### ✍️ Description

This PR bumps the access-token-verifier to version 2.0.3 which uses a default of 2 minutes maximum age for DPoP proofs and a clock tolerance of 2 minutes (for DPoP proofs issued in the future).

The latest DPoP draft is fine with so much lenience in checking iat claims:

> To limit this, servers MUST only accept DPoP proofs for a limited time after their creation (preferably only for a relatively brief period on the order of seconds or minutes).
> — https://datatracker.ietf.org/doc/html/draft-ietf-oauth-dpop-09#section-11.1


### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [x] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [x] any relevant documentation was updated to reflect the changes in this PR.

