### PR TITLE
Feat: Store turtle prefixes in metadata when parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "pump": "^3.0.0",
         "punycode": "^2.1.1",
         "rdf-dereference": "^2.0.0",
-        "rdf-parse": "^2.0.0",
+        "rdf-parse": "^2.1.0",
         "rdf-serialize": "^2.0.0",
         "rdf-terms": "^1.7.1",
         "sparqlalgebrajs": "^4.0.2",
@@ -1061,71 +1061,161 @@
       }
     },
     "node_modules/@comunica/actor-abstract-mediatyped": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.2.0.tgz",
-      "integrity": "sha512-bzhameyDf+A3bEurlLYhmwozZFuimU9ugUu2nlFsdny7wi1d5koh7jlD1oJkoWhNLG2ZCMi7hjicEhHMheKx4A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.3.0.tgz",
+      "integrity": "sha512-by0CIAdvaxb4FoGcb62//dMOdRrdACLuGLwdRddt9I8qlvrSi830T91Xi7ydw59cA4ti8iGaGM+hDOhsuvzOFQ==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-mediatyped/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-abstract-parse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.2.0.tgz",
-      "integrity": "sha512-n36poF3yyCTUCIcp9Bjg01+VwuHVfIVUaw3WMF89s1XLKQO482OEushQ6oC5gj4z8jfgFXgqcg44y6Iev2610Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.3.0.tgz",
+      "integrity": "sha512-Quz3mWyaNNLft8tyGt3Yl6rhnfiS1R2Kt/+pgAfNwReOITI7LmtPkUNd3OpodJsMutTEtV3YFjnRHzvMVK4npA==",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0"
       }
     },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-abstract-parse/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
     "node_modules/@comunica/actor-abstract-path": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.2.0.tgz",
-      "integrity": "sha512-ai3bfrX3z6gKFD2WV9kv1+dqzKBlBlGEL9OMCdt/c//cBBWMwufWAS4lJj56AnmzAAmBOdZxtJBJQtzAR4rvYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.3.0.tgz",
+      "integrity": "sha512-MqwVu100pq1RtePn9wCGZefAMaLVqg7SdA3iIz12/wvc+UpDqYn0O4GpdlV2/h6ewL2EoA59wDmJXSePzpuuUw==",
       "dependencies": {
         "@comunica/bindings-factory": "^2.2.0",
-        "@comunica/bus-query-operation": "^2.2.0",
-        "@comunica/bus-rdf-join": "^2.2.0",
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0",
-        "@comunica/mediatortype-join-coefficients": "^2.2.0",
-        "@comunica/types": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.3.0",
+        "asynciterator": "^3.4.2",
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^4.0.0"
       }
     },
-    "node_modules/@comunica/actor-dereference-fallback": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.2.0.tgz",
-      "integrity": "sha512-LY9zt2y+CwPUyHrL13+mRSE5BpMN9Mb2dT3zo7eJ3gQcpldUykv/2Xof7Z5/b9wy6sD/jlJ+CODDFv6hVzRYyQ==",
+    "node_modules/@comunica/actor-abstract-path/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
+    },
+    "node_modules/@comunica/actor-dereference-fallback": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.3.0.tgz",
+      "integrity": "sha512-BQDmgYF9V/uutKwdDw4Ckv4SLCk4otN+spWCLnq6NiGzHppQr7MZ8mA4ZpY14XQak+q/1JgiM2P5kkv0wbKd/A==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-fallback/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-fallback/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/@comunica/actor-dereference-file": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.2.0.tgz",
-      "integrity": "sha512-hduhRGQSFkgJF0GNu1V+ObPdIj4I5YP8gugVOord1K/yxvN0k87Nwul9BgVpX3//zU/seoTz0jtnbL+4DvQWyQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.3.0.tgz",
+      "integrity": "sha512-ChosWxudOANaQX/XndOlO5io/6SPj5vWRs5S+TlU7o+dd8l2YbbS0aE1FWHR1BSHo19W7nka7GYFr3qhwtgNHQ==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/core": "^2.3.0"
       }
     },
-    "node_modules/@comunica/actor-dereference-http": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.2.0.tgz",
-      "integrity": "sha512-M9wyz/wOxUzAIIshkGGO7dolBMiYtztURM8iMcCXv070r4wtWVqd9gBFtuDzp6USlRAmDGo8W3c6roc/2DzNLA==",
+    "node_modules/@comunica/actor-dereference-file/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/bus-http": "^2.2.0",
-        "@comunica/core": "^2.2.0",
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-file/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
+    "node_modules/@comunica/actor-dereference-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.3.0.tgz",
+      "integrity": "sha512-Zo1uBlJHB3reR5fvAWmf3k2binlLxqjf+wzZc3INK2ZV2fkSDaRH81V/LRzHmEqA49P0/4gnf3Q6azYOc6W7cQ==",
+      "dependencies": {
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/core": "^2.3.0",
         "cross-fetch": "^3.0.5",
         "relative-to-absolute-iri": "^1.0.5",
         "stream-to-string": "^1.2.0"
       }
+    },
+    "node_modules/@comunica/actor-dereference-http/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-http/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/@comunica/actor-dereference-rdf-parse": {
       "version": "2.2.0",
@@ -1135,6 +1225,23 @@
         "@comunica/bus-dereference-rdf": "^2.2.0",
         "@comunica/core": "^2.2.0"
       }
+    },
+    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-dereference-rdf-parse/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/@comunica/actor-hash-bindings-sha1": {
       "version": "2.2.0",
@@ -1146,6 +1253,18 @@
         "canonicalize": "^1.0.8",
         "hash.js": "^1.1.7",
         "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-hash-bindings-sha1/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-http-fetch": {
@@ -1160,6 +1279,23 @@
         "cross-fetch": "^3.0.5"
       }
     },
+    "node_modules/@comunica/actor-http-fetch/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-fetch/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
     "node_modules/@comunica/actor-http-proxy": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.2.0.tgz",
@@ -1170,6 +1306,18 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-time": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-http-proxy/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-init-query": {
@@ -1203,6 +1351,18 @@
         "yargs": "^17.1.1"
       }
     },
+    "node_modules/@comunica/actor-init-query/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.2.0.tgz",
@@ -1211,6 +1371,18 @@
         "@comunica/bus-optimize-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-optimize-query-operation-bgp-to-join/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-optimize-query-operation-join-connected": {
@@ -1223,6 +1395,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-optimize-query-operation-join-connected/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-operation-bgp-join": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.2.0.tgz",
@@ -1231,6 +1415,18 @@
         "@comunica/bus-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-bgp-join/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-operation-leftjoin": {
@@ -1246,6 +1442,55 @@
         "sparqlee": "^2.0.1"
       }
     },
+    "node_modules/@comunica/actor-query-operation-leftjoin/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-path-link": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.3.0.tgz",
+      "integrity": "sha512-F+S/WWM29w4/YfvMY6/Voi7CXELgOfAPRmIoBigu8mXr+Ue/vmOGVDxvMb7b/meWObxs6EdA3LaO5FGlU2/68w==",
+      "dependencies": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.3.0.tgz",
+      "integrity": "sha512-MHUdqzabvfnOqry/9GbC+WYeDXin4VW5aAzmYlAQCwcJ+QSNMTNfWBt4JmPzbi1CcFnPc/RO3qbkqlimeX2r/w==",
+      "dependencies": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-operation-values/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-parse-graphql": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.2.0.tgz",
@@ -1255,6 +1500,18 @@
         "@comunica/context-entries": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "graphql-to-sparql": "^3.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-parse-graphql/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-parse-sparql": {
@@ -1270,6 +1527,18 @@
         "sparqljs": "^3.4.1"
       }
     },
+    "node_modules/@comunica/actor-query-parse-sparql/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-result-serialize-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.2.0.tgz",
@@ -1281,6 +1550,18 @@
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*",
         "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-json/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-rdf": {
@@ -1296,6 +1577,18 @@
         "@comunica/types": "^2.2.0"
       }
     },
+    "node_modules/@comunica/actor-query-result-serialize-rdf/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-result-serialize-simple": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.2.0.tgz",
@@ -1306,6 +1599,18 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-simple/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-csv": {
@@ -1320,6 +1625,18 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-csv/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-result-serialize-sparql-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.2.0.tgz",
@@ -1330,6 +1647,18 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-json/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-tsv": {
@@ -1343,6 +1672,18 @@
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*",
         "rdf-string-ttl": "^1.1.0"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-tsv/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-sparql-xml": {
@@ -1359,6 +1700,18 @@
         "xml": "^1.0.1"
       }
     },
+    "node_modules/@comunica/actor-query-result-serialize-sparql-xml/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-result-serialize-stats": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.2.0.tgz",
@@ -1370,6 +1723,18 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-query-result-serialize-stats/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-query-result-serialize-table": {
@@ -1386,6 +1751,18 @@
         "rdf-terms": "^1.6.2"
       }
     },
+    "node_modules/@comunica/actor-query-result-serialize-table/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-query-result-serialize-tree": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.2.0.tgz",
@@ -1400,6 +1777,18 @@
         "sparqljson-to-tree": "^2.0.0"
       }
     },
+    "node_modules/@comunica/actor-query-result-serialize-tree/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.2.0.tgz",
@@ -1407,6 +1796,18 @@
       "dependencies": {
         "@comunica/bus-rdf-join-entries-sort": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-entries-sort-cardinality/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-hash": {
@@ -1420,6 +1821,18 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-hash/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-bind": {
@@ -1436,6 +1849,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-bind/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-join-inner-multi-empty": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.2.0.tgz",
@@ -1445,6 +1870,18 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "asynciterator": "^3.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-empty/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-multi-smallest": {
@@ -1461,6 +1898,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-join-inner-multi-smallest/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-join-inner-nestedloop": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.2.0.tgz",
@@ -1472,6 +1921,18 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-nestedloop/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-none": {
@@ -1487,6 +1948,18 @@
         "asynciterator": "^3.3.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-join-inner-none/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-join-inner-single": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.2.0.tgz",
@@ -1495,6 +1968,18 @@
         "@comunica/bus-rdf-join": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-join-coefficients": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-single/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-inner-symmetrichash": {
@@ -1508,6 +1993,18 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-inner-symmetrichash/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-minus-hash": {
@@ -1535,6 +2032,30 @@
         "rdf-string": "^1.5.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-join-minus-hash-undef/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-minus-hash/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-join-optional-bind": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.2.0.tgz",
@@ -1549,6 +2070,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-join-optional-bind/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-join-optional-nestedloop": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.2.0.tgz",
@@ -1558,6 +2091,18 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-join-optional-nestedloop/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting": {
@@ -1570,6 +2115,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-join-selectivity-variable-counting/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.2.0.tgz",
@@ -1577,6 +2134,18 @@
       "dependencies": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-allow-http-methods/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls": {
@@ -1591,6 +2160,18 @@
         "uritemplate": "0.3.4"
       }
     },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-controls/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.2.0.tgz",
@@ -1598,6 +2179,18 @@
       "dependencies": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-count/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
@@ -1609,6 +2202,18 @@
         "@comunica/core": "^2.2.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-metadata-extract-hydra-pagesize/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.2.0.tgz",
@@ -1616,6 +2221,18 @@
       "dependencies": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-patch-sparql-update/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted": {
@@ -1627,6 +2244,18 @@
         "@comunica/core": "^2.2.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-metadata-extract-put-accepted/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-metadata-extract-request-time": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.2.0.tgz",
@@ -1634,6 +2263,18 @@
       "dependencies": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-extract-request-time/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service": {
@@ -1646,6 +2287,18 @@
         "relative-to-absolute-iri": "^1.0.5"
       }
     },
+    "node_modules/@comunica/actor-rdf-metadata-extract-sparql-service/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-metadata-primary-topic": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.2.0.tgz",
@@ -1654,6 +2307,18 @@
         "@comunica/bus-rdf-metadata": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-metadata-primary-topic/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html": {
@@ -1678,6 +2343,18 @@
         "microdata-rdf-streaming-parser": "^1.2.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-parse-html-microdata/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-parse-html-rdfa": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.2.0.tgz",
@@ -1686,6 +2363,18 @@
         "@comunica/bus-rdf-parse-html": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-rdfa/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html-script": {
@@ -1699,6 +2388,30 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html-script/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-html/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-html/node_modules/domhandler": {
@@ -1759,6 +2472,18 @@
         "stream-to-string": "^1.2.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-parse-jsonld/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-parse-n3": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.2.0.tgz",
