### PR TITLE
docs: update docs links to new documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ Recipes for configuring the server can be found at [CommunitySolidServer/recipes
 The server allows writing and plugging in custom modules
 without altering its base source code.
 
-The [📗 API documentation](https://communitysolidserver.github.io/CommunitySolidServer/docs/) and
+The [📗 API documentation](https://communitysolidserver.github.io/CommunitySolidServer/latest/docs) and
 the [📐 architectural diagram](https://rubenverborgh.github.io/solid-server-architecture/solid-architecture-v1-3-0.pdf)
 can help you find your way.
 
 If you want to help out with server development,
-have a look at the [📓 user documentation](https://github.com/CommunitySolidServer/CommunitySolidServer/blob/main/documentation/) and
+have a look at the [📓 user documentation](https://communitysolidserver.github.io/CommunitySolidServer/) and
 [🛠️ good first issues](https://github.com/CommunitySolidServer/CommunitySolidServer/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,9 +7,9 @@ as described in https://github.com/inrupt/solid-client-authn-js/issues/2103.
 ## v4.0.0
 ### New features
 - The server can be started with a new parameter to automatically generate accounts and pods, 
-  for more info see [here](documentation/seeding-pods.md).
+  for more info see [here](https://communitysolidserver.github.io/CommunitySolidServer/4.0/seeding-pods/).
 - It is now possible to automate authentication requests using Client Credentials,
-  for more info see [here](documentation/client-credentials.md).
+  for more info see [here](https://communitysolidserver.github.io/CommunitySolidServer/4.0/client-credentials/).
 - A new `RedirectingHttpHandler` class has been added which can be used to redirect certain URLs.
 - A new default configuration `config/https-file-cli.json` 
   that can set the HTTPS parameters through the CLI has been added.


### PR DESCRIPTION
Just to update the links of README and RELEASE_NOTES to the new documentation site.