### PR TITLE
Use IdentifierMap for ResourceStore responses

### DIFF
--- a/documentation/markdown/resource-store.md
+++ b/documentation/markdown/resource-store.md
@@ -30,7 +30,8 @@ and all the entries in `config/storage/backend`.
 This store emits the events that are necessary to emit notifications when resources change.
 
 There are 4 different events that can be emitted:
-- `this.emit('changed', identifier, AS.Create | AS.Update | AS.Delete | undefined)`: is emitted for every resource that was changed/effected by a call to the store.
+- `this.emit('changed', identifier, activity)`: is emitted for every resource that was changed/effected by a call to the store.
+  With activity being undefined or one of the available ActivityStream terms.
 - `this.emit(AS.Create, identifier)`: is emitted for every resource that was created by the call to the store.
 - `this.emit(AS.Update, identifier)`: is emitted for every resource that was updated by the call to the store.
 - `this.emit(AS.Delete, identifier)`: is emitted for every resource that was deleted by the call to the store.

--- a/src/http/ldp/PostOperationHandler.ts
+++ b/src/http/ldp/PostOperationHandler.ts
@@ -1,11 +1,12 @@
 import { getLoggerFor } from '../../logging/LogUtil';
 import type { ResourceStore } from '../../storage/ResourceStore';
 import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
+import { InternalServerError } from '../../util/errors/InternalServerError';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { find } from '../../util/IterableUtil';
 import { AS, SOLID_AS } from '../../util/Vocabularies';
 import { CreatedResponseDescription } from '../output/response/CreatedResponseDescription';
 import type { ResponseDescription } from '../output/response/ResponseDescription';
-import { createResourceIdentifier } from '../representation/ResourceIdentifier';
 import type { OperationHandlerInput } from './OperationHandler';
 import { OperationHandler } from './OperationHandler';
 
@@ -37,10 +38,12 @@ export class PostOperationHandler extends OperationHandler {
       this.logger.warn('POST requests require the Content-Type header to be set');
       throw new BadRequestHttpError('POST requests require the Content-Type header to be set');
     }
-    const result = await this.store.addResource(operation.target, operation.body, operation.conditions);
-    const createdIdentifier = Object.entries(result).find(
-      ([ , value ]): boolean => value.get(SOLID_AS.terms.Activity)?.value === AS.Create,
-    )![0];
-    return new CreatedResponseDescription(createResourceIdentifier(createdIdentifier));
+    const changes = await this.store.addResource(operation.target, operation.body, operation.conditions);
+    const createdIdentifier = find(changes.keys(), (identifier): boolean =>
+      Boolean(changes.get(identifier)?.has(SOLID_AS.terms.Activity, AS.terms.Create)));
+    if (!createdIdentifier) {
+      throw new InternalServerError('Operation was successful but no created identifier was returned.');
+    }
+    return new CreatedResponseDescription(createdIdentifier);
   }
 }