@@ -1768,6 +2493,18 @@
         "@comunica/core": "^2.2.0",
         "@types/n3": "^1.4.4",
         "n3": "^1.6.3"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-parse-n3/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-parse-rdfxml": {
@@ -1780,6 +2517,18 @@
         "rdfxml-streaming-parser": "^1.5.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-parse-rdfxml/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.2.0.tgz",
@@ -1790,6 +2539,18 @@
         "rdfa-streaming-parser": "^1.5.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-parse-xml-rdfa/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.2.0.tgz",
@@ -1797,6 +2558,18 @@
       "dependencies": {
         "@comunica/bus-rdf-resolve-hypermedia-links": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-next/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
@@ -1809,6 +2582,18 @@
         "@comunica/core": "^2.2.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-none": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.2.0.tgz",
@@ -1819,6 +2604,18 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "rdf-store-stream": "^1.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-none/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf": {
@@ -1838,6 +2635,18 @@
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-qpf/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql": {
@@ -1860,6 +2669,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-resolve-hypermedia-sparql/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.2.0.tgz",
@@ -1874,6 +2695,18 @@
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-federated/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
@@ -1903,6 +2736,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.2.0.tgz",
@@ -1912,6 +2757,18 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-serialize-jsonld": {
@@ -1925,6 +2782,18 @@
         "jsonld-streaming-serializer": "^1.3.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-serialize-jsonld/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-serialize-n3": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.2.0.tgz",
@@ -1936,6 +2805,18 @@
         "@types/n3": "^1.4.4",
         "n3": "^1.6.3",
         "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-serialize-n3/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
@@ -1952,6 +2833,18 @@
         "rdf-string-ttl": "^1.1.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.2.0.tgz",
@@ -1966,6 +2859,18 @@
         "cross-fetch": "^3.0.5"
       }
     },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-put-ldp/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-update-hypermedia-sparql": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.2.0.tgz",
@@ -1977,6 +2882,18 @@
         "fetch-sparql-endpoint": "^2.3.2",
         "rdf-string-ttl": "^1.1.0",
         "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-hypermedia-sparql/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/actor-rdf-update-quads-hypermedia": {
@@ -1995,6 +2912,18 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "node_modules/@comunica/actor-rdf-update-quads-hypermedia/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.2.0.tgz",
@@ -2006,6 +2935,18 @@
         "asynciterator": "^3.3.0",
         "rdf-data-factory": "^1.0.4",
         "rdf-string": "^1.5.0"
+      }
+    },
+    "node_modules/@comunica/actor-rdf-update-quads-rdfjs-store/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bindings-factory": {
@@ -2027,27 +2968,85 @@
         "@comunica/core": "^2.2.0"
       }
     },
-    "node_modules/@comunica/bus-dereference": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.2.0.tgz",
-      "integrity": "sha512-reaXX2neHO/QoaXJwXqUlJ/mgBY+8fLMo2W1J4mQzLNUnOTYsbGkp0OOUdZOUCNdjgmgpn9mi2mxtcJS20rxpQ==",
+    "node_modules/@comunica/bus-context-preprocess/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/actor-abstract-mediatyped": "^2.2.0",
-        "@comunica/actor-abstract-parse": "^2.2.0",
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.3.0.tgz",
+      "integrity": "sha512-0t7oFxmEx8WUkjtGGVOqWiOvqlJWByPA7cSKopLuhOuvlSJKxnXVjF8nn60rwq8lprnpfZ42sJ0GDN39HUMZVQ==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
       }
     },
     "node_modules/@comunica/bus-dereference-rdf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.2.0.tgz",
-      "integrity": "sha512-3rGk/zjiXEC2usqYzfGSqRz+RgEHkpCjflzNIJQHDEucCwZBzEfoxUB00QS1ZT6JOOKYm1WdW02DrwMrpXT+iw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.3.0.tgz",
+      "integrity": "sha512-yWpLhfYFwBhm3rTFSS9hX9b8JFFW9PNDp8QIncC7AQn5c2iOBkKkd4TCNd5f3d2nUTy4Xs/PTh0pJvB71a24kQ==",
       "dependencies": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/bus-rdf-parse": "^2.2.0",
-        "@comunica/core": "^2.2.0",
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
         "@rdfjs/types": "*"
       }
+    },
+    "node_modules/@comunica/bus-dereference-rdf/node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.3.0.tgz",
+      "integrity": "sha512-oUqn9oDp68bBnRMZ58JXu3VgZuVCv7/bVen8wApLGB+I2wMbBZ664p9c6clTn0LFyEGp8PtAFsNMSLIsEm+5Hg==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-dereference-rdf/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference-rdf/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
+    "node_modules/@comunica/bus-dereference/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-dereference/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/@comunica/bus-hash-bindings": {
       "version": "2.2.0",
@@ -2057,14 +3056,24 @@
         "@comunica/core": "^2.2.0"
       }
     },
-    "node_modules/@comunica/bus-http": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.2.0.tgz",
-      "integrity": "sha512-7yw9MfijbRsGQRTlDRwDuJkBlJBDJAdP2N1uS56My87ucgUv7MCVBx7nWeTm69TWMVE59onNBoVkBLP4IUm0Og==",
+    "node_modules/@comunica/bus-hash-bindings/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0",
-        "@types/readable-stream": "^2.3.11",
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-http": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.3.0.tgz",
+      "integrity": "sha512-UFwf0j6TlSFF3AMsw75rqalTDgDPvCnwfBOb134Kytbh2MwCP5/hK36mJnGiuxPCVTXrZ+lmpNmZK5yPB8XPRA==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
         "is-stream": "^2.0.0",
         "readable-web-to-node-stream": "^3.0.2",
         "web-streams-node": "^0.4.0"
@@ -2078,12 +3087,48 @@
         "@comunica/core": "^2.2.0"
       }
     },
+    "node_modules/@comunica/bus-http-invalidate/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-http/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-init": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.2.0.tgz",
       "integrity": "sha512-bm/xOYcCG80LscA+DDNPTmZNNNel+k8hGodn9NLRyogWLbcyllpieB7Ks307KehypUySG47YnLFcqEOjgCDzxQ==",
       "dependencies": {
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-init/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-optimize-query-operation": {
@@ -2096,20 +3141,43 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/bus-optimize-query-operation/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-query-operation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.2.0.tgz",
-      "integrity": "sha512-n66f92vvJegEki3rO+EPSIRkNd1yMd0j3RSv0bm1pneNYSAqetrD1J3JyryvH95Kgri9T15v5TMCWT1EZC9TCg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.3.0.tgz",
+      "integrity": "sha512-4s2NzrUCrFhM8tMpp0OYmfE2M2PqM0rSIOfHiqBG9nCmDERwWIRbRbU6E4VFBkxHXSc7rixtQrtcVOWw+YsMTg==",
       "dependencies": {
         "@comunica/bindings-factory": "^2.2.0",
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
         "@comunica/data-factory": "^2.0.1",
-        "@comunica/types": "^2.2.0",
+        "@comunica/types": "^2.3.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.3.0",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-operation/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-query-parse": {
@@ -2122,6 +3190,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/bus-query-parse/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-query-result-serialize": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.2.0.tgz",
@@ -2131,6 +3211,18 @@
         "@comunica/bus-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-query-result-serialize/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-rdf-join": {
@@ -2151,12 +3243,24 @@
       }
     },
     "node_modules/@comunica/bus-rdf-join-entries-sort": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.2.0.tgz",
-      "integrity": "sha512-mOyiELRyFd0ow7B/btI5MxbwqDGVq6qjckMr3VwUY6iKp/h0I6peEtLjQAlfpe3jkvP1mmu7sVd+vDRdleWMYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.3.0.tgz",
+      "integrity": "sha512-dsJUxkWAlFpEgni2FdVwDGCNtb9mWSvd4E2F+Mg3mjDs529cOHlC9fHEsz5SxQ0FnMDogN9F9wzPYnJJukQr5Q==",
       "dependencies": {
-        "@comunica/core": "^2.2.0",
-        "@comunica/types": "^2.2.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-entries-sort/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-rdf-join-selectivity": {
@@ -2167,6 +3271,30 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-accuracy": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join-selectivity/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-join/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-rdf-metadata": {
@@ -2187,6 +3315,30 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/@comunica/bus-rdf-metadata-extract/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-metadata/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-rdf-parse": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.2.0.tgz",
@@ -2205,6 +3357,30 @@
       "dependencies": {
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse-html/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-parse/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-rdf-resolve-hypermedia": {
@@ -2236,6 +3412,42 @@
         "@comunica/core": "^2.2.0"
       }
     },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links-queue/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia-links/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-resolve-hypermedia/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-rdf-resolve-quad-pattern": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.2.0.tgz",
@@ -2249,6 +3461,18 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
+    "node_modules/@comunica/bus-rdf-resolve-quad-pattern/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-rdf-serialize": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.2.0.tgz",
@@ -2259,6 +3483,18 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/@comunica/bus-rdf-serialize/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/bus-rdf-update-hypermedia": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.2.0.tgz",
@@ -2266,6 +3502,18 @@
       "dependencies": {
         "@comunica/bus-rdf-update-quads": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/bus-rdf-update-hypermedia/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/bus-rdf-update-quads": {
@@ -2283,27 +3531,41 @@
         "stream-to-string": "^1.2.0"
       }
     },
+    "node_modules/@comunica/bus-rdf-update-quads/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/config-query-sparql": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/config-query-sparql/-/config-query-sparql-2.2.0.tgz",
       "integrity": "sha512-kfW1MkWlQszhOuyeyIvewLve0MOh6zqH5BPbdR84Y84rN56eXyx2pRHm/fswGqsuGEW+G1u6nclxNyx+4wEZYA=="
     },
     "node_modules/@comunica/context-entries": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.2.0.tgz",
-      "integrity": "sha512-zZfqYjI5Xs5DJZM0ku0zIguQvoqR3LxxFJzALGnVgdkFHsJxVE1ARmb3YY8FliDE26xH7aQsuwz5VOg2URj24Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.3.0.tgz",
+      "integrity": "sha512-8WQVmldN6LyQoifLqOm+Oz4eL0mhGZXPMGX+nf5rJhDPelpywGasUNs6AITCcMkN0+2eliW0GEFmQbe0xtatrQ==",
       "dependencies": {
-        "@comunica/core": "^2.2.0",
-        "@comunica/types": "^2.2.0",
-        "jsonld-context-parser": "^2.1.5"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.1.5",
+        "sparqlalgebrajs": "^4.0.2"
       }
     },
-    "node_modules/@comunica/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-Uuj4fQP8gMtJr0ZQeLhhh4ul85tQAuaL9mtQUNEX74foWOMl6UJVV+aspGSIear3xQcqN4r5Oo9YWoKAB0OEKQ==",
+    "node_modules/@comunica/context-entries/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/types": "^2.2.0",
+        "@comunica/types": "^2.3.0",
         "immutable": "^4.0.0"
       },
       "engines": {
@@ -2319,43 +3581,60 @@
       }
     },
     "node_modules/@comunica/logger-pretty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.2.0.tgz",
-      "integrity": "sha512-hbxM9MhGLncak1I3BBKOKJ8pgAI0vlq8DV9DijummbufTzQjLVLlpCJb/6Skretx4Xd6QsoI5EdTf0b+r9hudQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.3.0.tgz",
+      "integrity": "sha512-1VoMQ0BhPnkew4prDa/AM4cvwOMuovEIpFF8/kOFTtQhb8SY+v+XaoV3ZqLxk11aRSHpvy0bCkawJR/BrKRc+g==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0"
       }
     },
     "node_modules/@comunica/logger-void": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.2.0.tgz",
-      "integrity": "sha512-oXRRhamRDn7rgTa8TDNuRrew1BCgOSiQsWuGapieHCk2uJ5unIHA6K+jL2lfBki4Z1MnBVMBtW5FlOfVsY0KyQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.3.0.tgz",
+      "integrity": "sha512-2C95ixrZSQvLTaoQPyyhKXWSbmkf3tizeKoy4lMHpUvp2kuL86G6WPD7Cb5QI/a+pwH5QSZtjvVRrVzRfz2++g==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0"
       }
     },
     "node_modules/@comunica/mediator-all": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.2.0.tgz",
-      "integrity": "sha512-CCrfrThtjz3Hl0cGlQHFC7SvkldUkjp/5txNVHwnIztzYCTbPIZCYKmSvB1T29tq9oPLHqTgnVlbwy4GVnbc/Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.3.0.tgz",
+      "integrity": "sha512-VmjdkWHyiRGfph/bI2JfNGqNJNc14NiH8fhPbm70eEF5ixmdi8n2NjYa0JIMwabHw1CWuNNfqdbfWuyICj1XnA==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediator-all/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/mediator-combine-pipeline": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.2.0.tgz",
-      "integrity": "sha512-P7GVVWHRzvYK5IU8SlTzqsPGYvdHsqcrSj7rR5hiNq1cpw8+Rs7OmVVL5n/P3xzxobTugFyQQue+tTpspppJKg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.3.0.tgz",
+      "integrity": "sha512-vwc5qLUVHgKAlCqcw2JckPaScpUEXFHN0tQ3oH1oFOHUUD0x8FTUIgki8HzveV45oVkmf9RphQJYZFslAbrDKQ==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
       }
     },
-    "node_modules/@comunica/mediator-combine-union": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.2.0.tgz",
-      "integrity": "sha512-LZNlN1C65orCHDiVElz4ZPI+lTDJV6V8DIrIcqI6Im93X287wVI5Se0oUTXfS6Ca+rcwAYTYpovnEeNCzZ3sNg==",
+    "node_modules/@comunica/mediator-combine-pipeline/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/mediator-join-coefficients-fixed": {
@@ -2375,20 +3654,16 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
-    "node_modules/@comunica/mediator-number": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.2.0.tgz",
-      "integrity": "sha512-jruiMyiCrwvx+BYt/8oug79KTUZfjbxT8Jl9XM1Hm/JgDFYuT0YF8Yosn0xRAk3mAk0lMHuOJYHkuzKMtoEukw==",
+    "node_modules/@comunica/mediator-join-coefficients-fixed/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
-      }
-    },
-    "node_modules/@comunica/mediator-race": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.2.0.tgz",
-      "integrity": "sha512-XJdMZT0+EnFPWFKLJvP6+LduAcLD2XO6M/nzR79Awck/UlvtAOBqmRzm3i7LKdPDNkfuG73fhjT2b3n8aC5xSw==",
-      "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/mediatortype-accuracy": {
@@ -2399,12 +3674,36 @@
         "@comunica/core": "^2.2.0"
       }
     },
+    "node_modules/@comunica/mediatortype-accuracy/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/@comunica/mediatortype-httprequests": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.2.0.tgz",
       "integrity": "sha512-mH3AWtjZJL9GOxjQcK2MfEjCWzH8fZEQdjkdhB1pRrxdq9e1a7c5hijUmsr3JQNgL13tk+MRiHLs/btyJXyj/w==",
       "dependencies": {
         "@comunica/core": "^2.2.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-httprequests/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@comunica/mediatortype-join-coefficients": {
@@ -2416,13 +3715,42 @@
         "@rdfjs/types": "*"
       }
     },
-    "node_modules/@comunica/mediatortype-time": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.2.0.tgz",
-      "integrity": "sha512-nEXU/KtDVIhfr1WSeMk3Q+WlRwedTO13Q+WXXCR3HUMBY05BqsJqmdXNcNFyoGgS4UH97v+ywKMVyWwBPTzo0g==",
+    "node_modules/@comunica/mediatortype-join-coefficients/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
+    },
+    "node_modules/@comunica/mediatortype-time": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.3.0.tgz",
+      "integrity": "sha512-zoM7TX7C7ncr2uTd/FvADK13wJqnSxqGdAUYch/+rhkQBIdZU/f/3a4JiJn7A8Vifuot2CJB7yrmuvMLsidOqQ==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/mediatortype-time/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/@comunica/query-sparql": {
       "version": "2.2.1",
@@ -2764,18 +4092,6 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
-    "node_modules/@comunica/query-sparql/node_modules/@comunica/actor-query-operation-path-link": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.2.0.tgz",
-      "integrity": "sha512-LUmo47ADoEXgS4hEoekiPzNR2skMboNP4M5jmdcsTu1wYRhOE0MWPDcjI7IcwLyZbaQv1ry7dCNvnDGUcwX3gg==",
-      "dependencies": {
-        "@comunica/actor-abstract-path": "^2.2.0",
-        "@comunica/bus-query-operation": "^2.2.0",
-        "@comunica/core": "^2.2.0",
-        "@comunica/types": "^2.2.0",
-        "sparqlalgebrajs": "^4.0.0"
-      }
-    },
     "node_modules/@comunica/query-sparql/node_modules/@comunica/actor-query-operation-path-nps": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.2.0.tgz",
@@ -3052,21 +4368,6 @@
         "sparqlalgebrajs": "^4.0.0"
       }
     },
-    "node_modules/@comunica/query-sparql/node_modules/@comunica/actor-query-operation-values": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.2.0.tgz",
-      "integrity": "sha512-9zyA7PdS06wWGMk6nG9Jaj/FdRYc2/DGzrmWB5++lMo4GQdJu+85kj/yLyW1WnVwmGHqYmKziarz5fqkIvJEmw==",
-      "dependencies": {
-        "@comunica/bindings-factory": "^2.2.0",
-        "@comunica/bus-query-operation": "^2.2.0",
-        "@comunica/core": "^2.2.0",
-        "@comunica/types": "^2.2.0",
-        "asynciterator": "^3.3.0",
-        "rdf-data-factory": "^1.1.0",
-        "rdf-string": "^1.5.0",
-        "sparqlalgebrajs": "^4.0.0"
-      }
-    },
     "node_modules/@comunica/query-sparql/node_modules/@comunica/actor-rdf-metadata-all": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.2.0.tgz",
@@ -3075,6 +4376,42 @@
         "@comunica/bus-rdf-metadata": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@comunica/query-sparql/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql/node_modules/@comunica/mediator-combine-union": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+      "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql/node_modules/@comunica/mediator-number": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.3.0.tgz",
+      "integrity": "sha512-LGo2czqXdfmyPpNcn6b7CdQw68KRew9hn6/gdX0PFVsk8FGEnTs0Uab7wUtPancqJFi/KpVMWKu8m3sfJ4dGMw==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/@comunica/query-sparql/node_modules/@comunica/mediator-race": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+      "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
       }
     },
     "node_modules/@comunica/runner": {
@@ -3103,14 +4440,38 @@
         "comunica-run": "bin/run.js"
       }
     },
-    "node_modules/@comunica/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-gAPmD/Oofn7BGISKO1pHEgekxbav7UxWFahZw7UFGm044xdpuum6huOfIYroXmKi/Ij1FVC5JOFUiqeztWMLXg==",
+    "node_modules/@comunica/runner-cli/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
       "dependencies": {
-        "@rdfjs/types": ">=1.1.0",
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/runner/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/@comunica/types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.3.0.tgz",
+      "integrity": "sha512-OqG+kP/RcDpNPg3Y85MZWCFuk7yPSpaUsX5TbuL3KSxSGd9gzXmh1pGX5a3ezAlYJh+rKuI+4gOxdQszCdB2kg==",
+      "dependencies": {
+        "@rdfjs/types": "*",
         "@types/yargs": "^17.0.2",
-        "asynciterator": "^3.3.0",
+        "asynciterator": "^3.4.2",
         "sparqlalgebrajs": "^4.0.0"
       }
     },
@@ -5155,9 +6516,9 @@
       "integrity": "sha512-8A7SkiisnEgME2zEedtDYPxUPzdv3x//E7n5IFktPAtMYSEAV7eNJF0rMwrVyUFj6d/8rgajLantbjcNRQYXIg=="
     },
     "node_modules/asynciterator": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.4.0.tgz",
-      "integrity": "sha512-jFuvnCHjUAyW33E3zpZhQxBM3SDuyxkDwtjhXD27WKwB/7UrZHaDAia7ZbqL94zLbUGhgxhO0vfopTLi7Jcrig=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.5.0.tgz",
+      "integrity": "sha512-CbnvkU50ZXNnVSPi/VUvzzjIJ128WNixWVBMY4j5yZwibSaIdGRirPplgtpJiOhmQyagFlPr1T6f5GmCiOg4dg=="
     },
     "node_modules/asyncjoin": {
       "version": "1.0.5",
@@ -13165,6 +14526,221 @@
         "rdf-dereference": "bin/Runner.js"
       }
     },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-http-proxy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.3.0.tgz",
+      "integrity": "sha512-zgjISdqHE8rwrk7d9z0+S3P47rQXv9o7bWe2RfGUZwExzLThSYb/W/jRdQ7xqBdKetEOg/J9tTfNGJXjlEb5DA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-time": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.3.0.tgz",
+      "integrity": "sha512-r4PgCyMc6cRU+EY9JVrTjIXQAnlca9mCCJsSfJi5ZMrw0kDemVTXbP5t2P+uYegCR8w1FIiydgPbkskmAj3iBg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "htmlparser2": "^7.0.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.3.0.tgz",
+      "integrity": "sha512-Bq1edaB+opRrNMJT33P8RoqafhBsq5O55oEL7+b8F/Cx0AqiYGVndz1vz91cBopxMStEHFsuAuqRHtP2hN0t8A==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "microdata-rdf-streaming-parser": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.3.0.tgz",
+      "integrity": "sha512-IXq1ahqy8PV4kA/39ZMCjqxRZNKsK8YUSc1aFV8jxNnPl6pp3YpQCeYh/BaW61gozd41hybl+nnF7dE3u3FRdw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.3.0.tgz",
+      "integrity": "sha512-0XRNkKPAJHpK9rp9V8Ls+/nwlFW3E8l9zUHvUCeRW3D2aLQ3yLQk10EfuhScd0ZZRZwp3+sPholLFoF+2nbFOQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.3.0.tgz",
+      "integrity": "sha512-2ddvd3VSBKNGU10F3+TY0TOoHWiuX8s1N5fW6ZCepliUmadyy2kt56GjQ9exunkRWNsP1g7e8j/Ub85EJ4qjrg==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-context-parser": "^2.1.5",
+        "jsonld-streaming-parser": "^2.4.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.3.0.tgz",
+      "integrity": "sha512-jBsaXm7OdSqM8+EyfLhcbu3TtJT3ozW1JagrqXxPBLV4GhgPnke4YA1mCZpVlYdZL36d5h3yjZjX0sgEhbg6qg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/n3": "^1.4.4",
+        "n3": "^1.6.3"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.3.0.tgz",
+      "integrity": "sha512-s8Of6sfqslH5bn4AG5SMX5RWiaJQt3ymnC4CTxMCKkuoUWxVFb/1l39zRzb+cqMiArl44p0VM1kbCtq+zgCC6A==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfxml-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.3.0.tgz",
+      "integrity": "sha512-ucYD1Jb4bCbTK6fF0wW7M4YcXHCH5nNzkKLhA/fz00QmKV2IFtLDcxezjbgCuBtlhKGdsNs1pLB2L/igibIL+w==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/bus-init": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.3.0.tgz",
+      "integrity": "sha512-YZ/kFFQ/JnjjAv4FlKNiuGttOJKSeUSvrQlvHUKPGEO0j3mgpaiHBJ9eD1WoRdnsZisSFoszCdbqoVRnRXWzOQ==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.3.0.tgz",
+      "integrity": "sha512-oUqn9oDp68bBnRMZ58JXu3VgZuVCv7/bVen8wApLGB+I2wMbBZ664p9c6clTn0LFyEGp8PtAFsNMSLIsEm+5Hg==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.3.0.tgz",
+      "integrity": "sha512-X1TBIK7d9zViRYCgv9taWXpxotPgh05GXFe+lms2oa2IpcbhdnfG2ujmiBTeja7BcDNJZfiNZiXRpd6kgnsjZg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/mediator-combine-union": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+      "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/mediator-number": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.3.0.tgz",
+      "integrity": "sha512-LGo2czqXdfmyPpNcn6b7CdQw68KRew9hn6/gdX0PFVsk8FGEnTs0Uab7wUtPancqJFi/KpVMWKu8m3sfJ4dGMw==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/@comunica/mediator-race": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+      "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/rdf-dereference/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+    },
     "node_modules/rdf-isomorphic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rdf-isomorphic/-/rdf-isomorphic-1.3.0.tgz",
@@ -13206,9 +14782,9 @@
       }
     },
     "node_modules/rdf-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.0.0.tgz",