--- a/src/http/representation/ResourceIdentifier.ts
+++ b/src/http/representation/ResourceIdentifier.ts
@@ -14,10 +14,3 @@ export interface ResourceIdentifier {
 export function isResourceIdentifier(object: any): object is ResourceIdentifier {
   return object && (typeof object.path === 'string');
 }
-
-/**
- * Factory function creating a {@link ResourceIdentifier} for convenience.
- */
-export function createResourceIdentifier(resourcePath: string): ResourceIdentifier {
-  return { path: resourcePath };
-}

--- a/src/storage/ResourceStore.ts
+++ b/src/storage/ResourceStore.ts
@@ -3,15 +3,16 @@ import type { Representation } from '../http/representation/Representation';
 import type { RepresentationMetadata } from '../http/representation/RepresentationMetadata';
 import type { RepresentationPreferences } from '../http/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
+import type { IdentifierMap } from '../util/map/IdentifierMap';
 import type { Conditions } from './Conditions';
 import type { ResourceSet } from './ResourceSet';
 
 /**
- * An object containing one property for each resource that was created, updated or deleted
- * by this operation. Where the key of the property is the path of the resource (string) and the value is an
- * instance of RepresentationMetadata containing extra information about the change of the resource.
+ * An {@link IdentifierMap} containing one entry for each resource that was created, updated or deleted
+ * by this operation. Where the value is a {@link RepresentationMetadata}
+ * containing extra information about the change of the resource.
  */
-export type ChangeMap = Record<string, RepresentationMetadata>;
+export type ChangeMap = IdentifierMap<RepresentationMetadata>;
 
 /**
  * A ResourceStore represents a collection of resources.

--- a/src/util/IterableUtil.ts
+++ b/src/util/IterableUtil.ts
@@ -51,6 +51,27 @@ export function* concat<T>(iterables: Iterable<Iterable<T>>): Iterable<T> {
 }
 
 /**
+ * Returns the first element in the provided iterable that satisfies the provided testing function.
+ * If no values satisfy the testing function, `undefined` is returned.
+ * Similar to the {@link Array.prototype.find} function.
+ * See the documentation of the above function for more details.
+ *
+ * @param iterable - Iterable on which to call the map function.
+ * @param callbackFn - Function that is called to test every element.
+ * @param thisArg - Value to use as `this` when executing `callbackFn`.
+ */
+export function find<T>(iterable: Iterable<T>, callbackFn: (element: T, index: number) => boolean, thisArg?: any):
+T | undefined {
+  const boundMapFn = callbackFn.bind(thisArg);
+  const count = 0;
+  for (const value of iterable) {
+    if (boundMapFn(value, count)) {
+      return value;
+    }
+  }
+}
+
+/**
  * Similar to the {@link Array.prototype.reduce} function, but for an iterable.
  * See the documentation of the above function for more details.
  * The first element will be used as the initial value.

--- a/test/unit/util/IterableUtil.test.ts
+++ b/test/unit/util/IterableUtil.test.ts
@@ -1,28 +1,40 @@
-import { concat, filter, map, reduce } from '../../../src/util/IterableUtil';
+import { concat, filter, find, map, reduce } from '../../../src/util/IterableUtil';
 
 describe('IterableUtil', (): void => {
-  describe('#mapIterable', (): void => {
+  describe('#map', (): void => {
     it('maps the values to a new iterable.', async(): Promise<void> => {
       const input = [ 1, 2, 3 ];
       expect([ ...map(input, (val): number => val + 3) ]).toEqual([ 4, 5, 6 ]);
     });
   });
 
-  describe('#filterIterable', (): void => {
+  describe('#filter', (): void => {
     it('filters the values of the iterable.', async(): Promise<void> => {
       const input = [ 1, 2, 3 ];
       expect([ ...filter(input, (val): boolean => val % 2 === 1) ]).toEqual([ 1, 3 ]);
     });
   });
 
-  describe('#concatIterables', (): void => {
+  describe('#concat', (): void => {
     it('concatenates all the iterables.', async(): Promise<void> => {
       const input = [[ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ]];
       expect([ ...concat(input) ]).toEqual([ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
     });
   });
 
-  describe('#reduceIterable', (): void => {
+  describe('#find', (): void => {
+    it('finds the matching value.', async(): Promise<void> => {
+      const input = [[ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ]];
+      expect(find(input, (entry): boolean => entry.includes(5))).toEqual([ 4, 5, 6 ]);
+    });
+
+    it('returns undefined if there is no match.', async(): Promise<void> => {
+      const input = [[ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ]];
+      expect(find(input, (entry): boolean => entry.includes(0))).toBeUndefined();
+    });
+  });
+
+  describe('#reduce', (): void => {
     it('reduces the values in an iterable.', async(): Promise<void> => {
       const input = [ 1, 2, 3 ];
       expect(reduce(input, (acc, cur): number => acc + cur)).toBe(6);


### PR DESCRIPTION
#### 📁 Related issues

As mentioned in https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1350#pullrequestreview-1027218923

#### ✍️ Description

Updates the response type of a `ResourceStore` to use a `HashMap` instead of an object with string keys. Also fixed some issues about how terms were being used.