-      "integrity": "sha512-ob/Paok5Kik74uPqWq8CWHUVt7xQ0e38oQbBU0ivBHbsF0a+rdvKhcgH/fY0YhXsU84rfZgiiwxguhBpEXoSew==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.1.0.tgz",
+      "integrity": "sha512-Ew0M3uokgtDr3YAJ77/Wcwxu1pRarFeR7dNAPFncpLfpmOhfh0UzYAhw1JRMyqNb4t0pIvB3qWHf5yDxy8upgQ==",
       "dependencies": {
         "@comunica/actor-http-fetch": "^2.0.1",
         "@comunica/actor-http-proxy": "^2.0.1",
@@ -13233,6 +14809,221 @@
         "@rdfjs/types": "*",
         "stream-to-string": "^1.2.0"
       }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-http-proxy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.3.0.tgz",
+      "integrity": "sha512-zgjISdqHE8rwrk7d9z0+S3P47rQXv9o7bWe2RfGUZwExzLThSYb/W/jRdQ7xqBdKetEOg/J9tTfNGJXjlEb5DA==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/mediatortype-time": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.3.0.tgz",
+      "integrity": "sha512-r4PgCyMc6cRU+EY9JVrTjIXQAnlca9mCCJsSfJi5ZMrw0kDemVTXbP5t2P+uYegCR8w1FIiydgPbkskmAj3iBg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "htmlparser2": "^7.0.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html-microdata": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.3.0.tgz",
+      "integrity": "sha512-Bq1edaB+opRrNMJT33P8RoqafhBsq5O55oEL7+b8F/Cx0AqiYGVndz1vz91cBopxMStEHFsuAuqRHtP2hN0t8A==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "microdata-rdf-streaming-parser": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html-rdfa": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.3.0.tgz",
+      "integrity": "sha512-IXq1ahqy8PV4kA/39ZMCjqxRZNKsK8YUSc1aFV8jxNnPl6pp3YpQCeYh/BaW61gozd41hybl+nnF7dE3u3FRdw==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-html-script": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.3.0.tgz",
+      "integrity": "sha512-0XRNkKPAJHpK9rp9V8Ls+/nwlFW3E8l9zUHvUCeRW3D2aLQ3yLQk10EfuhScd0ZZRZwp3+sPholLFoF+2nbFOQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/bus-rdf-parse-html": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "relative-to-absolute-iri": "^1.0.5"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-jsonld": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.3.0.tgz",
+      "integrity": "sha512-2ddvd3VSBKNGU10F3+TY0TOoHWiuX8s1N5fW6ZCepliUmadyy2kt56GjQ9exunkRWNsP1g7e8j/Ub85EJ4qjrg==",
+      "dependencies": {
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-context-parser": "^2.1.5",
+        "jsonld-streaming-parser": "^2.4.2",
+        "stream-to-string": "^1.2.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-n3": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.3.0.tgz",
+      "integrity": "sha512-jBsaXm7OdSqM8+EyfLhcbu3TtJT3ozW1JagrqXxPBLV4GhgPnke4YA1mCZpVlYdZL36d5h3yjZjX0sgEhbg6qg==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@types/n3": "^1.4.4",
+        "n3": "^1.6.3"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-rdfxml": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.3.0.tgz",
+      "integrity": "sha512-s8Of6sfqslH5bn4AG5SMX5RWiaJQt3ymnC4CTxMCKkuoUWxVFb/1l39zRzb+cqMiArl44p0VM1kbCtq+zgCC6A==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfxml-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/actor-rdf-parse-xml-rdfa": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.3.0.tgz",
+      "integrity": "sha512-ucYD1Jb4bCbTK6fF0wW7M4YcXHCH5nNzkKLhA/fz00QmKV2IFtLDcxezjbgCuBtlhKGdsNs1pLB2L/igibIL+w==",
+      "dependencies": {
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "rdfa-streaming-parser": "^1.5.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/bus-init": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.3.0.tgz",
+      "integrity": "sha512-YZ/kFFQ/JnjjAv4FlKNiuGttOJKSeUSvrQlvHUKPGEO0j3mgpaiHBJ9eD1WoRdnsZisSFoszCdbqoVRnRXWzOQ==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/bus-rdf-parse": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.3.0.tgz",
+      "integrity": "sha512-oUqn9oDp68bBnRMZ58JXu3VgZuVCv7/bVen8wApLGB+I2wMbBZ664p9c6clTn0LFyEGp8PtAFsNMSLIsEm+5Hg==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/bus-rdf-parse-html": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.3.0.tgz",
+      "integrity": "sha512-X1TBIK7d9zViRYCgv9taWXpxotPgh05GXFe+lms2oa2IpcbhdnfG2ujmiBTeja7BcDNJZfiNZiXRpd6kgnsjZg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/mediator-combine-union": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+      "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/mediator-number": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.3.0.tgz",
+      "integrity": "sha512-LGo2czqXdfmyPpNcn6b7CdQw68KRew9hn6/gdX0PFVsk8FGEnTs0Uab7wUtPancqJFi/KpVMWKu8m3sfJ4dGMw==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/@comunica/mediator-race": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+      "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/rdf-parse/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/rdf-quad": {
       "version": "1.5.0",
@@ -13261,6 +15052,77 @@
         "@rdfjs/types": "*",
         "stream-to-string": "^1.2.0"
       }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/actor-rdf-serialize-jsonld": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.3.0.tgz",
+      "integrity": "sha512-sGHFpdjNPJ9tObhQj5pr1gINTD+3o90EJSDLWbgeynpw6tcP/YeDMhovb2nQlUmPUirGfXexli7Gf4Mpjuo/EQ==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "jsonld-streaming-serializer": "^1.3.0"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/actor-rdf-serialize-n3": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.3.0.tgz",
+      "integrity": "sha512-+ayKoYsrGxwn6qcm+LqjOEwg9J7lia9/jM1olyd+I4JzPHHsSEt5bXGlcNZaQ6/J6TKlTzszD6drGiVwIfVF6A==",
+      "dependencies": {
+        "@comunica/bus-rdf-serialize": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "n3": "^1.6.3"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/bus-init": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.3.0.tgz",
+      "integrity": "sha512-YZ/kFFQ/JnjjAv4FlKNiuGttOJKSeUSvrQlvHUKPGEO0j3mgpaiHBJ9eD1WoRdnsZisSFoszCdbqoVRnRXWzOQ==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/bus-rdf-serialize": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.3.0.tgz",
+      "integrity": "sha512-Dfr+GBVidtMj46izZKI6MsTC7A3JQipRCzp2TTY3di8VRRctEmKQmLCpDUf9HSQ0thKb2j9waVfeIgfCjOQjBw==",
+      "dependencies": {
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+      "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+      "dependencies": {
+        "@comunica/types": "^2.3.0",
+        "immutable": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/mediator-combine-union": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+      "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/@comunica/mediator-race": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+      "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+      "dependencies": {
+        "@comunica/core": "^2.3.0"
+      }
+    },
+    "node_modules/rdf-serialize/node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
     },
     "node_modules/rdf-store-stream": {
       "version": "1.3.0",
@@ -16470,70 +18332,154 @@
       }
     },
     "@comunica/actor-abstract-mediatyped": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.2.0.tgz",
-      "integrity": "sha512-bzhameyDf+A3bEurlLYhmwozZFuimU9ugUu2nlFsdny7wi1d5koh7jlD1oJkoWhNLG2ZCMi7hjicEhHMheKx4A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.3.0.tgz",
+      "integrity": "sha512-by0CIAdvaxb4FoGcb62//dMOdRrdACLuGLwdRddt9I8qlvrSi830T91Xi7ydw59cA4ti8iGaGM+hDOhsuvzOFQ==",
       "requires": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-abstract-parse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.2.0.tgz",
-      "integrity": "sha512-n36poF3yyCTUCIcp9Bjg01+VwuHVfIVUaw3WMF89s1XLKQO482OEushQ6oC5gj4z8jfgFXgqcg44y6Iev2610Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.3.0.tgz",
+      "integrity": "sha512-Quz3mWyaNNLft8tyGt3Yl6rhnfiS1R2Kt/+pgAfNwReOITI7LmtPkUNd3OpodJsMutTEtV3YFjnRHzvMVK4npA==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/actor-abstract-path": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.2.0.tgz",
-      "integrity": "sha512-ai3bfrX3z6gKFD2WV9kv1+dqzKBlBlGEL9OMCdt/c//cBBWMwufWAS4lJj56AnmzAAmBOdZxtJBJQtzAR4rvYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-2.3.0.tgz",
+      "integrity": "sha512-MqwVu100pq1RtePn9wCGZefAMaLVqg7SdA3iIz12/wvc+UpDqYn0O4GpdlV2/h6ewL2EoA59wDmJXSePzpuuUw==",
       "requires": {
         "@comunica/bindings-factory": "^2.2.0",
-        "@comunica/bus-query-operation": "^2.2.0",
-        "@comunica/bus-rdf-join": "^2.2.0",
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0",
-        "@comunica/mediatortype-join-coefficients": "^2.2.0",
-        "@comunica/types": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.3.0",
+        "asynciterator": "^3.4.2",
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-dereference-fallback": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.2.0.tgz",
-      "integrity": "sha512-LY9zt2y+CwPUyHrL13+mRSE5BpMN9Mb2dT3zo7eJ3gQcpldUykv/2Xof7Z5/b9wy6sD/jlJ+CODDFv6hVzRYyQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.3.0.tgz",
+      "integrity": "sha512-BQDmgYF9V/uutKwdDw4Ckv4SLCk4otN+spWCLnq6NiGzHppQr7MZ8mA4ZpY14XQak+q/1JgiM2P5kkv0wbKd/A==",
       "requires": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/actor-dereference-file": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.2.0.tgz",
-      "integrity": "sha512-hduhRGQSFkgJF0GNu1V+ObPdIj4I5YP8gugVOord1K/yxvN0k87Nwul9BgVpX3//zU/seoTz0jtnbL+4DvQWyQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-file/-/actor-dereference-file-2.3.0.tgz",
+      "integrity": "sha512-ChosWxudOANaQX/XndOlO5io/6SPj5vWRs5S+TlU7o+dd8l2YbbS0aE1FWHR1BSHo19W7nka7GYFr3qhwtgNHQ==",
       "requires": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/core": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/actor-dereference-http": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.2.0.tgz",
-      "integrity": "sha512-M9wyz/wOxUzAIIshkGGO7dolBMiYtztURM8iMcCXv070r4wtWVqd9gBFtuDzp6USlRAmDGo8W3c6roc/2DzNLA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-dereference-http/-/actor-dereference-http-2.3.0.tgz",
+      "integrity": "sha512-Zo1uBlJHB3reR5fvAWmf3k2binlLxqjf+wzZc3INK2ZV2fkSDaRH81V/LRzHmEqA49P0/4gnf3Q6azYOc6W7cQ==",
       "requires": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/bus-http": "^2.2.0",
-        "@comunica/core": "^2.2.0",
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-http": "^2.3.0",
+        "@comunica/core": "^2.3.0",
         "cross-fetch": "^3.0.5",
         "relative-to-absolute-iri": "^1.0.5",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/actor-dereference-rdf-parse": {
@@ -16543,6 +18489,22 @@
       "requires": {
         "@comunica/bus-dereference-rdf": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/actor-hash-bindings-sha1": {
@@ -16555,6 +18517,17 @@
         "canonicalize": "^1.0.8",
         "hash.js": "^1.1.7",
         "rdf-string": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-http-fetch": {
@@ -16567,6 +18540,22 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-time": "^2.2.0",
         "cross-fetch": "^3.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/actor-http-proxy": {
@@ -16579,6 +18568,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-time": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-init-query": {
@@ -16610,6 +18610,17 @@
         "sparqlalgebrajs": "^4.0.0",
         "streamify-string": "^1.0.1",
         "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-optimize-query-operation-bgp-to-join": {
@@ -16620,6 +18631,17 @@
         "@comunica/bus-optimize-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-optimize-query-operation-join-connected": {
@@ -16630,6 +18652,17 @@
         "@comunica/bus-optimize-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-operation-bgp-join": {
@@ -16640,6 +18673,17 @@
         "@comunica/bus-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-operation-leftjoin": {
@@ -16653,6 +18697,53 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0",
         "sparqlee": "^2.0.1"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@comunica/actor-query-operation-path-link": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.3.0.tgz",
+      "integrity": "sha512-F+S/WWM29w4/YfvMY6/Voi7CXELgOfAPRmIoBigu8mXr+Ue/vmOGVDxvMb7b/meWObxs6EdA3LaO5FGlU2/68w==",
+      "requires": {
+        "@comunica/actor-abstract-path": "^2.3.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "sparqlalgebrajs": "^4.0.0"
+      }
+    },
+    "@comunica/actor-query-operation-values": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.3.0.tgz",
+      "integrity": "sha512-MHUdqzabvfnOqry/9GbC+WYeDXin4VW5aAzmYlAQCwcJ+QSNMTNfWBt4JmPzbi1CcFnPc/RO3qbkqlimeX2r/w==",
+      "requires": {
+        "@comunica/bindings-factory": "^2.2.0",
+        "@comunica/bus-query-operation": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "asynciterator": "^3.4.2",
+        "rdf-data-factory": "^1.1.0",
+        "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-parse-graphql": {
@@ -16664,6 +18755,17 @@
         "@comunica/context-entries": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "graphql-to-sparql": "^3.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-parse-sparql": {
@@ -16677,6 +18779,17 @@
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^4.0.0",
         "sparqljs": "^3.4.1"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-json": {
@@ -16690,6 +18803,17 @@
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*",
         "rdf-string": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-rdf": {
@@ -16703,6 +18827,17 @@
         "@comunica/bus-rdf-serialize": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-simple": {
@@ -16715,6 +18850,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-sparql-csv": {
@@ -16727,6 +18873,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-sparql-json": {
@@ -16739,6 +18896,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-sparql-tsv": {
@@ -16752,6 +18920,17 @@
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*",
         "rdf-string-ttl": "^1.1.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-sparql-xml": {
@@ -16766,6 +18945,17 @@
         "@rdfjs/types": "*",
         "@types/xml": "^1.0.2",
         "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-stats": {
@@ -16779,6 +18969,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-table": {
@@ -16793,6 +18994,17 @@
         "@rdfjs/types": "*",
         "rdf-data-factory": "^1.1.0",
         "rdf-terms": "^1.6.2"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-query-result-serialize-tree": {
@@ -16807,6 +19019,17 @@
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*",
         "sparqljson-to-tree": "^2.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-entries-sort-cardinality": {
@@ -16816,6 +19039,17 @@
       "requires": {
         "@comunica/bus-rdf-join-entries-sort": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-hash": {
@@ -16829,6 +19063,17 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-multi-bind": {
@@ -16843,6 +19088,17 @@
         "@comunica/core": "^2.2.0",
         "asynciterator": "^3.3.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-multi-empty": {
@@ -16854,6 +19110,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "asynciterator": "^3.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-multi-smallest": {
@@ -16868,6 +19135,17 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-nestedloop": {
@@ -16881,6 +19159,17 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-none": {
@@ -16894,6 +19183,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "asynciterator": "^3.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-single": {
@@ -16904,6 +19204,17 @@
         "@comunica/bus-rdf-join": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-join-coefficients": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-inner-symmetrichash": {
@@ -16917,6 +19228,17 @@
         "@comunica/mediatortype-join-coefficients": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-minus-hash": {
@@ -16929,6 +19251,17 @@
         "@comunica/types": "^2.2.0",
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-minus-hash-undef": {
@@ -16942,6 +19275,17 @@
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0",
         "rdf-string": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-optional-bind": {
@@ -16956,6 +19300,17 @@
         "@comunica/core": "^2.2.0",
         "asynciterator": "^3.3.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-optional-nestedloop": {
@@ -16967,6 +19322,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "asyncjoin": "^1.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-join-selectivity-variable-counting": {
@@ -16977,6 +19343,17 @@
         "@comunica/bus-rdf-join-selectivity": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-allow-http-methods": {
@@ -16986,6 +19363,17 @@
       "requires": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-controls": {
@@ -16998,6 +19386,17 @@
         "@rdfjs/types": "*",
         "@types/uritemplate": "^0.3.4",
         "uritemplate": "0.3.4"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-count": {
@@ -17007,6 +19406,17 @@
       "requires": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-hydra-pagesize": {
@@ -17016,6 +19426,17 @@
       "requires": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-patch-sparql-update": {
@@ -17025,6 +19446,17 @@
       "requires": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-put-accepted": {
@@ -17034,6 +19466,17 @@
       "requires": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-request-time": {
@@ -17043,6 +19486,17 @@
       "requires": {
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-extract-sparql-service": {
@@ -17053,6 +19507,17 @@
         "@comunica/bus-rdf-metadata-extract": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "relative-to-absolute-iri": "^1.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-metadata-primary-topic": {
@@ -17063,6 +19528,17 @@
         "@comunica/bus-rdf-metadata": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-html": {
@@ -17077,6 +19553,15 @@
         "htmlparser2": "^7.0.0"
       },
       "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
         "domhandler": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
@@ -17111,6 +19596,17 @@
         "@comunica/bus-rdf-parse-html": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "microdata-rdf-streaming-parser": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-html-rdfa": {
@@ -17121,6 +19617,17 @@
         "@comunica/bus-rdf-parse-html": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "rdfa-streaming-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-html-script": {
@@ -17134,6 +19641,17 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "relative-to-absolute-iri": "^1.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-jsonld": {
@@ -17149,6 +19667,17 @@
         "jsonld-context-parser": "^2.1.5",
         "jsonld-streaming-parser": "^2.4.2",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-n3": {
@@ -17160,6 +19689,17 @@
         "@comunica/core": "^2.2.0",
         "@types/n3": "^1.4.4",
         "n3": "^1.6.3"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-rdfxml": {
@@ -17170,6 +19710,17 @@
         "@comunica/bus-rdf-parse": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "rdfxml-streaming-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-parse-xml-rdfa": {
@@ -17180,6 +19731,17 @@
         "@comunica/bus-rdf-parse": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "rdfa-streaming-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-links-next": {
@@ -17189,6 +19751,17 @@
       "requires": {
         "@comunica/bus-rdf-resolve-hypermedia-links": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo": {
@@ -17199,6 +19772,17 @@
         "@comunica/bus-rdf-resolve-hypermedia-links": "^2.2.0",
         "@comunica/bus-rdf-resolve-hypermedia-links-queue": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-none": {
@@ -17211,6 +19795,17 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "rdf-store-stream": "^1.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-qpf": {
@@ -17230,6 +19825,17 @@
         "rdf-data-factory": "^1.0.3",
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-hypermedia-sparql": {
@@ -17250,6 +19856,17 @@
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
@@ -17266,6 +19883,17 @@
         "rdf-data-factory": "^1.0.3",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
@@ -17293,6 +19921,17 @@
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": {
@@ -17304,6 +19943,17 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
@@ -17315,6 +19965,17 @@
         "@comunica/bus-rdf-serialize": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "jsonld-streaming-serializer": "^1.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-serialize-n3": {
@@ -17328,6 +19989,17 @@
         "@types/n3": "^1.4.4",
         "n3": "^1.6.3",
         "rdf-string": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-update-hypermedia-patch-sparql-update": {
@@ -17342,6 +20014,17 @@
         "@comunica/types": "^2.2.0",
         "cross-fetch": "^3.0.5",
         "rdf-string-ttl": "^1.1.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-update-hypermedia-put-ldp": {
@@ -17356,6 +20039,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "cross-fetch": "^3.0.5"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-update-hypermedia-sparql": {
@@ -17369,6 +20063,17 @@
         "fetch-sparql-endpoint": "^2.3.2",
         "rdf-string-ttl": "^1.1.0",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-update-quads-hypermedia": {
@@ -17385,6 +20090,17 @@
         "@comunica/core": "^2.2.0",
         "@types/lru-cache": "^5.1.0",
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/actor-rdf-update-quads-rdfjs-store": {
@@ -17398,6 +20114,17 @@
         "asynciterator": "^3.3.0",
         "rdf-data-factory": "^1.0.4",
         "rdf-string": "^1.5.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bindings-factory": {
@@ -17417,28 +20144,83 @@
       "integrity": "sha512-PjYuWPX4KlkX80nQAC1rTssynkeY8jgpx2i5EO9IPpGCJpo0Zh80UqLOZFLIAI0tqE4YWEremFY3DNGZMrzNAw==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-dereference": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.2.0.tgz",
-      "integrity": "sha512-reaXX2neHO/QoaXJwXqUlJ/mgBY+8fLMo2W1J4mQzLNUnOTYsbGkp0OOUdZOUCNdjgmgpn9mi2mxtcJS20rxpQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference/-/bus-dereference-2.3.0.tgz",
+      "integrity": "sha512-0t7oFxmEx8WUkjtGGVOqWiOvqlJWByPA7cSKopLuhOuvlSJKxnXVjF8nn60rwq8lprnpfZ42sJ0GDN39HUMZVQ==",
       "requires": {
-        "@comunica/actor-abstract-mediatyped": "^2.2.0",
-        "@comunica/actor-abstract-parse": "^2.2.0",
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0"
+        "@comunica/actor-abstract-mediatyped": "^2.3.0",
+        "@comunica/actor-abstract-parse": "^2.3.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/bus-dereference-rdf": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.2.0.tgz",
-      "integrity": "sha512-3rGk/zjiXEC2usqYzfGSqRz+RgEHkpCjflzNIJQHDEucCwZBzEfoxUB00QS1ZT6JOOKYm1WdW02DrwMrpXT+iw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.3.0.tgz",
+      "integrity": "sha512-yWpLhfYFwBhm3rTFSS9hX9b8JFFW9PNDp8QIncC7AQn5c2iOBkKkd4TCNd5f3d2nUTy4Xs/PTh0pJvB71a24kQ==",
       "requires": {
-        "@comunica/bus-dereference": "^2.2.0",
-        "@comunica/bus-rdf-parse": "^2.2.0",
-        "@comunica/core": "^2.2.0",
+        "@comunica/bus-dereference": "^2.3.0",
+        "@comunica/bus-rdf-parse": "^2.3.0",
+        "@comunica/core": "^2.3.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/bus-rdf-parse": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.3.0.tgz",
+          "integrity": "sha512-oUqn9oDp68bBnRMZ58JXu3VgZuVCv7/bVen8wApLGB+I2wMbBZ664p9c6clTn0LFyEGp8PtAFsNMSLIsEm+5Hg==",
+          "requires": {
+            "@comunica/actor-abstract-mediatyped": "^2.3.0",
+            "@comunica/actor-abstract-parse": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/bus-hash-bindings": {
@@ -17447,19 +20229,39 @@
       "integrity": "sha512-9I9DCZXCu558ateA8/KG9YIpf+sI8rB1Lln0p7fuuZTu9jFfHzTZ0mlpuSV1AHwPhDhUZuo2y+mewoK0eLlDUg==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-http": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.2.0.tgz",
-      "integrity": "sha512-7yw9MfijbRsGQRTlDRwDuJkBlJBDJAdP2N1uS56My87ucgUv7MCVBx7nWeTm69TWMVE59onNBoVkBLP4IUm0Og==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-2.3.0.tgz",
+      "integrity": "sha512-UFwf0j6TlSFF3AMsw75rqalTDgDPvCnwfBOb134Kytbh2MwCP5/hK36mJnGiuxPCVTXrZ+lmpNmZK5yPB8XPRA==",
       "requires": {
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0",
-        "@types/readable-stream": "^2.3.11",
+        "@comunica/core": "^2.3.0",
         "is-stream": "^2.0.0",
         "readable-web-to-node-stream": "^3.0.2",
         "web-streams-node": "^0.4.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-http-invalidate": {
@@ -17468,6 +20270,17 @@
       "integrity": "sha512-CUW68VyjpJh5BkkLv+9WWJK3M7ZOx9p6KJvXOJkm5FFQTES39Cl9uRDdWTvNpkpZsJYegjzkSI5Y5Vy5GSUNQg==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-init": {
@@ -17476,6 +20289,17 @@
       "integrity": "sha512-bm/xOYcCG80LscA+DDNPTmZNNNel+k8hGodn9NLRyogWLbcyllpieB7Ks307KehypUySG47YnLFcqEOjgCDzxQ==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-optimize-query-operation": {
@@ -17486,22 +20310,43 @@
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-query-operation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.2.0.tgz",
-      "integrity": "sha512-n66f92vvJegEki3rO+EPSIRkNd1yMd0j3RSv0bm1pneNYSAqetrD1J3JyryvH95Kgri9T15v5TMCWT1EZC9TCg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-query-operation/-/bus-query-operation-2.3.0.tgz",
+      "integrity": "sha512-4s2NzrUCrFhM8tMpp0OYmfE2M2PqM0rSIOfHiqBG9nCmDERwWIRbRbU6E4VFBkxHXSc7rixtQrtcVOWw+YsMTg==",
       "requires": {
         "@comunica/bindings-factory": "^2.2.0",
-        "@comunica/context-entries": "^2.2.0",
-        "@comunica/core": "^2.2.0",
+        "@comunica/context-entries": "^2.3.0",
+        "@comunica/core": "^2.3.0",
         "@comunica/data-factory": "^2.0.1",
-        "@comunica/types": "^2.2.0",
+        "@comunica/types": "^2.3.0",
         "@rdfjs/types": "*",
-        "asynciterator": "^3.3.0",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-query-parse": {
@@ -17512,6 +20357,17 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-query-result-serialize": {
@@ -17523,6 +20379,17 @@
         "@comunica/bus-query-operation": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-join": {
@@ -17540,15 +20407,37 @@
         "rdf-data-factory": "^1.1.0",
         "rdf-string": "^1.5.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-join-entries-sort": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.2.0.tgz",
-      "integrity": "sha512-mOyiELRyFd0ow7B/btI5MxbwqDGVq6qjckMr3VwUY6iKp/h0I6peEtLjQAlfpe3jkvP1mmu7sVd+vDRdleWMYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.3.0.tgz",
+      "integrity": "sha512-dsJUxkWAlFpEgni2FdVwDGCNtb9mWSvd4E2F+Mg3mjDs529cOHlC9fHEsz5SxQ0FnMDogN9F9wzPYnJJukQr5Q==",
       "requires": {
-        "@comunica/core": "^2.2.0",
-        "@comunica/types": "^2.2.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-join-selectivity": {
@@ -17559,6 +20448,17 @@
         "@comunica/core": "^2.2.0",
         "@comunica/mediatortype-accuracy": "^2.2.0",
         "@comunica/types": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-metadata": {
@@ -17568,6 +20468,17 @@
       "requires": {
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-metadata-extract": {
@@ -17577,6 +20488,17 @@
       "requires": {
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-parse": {
@@ -17588,6 +20510,17 @@
         "@comunica/actor-abstract-parse": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-parse-html": {
@@ -17597,6 +20530,17 @@
       "requires": {
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia": {
@@ -17609,6 +20553,17 @@
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links": {
@@ -17617,6 +20572,17 @@
       "integrity": "sha512-7IHtO9OKZmaDO4aUs4DTpaei4lebjvPX06mNLh29Nn4hihSdZeoOzElSngEavk201bu05OcHujbpfMeMkT6z0w==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-resolve-hypermedia-links-queue": {
@@ -17626,6 +20592,17 @@
       "requires": {
         "@comunica/bus-rdf-resolve-hypermedia-links": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-resolve-quad-pattern": {
@@ -17639,6 +20616,17 @@
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0",
         "sparqlalgebrajs": "^4.0.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-serialize": {
@@ -17649,6 +20637,17 @@
         "@comunica/actor-abstract-mediatyped": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-update-hypermedia": {
@@ -17658,6 +20657,17 @@
       "requires": {
         "@comunica/bus-rdf-update-quads": "^2.2.0",
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/bus-rdf-update-quads": {
@@ -17673,6 +20683,17 @@
         "@rdfjs/types": "*",
         "asynciterator": "^3.3.0",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/config-query-sparql": {
@@ -17681,22 +20702,26 @@
       "integrity": "sha512-kfW1MkWlQszhOuyeyIvewLve0MOh6zqH5BPbdR84Y84rN56eXyx2pRHm/fswGqsuGEW+G1u6nclxNyx+4wEZYA=="
     },
     "@comunica/context-entries": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.2.0.tgz",
-      "integrity": "sha512-zZfqYjI5Xs5DJZM0ku0zIguQvoqR3LxxFJzALGnVgdkFHsJxVE1ARmb3YY8FliDE26xH7aQsuwz5VOg2URj24Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/context-entries/-/context-entries-2.3.0.tgz",
+      "integrity": "sha512-8WQVmldN6LyQoifLqOm+Oz4eL0mhGZXPMGX+nf5rJhDPelpywGasUNs6AITCcMkN0+2eliW0GEFmQbe0xtatrQ==",
       "requires": {
-        "@comunica/core": "^2.2.0",
-        "@comunica/types": "^2.2.0",
-        "jsonld-context-parser": "^2.1.5"
-      }
-    },
-    "@comunica/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-Uuj4fQP8gMtJr0ZQeLhhh4ul85tQAuaL9mtQUNEX74foWOMl6UJVV+aspGSIear3xQcqN4r5Oo9YWoKAB0OEKQ==",
-      "requires": {
-        "@comunica/types": "^2.2.0",
-        "immutable": "^4.0.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0",
+        "@rdfjs/types": "*",
+        "jsonld-context-parser": "^2.1.5",
+        "sparqlalgebrajs": "^4.0.2"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/data-factory": {
@@ -17708,43 +20733,58 @@
       }
     },
     "@comunica/logger-pretty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.2.0.tgz",
-      "integrity": "sha512-hbxM9MhGLncak1I3BBKOKJ8pgAI0vlq8DV9DijummbufTzQjLVLlpCJb/6Skretx4Xd6QsoI5EdTf0b+r9hudQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-pretty/-/logger-pretty-2.3.0.tgz",
+      "integrity": "sha512-1VoMQ0BhPnkew4prDa/AM4cvwOMuovEIpFF8/kOFTtQhb8SY+v+XaoV3ZqLxk11aRSHpvy0bCkawJR/BrKRc+g==",
       "requires": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0"
       }
     },
     "@comunica/logger-void": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.2.0.tgz",
-      "integrity": "sha512-oXRRhamRDn7rgTa8TDNuRrew1BCgOSiQsWuGapieHCk2uJ5unIHA6K+jL2lfBki4Z1MnBVMBtW5FlOfVsY0KyQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/logger-void/-/logger-void-2.3.0.tgz",
+      "integrity": "sha512-2C95ixrZSQvLTaoQPyyhKXWSbmkf3tizeKoy4lMHpUvp2kuL86G6WPD7Cb5QI/a+pwH5QSZtjvVRrVzRfz2++g==",
       "requires": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/types": "^2.3.0"
       }
     },
     "@comunica/mediator-all": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.2.0.tgz",
-      "integrity": "sha512-CCrfrThtjz3Hl0cGlQHFC7SvkldUkjp/5txNVHwnIztzYCTbPIZCYKmSvB1T29tq9oPLHqTgnVlbwy4GVnbc/Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-all/-/mediator-all-2.3.0.tgz",
+      "integrity": "sha512-VmjdkWHyiRGfph/bI2JfNGqNJNc14NiH8fhPbm70eEF5ixmdi8n2NjYa0JIMwabHw1CWuNNfqdbfWuyICj1XnA==",
       "requires": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/mediator-combine-pipeline": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.2.0.tgz",
-      "integrity": "sha512-P7GVVWHRzvYK5IU8SlTzqsPGYvdHsqcrSj7rR5hiNq1cpw8+Rs7OmVVL5n/P3xzxobTugFyQQue+tTpspppJKg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.3.0.tgz",
+      "integrity": "sha512-vwc5qLUVHgKAlCqcw2JckPaScpUEXFHN0tQ3oH1oFOHUUD0x8FTUIgki8HzveV45oVkmf9RphQJYZFslAbrDKQ==",
       "requires": {
-        "@comunica/core": "^2.2.0"
-      }
-    },
-    "@comunica/mediator-combine-union": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.2.0.tgz",
-      "integrity": "sha512-LZNlN1C65orCHDiVElz4ZPI+lTDJV6V8DIrIcqI6Im93X287wVI5Se0oUTXfS6Ca+rcwAYTYpovnEeNCzZ3sNg==",
-      "requires": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0",
+        "@comunica/types": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/mediator-join-coefficients-fixed": {
@@ -17762,22 +20802,17 @@
         "rdf-string": "^1.5.0",
         "rdf-terms": "^1.6.2",
         "sparqlalgebrajs": "^4.0.0"
-      }
-    },
-    "@comunica/mediator-number": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.2.0.tgz",
-      "integrity": "sha512-jruiMyiCrwvx+BYt/8oug79KTUZfjbxT8Jl9XM1Hm/JgDFYuT0YF8Yosn0xRAk3mAk0lMHuOJYHkuzKMtoEukw==",
-      "requires": {
-        "@comunica/core": "^2.2.0"
-      }
-    },
-    "@comunica/mediator-race": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.2.0.tgz",
-      "integrity": "sha512-XJdMZT0+EnFPWFKLJvP6+LduAcLD2XO6M/nzR79Awck/UlvtAOBqmRzm3i7LKdPDNkfuG73fhjT2b3n8aC5xSw==",
-      "requires": {
-        "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/mediatortype-accuracy": {
@@ -17786,6 +20821,17 @@
       "integrity": "sha512-5fS94tQ4O5TpMXuoyfyGC4pcXMAcxvCcta2eubLVrRCABO38pJpdTD0HC0c3X6SjqRadm0Ea/boQGBAvW7ASCg==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/mediatortype-httprequests": {
@@ -17794,6 +20840,17 @@
       "integrity": "sha512-mH3AWtjZJL9GOxjQcK2MfEjCWzH8fZEQdjkdhB1pRrxdq9e1a7c5hijUmsr3JQNgL13tk+MRiHLs/btyJXyj/w==",
       "requires": {
         "@comunica/core": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/mediatortype-join-coefficients": {
@@ -17803,14 +20860,41 @@
       "requires": {
         "@comunica/core": "^2.2.0",
         "@rdfjs/types": "*"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/mediatortype-time": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.2.0.tgz",
-      "integrity": "sha512-nEXU/KtDVIhfr1WSeMk3Q+WlRwedTO13Q+WXXCR3HUMBY05BqsJqmdXNcNFyoGgS4UH97v+ywKMVyWwBPTzo0g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/mediatortype-time/-/mediatortype-time-2.3.0.tgz",
+      "integrity": "sha512-zoM7TX7C7ncr2uTd/FvADK13wJqnSxqGdAUYch/+rhkQBIdZU/f/3a4JiJn7A8Vifuot2CJB7yrmuvMLsidOqQ==",
       "requires": {
-        "@comunica/core": "^2.2.0"
+        "@comunica/core": "^2.3.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "@comunica/query-sparql": {
@@ -18148,18 +21232,6 @@
             "sparqlalgebrajs": "^4.0.0"
           }
         },
-        "@comunica/actor-query-operation-path-link": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.2.0.tgz",
-          "integrity": "sha512-LUmo47ADoEXgS4hEoekiPzNR2skMboNP4M5jmdcsTu1wYRhOE0MWPDcjI7IcwLyZbaQv1ry7dCNvnDGUcwX3gg==",
-          "requires": {
-            "@comunica/actor-abstract-path": "^2.2.0",
-            "@comunica/bus-query-operation": "^2.2.0",
-            "@comunica/core": "^2.2.0",
-            "@comunica/types": "^2.2.0",
-            "sparqlalgebrajs": "^4.0.0"
-          }
-        },
         "@comunica/actor-query-operation-path-nps": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.2.0.tgz",
@@ -18436,21 +21508,6 @@
             "sparqlalgebrajs": "^4.0.0"
           }
         },
-        "@comunica/actor-query-operation-values": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.2.0.tgz",
-          "integrity": "sha512-9zyA7PdS06wWGMk6nG9Jaj/FdRYc2/DGzrmWB5++lMo4GQdJu+85kj/yLyW1WnVwmGHqYmKziarz5fqkIvJEmw==",
-          "requires": {
-            "@comunica/bindings-factory": "^2.2.0",
-            "@comunica/bus-query-operation": "^2.2.0",
-            "@comunica/core": "^2.2.0",
-            "@comunica/types": "^2.2.0",
-            "asynciterator": "^3.3.0",
-            "rdf-data-factory": "^1.1.0",
-            "rdf-string": "^1.5.0",
-            "sparqlalgebrajs": "^4.0.0"
-          }
-        },
         "@comunica/actor-rdf-metadata-all": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.2.0.tgz",
@@ -18459,6 +21516,39 @@
             "@comunica/bus-rdf-metadata": "^2.2.0",
             "@comunica/core": "^2.2.0",
             "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "@comunica/mediator-combine-union": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+          "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-number": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.3.0.tgz",
+          "integrity": "sha512-LGo2czqXdfmyPpNcn6b7CdQw68KRew9hn6/gdX0PFVsk8FGEnTs0Uab7wUtPancqJFi/KpVMWKu8m3sfJ4dGMw==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-race": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+          "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
           }
         }
       }
@@ -18471,6 +21561,17 @@
         "@comunica/bus-init": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "componentsjs": "^5.0.1"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/runner-cli": {
@@ -18481,16 +21582,27 @@
         "@comunica/bus-init": "^2.2.0",
         "@comunica/core": "^2.2.0",
         "@comunica/runner": "^2.2.0"
+      },
+      "dependencies": {
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        }
       }
     },
     "@comunica/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-gAPmD/Oofn7BGISKO1pHEgekxbav7UxWFahZw7UFGm044xdpuum6huOfIYroXmKi/Ij1FVC5JOFUiqeztWMLXg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@comunica/types/-/types-2.3.0.tgz",
+      "integrity": "sha512-OqG+kP/RcDpNPg3Y85MZWCFuk7yPSpaUsX5TbuL3KSxSGd9gzXmh1pGX5a3ezAlYJh+rKuI+4gOxdQszCdB2kg==",
       "requires": {
-        "@rdfjs/types": ">=1.1.0",
+        "@rdfjs/types": "*",
         "@types/yargs": "^17.0.2",
-        "asynciterator": "^3.3.0",
+        "asynciterator": "^3.4.2",
         "sparqlalgebrajs": "^4.0.0"
       }
     },
@@ -20164,9 +23276,9 @@
       "integrity": "sha512-8A7SkiisnEgME2zEedtDYPxUPzdv3x//E7n5IFktPAtMYSEAV7eNJF0rMwrVyUFj6d/8rgajLantbjcNRQYXIg=="
     },
     "asynciterator": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.4.0.tgz",
-      "integrity": "sha512-jFuvnCHjUAyW33E3zpZhQxBM3SDuyxkDwtjhXD27WKwB/7UrZHaDAia7ZbqL94zLbUGhgxhO0vfopTLi7Jcrig=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/asynciterator/-/asynciterator-3.5.0.tgz",
+      "integrity": "sha512-CbnvkU50ZXNnVSPi/VUvzzjIJ128WNixWVBMY4j5yZwibSaIdGRirPplgtpJiOhmQyagFlPr1T6f5GmCiOg4dg=="
     },
     "asyncjoin": {
       "version": "1.0.5",
@@ -26259,6 +29371,201 @@
         "@rdfjs/types": "*",
         "rdf-string": "^1.6.0",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/actor-http-proxy": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.3.0.tgz",
+          "integrity": "sha512-zgjISdqHE8rwrk7d9z0+S3P47rQXv9o7bWe2RfGUZwExzLThSYb/W/jRdQ7xqBdKetEOg/J9tTfNGJXjlEb5DA==",
+          "requires": {
+            "@comunica/bus-http": "^2.3.0",
+            "@comunica/context-entries": "^2.3.0",
+            "@comunica/mediatortype-time": "^2.3.0",
+            "@comunica/types": "^2.3.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.3.0.tgz",
+          "integrity": "sha512-r4PgCyMc6cRU+EY9JVrTjIXQAnlca9mCCJsSfJi5ZMrw0kDemVTXbP5t2P+uYegCR8w1FIiydgPbkskmAj3iBg==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "htmlparser2": "^7.0.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-microdata": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.3.0.tgz",
+          "integrity": "sha512-Bq1edaB+opRrNMJT33P8RoqafhBsq5O55oEL7+b8F/Cx0AqiYGVndz1vz91cBopxMStEHFsuAuqRHtP2hN0t8A==",
+          "requires": {
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "microdata-rdf-streaming-parser": "^1.2.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-rdfa": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.3.0.tgz",
+          "integrity": "sha512-IXq1ahqy8PV4kA/39ZMCjqxRZNKsK8YUSc1aFV8jxNnPl6pp3YpQCeYh/BaW61gozd41hybl+nnF7dE3u3FRdw==",
+          "requires": {
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "rdfa-streaming-parser": "^1.5.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-script": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.3.0.tgz",
+          "integrity": "sha512-0XRNkKPAJHpK9rp9V8Ls+/nwlFW3E8l9zUHvUCeRW3D2aLQ3yLQk10EfuhScd0ZZRZwp3+sPholLFoF+2nbFOQ==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/context-entries": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "@rdfjs/types": "*",
+            "relative-to-absolute-iri": "^1.0.5"
+          }
+        },
+        "@comunica/actor-rdf-parse-jsonld": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.3.0.tgz",
+          "integrity": "sha512-2ddvd3VSBKNGU10F3+TY0TOoHWiuX8s1N5fW6ZCepliUmadyy2kt56GjQ9exunkRWNsP1g7e8j/Ub85EJ4qjrg==",
+          "requires": {
+            "@comunica/bus-http": "^2.3.0",
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/context-entries": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "jsonld-context-parser": "^2.1.5",
+            "jsonld-streaming-parser": "^2.4.2",
+            "stream-to-string": "^1.2.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-n3": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.3.0.tgz",
+          "integrity": "sha512-jBsaXm7OdSqM8+EyfLhcbu3TtJT3ozW1JagrqXxPBLV4GhgPnke4YA1mCZpVlYdZL36d5h3yjZjX0sgEhbg6qg==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "@types/n3": "^1.4.4",
+            "n3": "^1.6.3"
+          }
+        },
+        "@comunica/actor-rdf-parse-rdfxml": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.3.0.tgz",
+          "integrity": "sha512-s8Of6sfqslH5bn4AG5SMX5RWiaJQt3ymnC4CTxMCKkuoUWxVFb/1l39zRzb+cqMiArl44p0VM1kbCtq+zgCC6A==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "rdfxml-streaming-parser": "^1.5.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-xml-rdfa": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.3.0.tgz",
+          "integrity": "sha512-ucYD1Jb4bCbTK6fF0wW7M4YcXHCH5nNzkKLhA/fz00QmKV2IFtLDcxezjbgCuBtlhKGdsNs1pLB2L/igibIL+w==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "rdfa-streaming-parser": "^1.5.0"
+          }
+        },
+        "@comunica/bus-init": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.3.0.tgz",
+          "integrity": "sha512-YZ/kFFQ/JnjjAv4FlKNiuGttOJKSeUSvrQlvHUKPGEO0j3mgpaiHBJ9eD1WoRdnsZisSFoszCdbqoVRnRXWzOQ==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/bus-rdf-parse": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.3.0.tgz",
+          "integrity": "sha512-oUqn9oDp68bBnRMZ58JXu3VgZuVCv7/bVen8wApLGB+I2wMbBZ664p9c6clTn0LFyEGp8PtAFsNMSLIsEm+5Hg==",
+          "requires": {
+            "@comunica/actor-abstract-mediatyped": "^2.3.0",
+            "@comunica/actor-abstract-parse": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/bus-rdf-parse-html": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.3.0.tgz",
+          "integrity": "sha512-X1TBIK7d9zViRYCgv9taWXpxotPgh05GXFe+lms2oa2IpcbhdnfG2ujmiBTeja7BcDNJZfiNZiXRpd6kgnsjZg==",
+          "requires": {
+            "@comunica/core": "^2.3.0",
+            "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "@comunica/mediator-combine-union": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+          "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-number": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.3.0.tgz",
+          "integrity": "sha512-LGo2czqXdfmyPpNcn6b7CdQw68KRew9hn6/gdX0PFVsk8FGEnTs0Uab7wUtPancqJFi/KpVMWKu8m3sfJ4dGMw==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-race": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+          "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "rdf-isomorphic": {
@@ -26302,9 +29609,9 @@
       }
     },
     "rdf-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.0.0.tgz",
-      "integrity": "sha512-ob/Paok5Kik74uPqWq8CWHUVt7xQ0e38oQbBU0ivBHbsF0a+rdvKhcgH/fY0YhXsU84rfZgiiwxguhBpEXoSew==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-parse/-/rdf-parse-2.1.0.tgz",
+      "integrity": "sha512-Ew0M3uokgtDr3YAJ77/Wcwxu1pRarFeR7dNAPFncpLfpmOhfh0UzYAhw1JRMyqNb4t0pIvB3qWHf5yDxy8upgQ==",
       "requires": {
         "@comunica/actor-http-fetch": "^2.0.1",
         "@comunica/actor-http-proxy": "^2.0.1",
@@ -26328,6 +29635,201 @@
         "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/actor-http-proxy": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-http-proxy/-/actor-http-proxy-2.3.0.tgz",
+          "integrity": "sha512-zgjISdqHE8rwrk7d9z0+S3P47rQXv9o7bWe2RfGUZwExzLThSYb/W/jRdQ7xqBdKetEOg/J9tTfNGJXjlEb5DA==",
+          "requires": {
+            "@comunica/bus-http": "^2.3.0",
+            "@comunica/context-entries": "^2.3.0",
+            "@comunica/mediatortype-time": "^2.3.0",
+            "@comunica/types": "^2.3.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.3.0.tgz",
+          "integrity": "sha512-r4PgCyMc6cRU+EY9JVrTjIXQAnlca9mCCJsSfJi5ZMrw0kDemVTXbP5t2P+uYegCR8w1FIiydgPbkskmAj3iBg==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "htmlparser2": "^7.0.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-microdata": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.3.0.tgz",
+          "integrity": "sha512-Bq1edaB+opRrNMJT33P8RoqafhBsq5O55oEL7+b8F/Cx0AqiYGVndz1vz91cBopxMStEHFsuAuqRHtP2hN0t8A==",
+          "requires": {
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "microdata-rdf-streaming-parser": "^1.2.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-rdfa": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.3.0.tgz",
+          "integrity": "sha512-IXq1ahqy8PV4kA/39ZMCjqxRZNKsK8YUSc1aFV8jxNnPl6pp3YpQCeYh/BaW61gozd41hybl+nnF7dE3u3FRdw==",
+          "requires": {
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "rdfa-streaming-parser": "^1.5.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-html-script": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.3.0.tgz",
+          "integrity": "sha512-0XRNkKPAJHpK9rp9V8Ls+/nwlFW3E8l9zUHvUCeRW3D2aLQ3yLQk10EfuhScd0ZZRZwp3+sPholLFoF+2nbFOQ==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/bus-rdf-parse-html": "^2.3.0",
+            "@comunica/context-entries": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "@rdfjs/types": "*",
+            "relative-to-absolute-iri": "^1.0.5"
+          }
+        },
+        "@comunica/actor-rdf-parse-jsonld": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.3.0.tgz",
+          "integrity": "sha512-2ddvd3VSBKNGU10F3+TY0TOoHWiuX8s1N5fW6ZCepliUmadyy2kt56GjQ9exunkRWNsP1g7e8j/Ub85EJ4qjrg==",
+          "requires": {
+            "@comunica/bus-http": "^2.3.0",
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/context-entries": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "jsonld-context-parser": "^2.1.5",
+            "jsonld-streaming-parser": "^2.4.2",
+            "stream-to-string": "^1.2.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-n3": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.3.0.tgz",
+          "integrity": "sha512-jBsaXm7OdSqM8+EyfLhcbu3TtJT3ozW1JagrqXxPBLV4GhgPnke4YA1mCZpVlYdZL36d5h3yjZjX0sgEhbg6qg==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "@types/n3": "^1.4.4",
+            "n3": "^1.6.3"
+          }
+        },
+        "@comunica/actor-rdf-parse-rdfxml": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.3.0.tgz",
+          "integrity": "sha512-s8Of6sfqslH5bn4AG5SMX5RWiaJQt3ymnC4CTxMCKkuoUWxVFb/1l39zRzb+cqMiArl44p0VM1kbCtq+zgCC6A==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "rdfxml-streaming-parser": "^1.5.0"
+          }
+        },
+        "@comunica/actor-rdf-parse-xml-rdfa": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.3.0.tgz",
+          "integrity": "sha512-ucYD1Jb4bCbTK6fF0wW7M4YcXHCH5nNzkKLhA/fz00QmKV2IFtLDcxezjbgCuBtlhKGdsNs1pLB2L/igibIL+w==",
+          "requires": {
+            "@comunica/bus-rdf-parse": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "rdfa-streaming-parser": "^1.5.0"
+          }
+        },
+        "@comunica/bus-init": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.3.0.tgz",
+          "integrity": "sha512-YZ/kFFQ/JnjjAv4FlKNiuGttOJKSeUSvrQlvHUKPGEO0j3mgpaiHBJ9eD1WoRdnsZisSFoszCdbqoVRnRXWzOQ==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/bus-rdf-parse": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.3.0.tgz",
+          "integrity": "sha512-oUqn9oDp68bBnRMZ58JXu3VgZuVCv7/bVen8wApLGB+I2wMbBZ664p9c6clTn0LFyEGp8PtAFsNMSLIsEm+5Hg==",
+          "requires": {
+            "@comunica/actor-abstract-mediatyped": "^2.3.0",
+            "@comunica/actor-abstract-parse": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/bus-rdf-parse-html": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.3.0.tgz",
+          "integrity": "sha512-X1TBIK7d9zViRYCgv9taWXpxotPgh05GXFe+lms2oa2IpcbhdnfG2ujmiBTeja7BcDNJZfiNZiXRpd6kgnsjZg==",
+          "requires": {
+            "@comunica/core": "^2.3.0",
+            "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "@comunica/mediator-combine-union": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+          "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-number": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-number/-/mediator-number-2.3.0.tgz",
+          "integrity": "sha512-LGo2czqXdfmyPpNcn6b7CdQw68KRew9hn6/gdX0PFVsk8FGEnTs0Uab7wUtPancqJFi/KpVMWKu8m3sfJ4dGMw==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-race": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+          "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "rdf-quad": {
@@ -26356,6 +29858,76 @@
         "@comunica/mediator-race": "^2.0.1",
         "@rdfjs/types": "*",
         "stream-to-string": "^1.2.0"
+      },
+      "dependencies": {
+        "@comunica/actor-rdf-serialize-jsonld": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.3.0.tgz",
+          "integrity": "sha512-sGHFpdjNPJ9tObhQj5pr1gINTD+3o90EJSDLWbgeynpw6tcP/YeDMhovb2nQlUmPUirGfXexli7Gf4Mpjuo/EQ==",
+          "requires": {
+            "@comunica/bus-rdf-serialize": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "jsonld-streaming-serializer": "^1.3.0"
+          }
+        },
+        "@comunica/actor-rdf-serialize-n3": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.3.0.tgz",
+          "integrity": "sha512-+ayKoYsrGxwn6qcm+LqjOEwg9J7lia9/jM1olyd+I4JzPHHsSEt5bXGlcNZaQ6/J6TKlTzszD6drGiVwIfVF6A==",
+          "requires": {
+            "@comunica/bus-rdf-serialize": "^2.3.0",
+            "@comunica/types": "^2.3.0",
+            "n3": "^1.6.3"
+          }
+        },
+        "@comunica/bus-init": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-2.3.0.tgz",
+          "integrity": "sha512-YZ/kFFQ/JnjjAv4FlKNiuGttOJKSeUSvrQlvHUKPGEO0j3mgpaiHBJ9eD1WoRdnsZisSFoszCdbqoVRnRXWzOQ==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/bus-rdf-serialize": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.3.0.tgz",
+          "integrity": "sha512-Dfr+GBVidtMj46izZKI6MsTC7A3JQipRCzp2TTY3di8VRRctEmKQmLCpDUf9HSQ0thKb2j9waVfeIgfCjOQjBw==",
+          "requires": {
+            "@comunica/actor-abstract-mediatyped": "^2.3.0",
+            "@comunica/core": "^2.3.0",
+            "@rdfjs/types": "*"
+          }
+        },
+        "@comunica/core": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/core/-/core-2.3.0.tgz",
+          "integrity": "sha512-Xl1ZBGuSObQgNV4HxAEXUUcGuCVtNobNkboOJ8v43x3G8494IIR5y1FCi1xn7yGZ/CSoCFzz6DKBd0ueqVQGFg==",
+          "requires": {
+            "@comunica/types": "^2.3.0",
+            "immutable": "^4.0.0"
+          }
+        },
+        "@comunica/mediator-combine-union": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-combine-union/-/mediator-combine-union-2.3.0.tgz",
+          "integrity": "sha512-3DRasP527TZQMb3gY1OU05CoWJJnrYFBjFPeCJfiRR9yjwUrR9AwtA2FWs797AXNlV2Q0jc4H82O98KcJaPWwg==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "@comunica/mediator-race": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@comunica/mediator-race/-/mediator-race-2.3.0.tgz",
+          "integrity": "sha512-kmJzd4YyXpwK/3fW4gnqsbYljNYf1VWjPBJE3sccia56ymVehW/q51ucf1iTvJ1ywSRVTKlALxxApS0wTGq5Og==",
+          "requires": {
+            "@comunica/core": "^2.3.0"
+          }
+        },
+        "immutable": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+          "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ=="
+        }
       }
     },
     "rdf-store-stream": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "pump": "^3.0.0",
     "punycode": "^2.1.1",
     "rdf-dereference": "^2.0.0",
-    "rdf-parse": "^2.0.0",
+    "rdf-parse": "^2.1.0",
     "rdf-serialize": "^2.0.0",
     "rdf-terms": "^1.7.1",
     "sparqlalgebrajs": "^4.0.2",

--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -1,10 +1,13 @@
 import { PassThrough } from 'stream';
+import type { NamedNode } from '@rdfjs/types';
 import rdfParser from 'rdf-parse';
 import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
 import type { Representation } from '../../http/representation/Representation';
+import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
 import { pipeSafely } from '../../util/StreamUtil';
+import { PREFERRED_PREFIX_TERM, SOLID_META } from '../../util/Vocabularies';
 import { BaseTypedRepresentationConverter } from './BaseTypedRepresentationConverter';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
 
@@ -20,13 +23,21 @@ export class RdfToQuadConverter extends BaseTypedRepresentationConverter {
   }
 
   public async handle({ representation, identifier }: RepresentationConverterArgs): Promise<Representation> {
+    const newMetadata = new RepresentationMetadata(representation.metadata, INTERNAL_QUADS);
     const rawQuads = rdfParser.parse(representation.data, {
       contentType: representation.metadata.contentType!,
       baseIRI: identifier.path,
-    });
+    })
+      // This works only for those cases where the data stream has been completely read before accessing the metadata.
+      // Eg. the PATCH operation, which is the main case why we store the prefixes in metadata here if there are any.
+      // See also https://github.com/CommunitySolidServer/CommunitySolidServer/issues/126
+      .on('prefix', (prefix, iri: NamedNode): void => {
+        newMetadata.addQuad(iri.value, PREFERRED_PREFIX_TERM, prefix, SOLID_META.terms.ResponseMetadata);
+      });
+
     const pass = new PassThrough({ objectMode: true });
     const data = pipeSafely(rawQuads, pass, (error): Error => new BadRequestHttpError(error.message));
 
-    return new BasicRepresentation(data, representation.metadata, INTERNAL_QUADS);
+    return new BasicRepresentation(data, newMetadata);
   }
 }

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -1,5 +1,6 @@
 import { createReadStream } from 'fs';
 import fetch from 'cross-fetch';
+import type { Quad } from 'n3';
 import { DataFactory, Parser, Store } from 'n3';
 import { joinFilePath, PIM, RDF } from '../../src/';
 import type { App } from '../../src/';
@@ -11,7 +12,8 @@ import {
   getPresetConfigPath,
   getTestConfigPath,
   getTestFolder,
-  instantiateFromConfig, removeFolder,
+  instantiateFromConfig,
+  removeFolder,
 } from './Config';
 const { literal, namedNode, quad } = DataFactory;
 
@@ -395,5 +397,71 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
   it('returns 415 for unsupported PATCH types.', async(): Promise<void> => {
     const response = await fetch(baseUrl, { method: 'PATCH', headers: { 'content-type': 'text/plain' }, body: 'abc' });
     expect(response.status).toBe(415);
+  });
+
+  it('maintains prefixes after PATCH operations.', async(): Promise<void> => {
+    // POST
+    const body = [ '@prefix test: <http://test.com/>.',
+      'test:s1 test:p1 test:o1.',
+      'test:s2 test:p2 test:o2.' ].join('\n');
+    let response = await postResource(baseUrl, { contentType: 'text/turtle', body });
+    const documentUrl = response.headers.get('location')!;
+
+    // PATCH
+    const query = [ 'PREFIX test: <http://test.com/>',
+      'DELETE { test:s1 test:p1 test:o1 }',
+      'INSERT { test:s3 test:p3 test:o3. test:s4 test:p4 test:o4 }',
+      'WHERE {}',
+    ].join('\n');
+    await patchResource(documentUrl, query, true);
+
+    // GET
+    response = await getResource(documentUrl);
+    const parser = new Parser();
+    const quads: Quad[] = [];
+    let prefixes: any = {};
+    const text = await response.clone().text();
+    const promise = new Promise<void>((resolve, reject): void => {
+      parser.parse(text, (error, aQuad, prefixHash): any => {
+        if (aQuad) {
+          quads.push(aQuad);
+        }
+        if (!aQuad) {
+          prefixes = prefixHash;
+          resolve();
+        }
+        if (error) {
+          reject(error);
+        }
+      });
+    });
+
+    await promise;
+
+    const expected = [
+      quad(
+        namedNode('http://test.com/s2'),
+        namedNode('http://test.com/p2'),
+        namedNode('http://test.com/o2'),
+      ),
+      quad(
+        namedNode('http://test.com/s3'),
+        namedNode('http://test.com/p3'),
+        namedNode('http://test.com/o3'),
+      ),
+      quad(
+        namedNode('http://test.com/s4'),
+        namedNode('http://test.com/p4'),
+        namedNode('http://test.com/o4'),
+      ),
+    ];
+    await expectQuads(response, expected, true);
+    expect(prefixes).toEqual({
+      test: 'http://test.com/',
+    });
+    expect(quads).toHaveLength(3);
+
+    // DELETE
+    expect(await deleteResource(documentUrl)).toBeUndefined();
   });
 });

--- a/test/unit/storage/conversion/RdfToQuadConverter.test.ts
+++ b/test/unit/storage/conversion/RdfToQuadConverter.test.ts
@@ -3,6 +3,7 @@ import { Readable } from 'stream';
 import arrayifyStream from 'arrayify-stream';
 import { DataFactory } from 'n3';
 import rdfParser from 'rdf-parse';
+import { PREFERRED_PREFIX_TERM, SOLID_META } from '../../../../src';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
 import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
@@ -11,7 +12,7 @@ import type { ResourceIdentifier } from '../../../../src/http/representation/Res
 import { RdfToQuadConverter } from '../../../../src/storage/conversion/RdfToQuadConverter';
 import { INTERNAL_QUADS } from '../../../../src/util/ContentTypes';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
-const { namedNode, triple } = DataFactory;
+const { namedNode, triple, literal, quad } = DataFactory;
 
 describe('A RdfToQuadConverter', (): void => {
   const converter = new RdfToQuadConverter();
@@ -61,6 +62,30 @@ describe('A RdfToQuadConverter', (): void => {
       namedNode('http://test.com/p'),
       namedNode('http://test.com/o'),
     ) ]);
+  });
+
+  it('emits on prefixes when converting turtle to quads.', async(): Promise<void> => {
+    const id: ResourceIdentifier = { path: 'http://example.com/' };
+    const metadata = new RepresentationMetadata('text/turtle');
+    const representation = new BasicRepresentation(`
+      @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+      <http://test.com/s> a foaf:Person.
+    `
+    , metadata);
+    const preferences: RepresentationPreferences = { type: { [INTERNAL_QUADS]: 1 }};
+    const result = await converter.handle({ identifier: id, representation, preferences });
+    expect(result).toEqual({
+      binary: false,
+      data: expect.any(Readable),
+      metadata: expect.any(RepresentationMetadata),
+    });
+    expect(result.metadata.contentType).toEqual(INTERNAL_QUADS);
+    await arrayifyStream(result.data);
+
+    expect(result.metadata.quads(null, PREFERRED_PREFIX_TERM, null)).toBeRdfIsomorphic([
+      quad(namedNode('http://xmlns.com/foaf/0.1/'), PREFERRED_PREFIX_TERM, literal('foaf'), SOLID_META.terms.ResponseMetadata),
+    ]);
   });
 
   it('converts JSON-LD to quads.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

* Closes #126
* Relevant for #1366

#### ✍️ Description

After adding a feature to rdf-parse.js via this PR https://github.com/rubensworks/rdf-parse.js/pull/42, we are now able to listen to events for `prefix` and `context` when parsing the stream. (it was merged in rdf-parse@2.1.0, so I've updated this dependency)

This should fix the PATCH problem in #126, when updating your turtle file looses the prefix notation.

Note that this works only for those cases where the data stream has been completely read before accessing the metadata.
Eg. the PATCH operation, which is the main case why we store the prefixes in metadata here if there are any.

If we want to make back to back calling of `RdfToQuadConverter.convert` followed by `QuadToRdfConverter.convert` idempotent, then we loose the benefit of streaming (since the RdfToQuadConverter would have to read the stream before returning the metadata). After a discussion we chose to ignore this small case, since the returned rdf is not incorrect, just prefix-less, and the occurrence of these cases should be low.
