### PR TITLE
Add CLI integration tests

### DIFF
--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -115,7 +115,8 @@
         }
       ],
       "options": {
-        "usage": "node ./bin/server.js [args]"
+        "usage": "node ./bin/server.js [args]",
+        "strictMode": true
       }
     }
   ]

--- a/src/init/cli/CliExtractor.ts
+++ b/src/init/cli/CliExtractor.ts
@@ -10,7 +10,7 @@ import type { CliArgv, Shorthand } from '../variables/Types';
  * but that does mean that this class should not error if they are present,
  * e.g., by being strict throwing an error on these unexpected parameters.
  *
- * The following core CLI parameters are mandatory:
+ * In case strict mode is preferred, the following should be added to the list of known parameters:
  *  - -c / \--config
  *  - -m / \--mainModulePath
  *  - -l / \--loggingLevel

--- a/test/integration/Cli.test.ts
+++ b/test/integration/Cli.test.ts
@@ -1,0 +1,49 @@
+import type { CliResolver } from '../../src/init/CliResolver';
+import { resolveModulePath } from '../../src/util/PathUtil';
+import { instantiateFromConfig } from './Config';
+
+// Needed to prevent yargs from stopping the process on error
+const error = jest.spyOn(console, 'error').mockImplementation(jest.fn());
+const exit = jest.spyOn(process, 'exit').mockImplementation(jest.fn() as any);
+
+describe('An instantiated CliResolver', (): void => {
+  let cliResolver: CliResolver;
+
+  beforeAll(async(): Promise<void> => {
+    // Create the CliExtractor
+    cliResolver = await instantiateFromConfig(
+      'urn:solid-server-app-setup:default:CliResolver',
+      resolveModulePath('config/default.json'),
+    );
+  });
+
+  it('converts known abbreviations to the full parameter.', async(): Promise<void> => {
+    const shorthand = await cliResolver.cliExtractor.handleSafe([ 'node', 'server.js',
+      '-c', 'c',
+      '-m', 'm',
+      '-l', 'l',
+      '-b', 'b',
+      '-p', '3000',
+      '-f', 'f',
+      '-t',
+      '-s', 's',
+      '-w', '2',
+    ]);
+    expect(shorthand.config).toBe('c');
+    expect(shorthand.mainModulePath).toBe('m');
+    expect(shorthand.loggingLevel).toBe('l');
+    expect(shorthand.baseUrl).toBe('b');
+    expect(shorthand.port).toBe(3000);
+    expect(shorthand.rootFilePath).toBe('f');
+    expect(shorthand.showStackTrace).toBe(true);
+    expect(shorthand.sparqlEndpoint).toBe('s');
+    expect(shorthand.workers).toBe(2);
+  });
+
+  it('errors on unknown parameters.', async(): Promise<void> => {
+    await cliResolver.cliExtractor.handleSafe([ 'node', 'server.js', '-a', 'abc' ]);
+
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith('Unknown argument: a');
+  });
+});

--- a/test/integration/ServerFetch.test.ts
+++ b/test/integration/ServerFetch.test.ts
@@ -1,8 +1,10 @@
 import fetch from 'cross-fetch';
 import type { App } from '../../src/init/App';
+import { AppRunner } from '../../src/init/AppRunner';
+import { resolveModulePath } from '../../src/util/PathUtil';
 import { LDP } from '../../src/util/Vocabularies';
 import { getPort } from '../util/Util';
-import { getDefaultVariables, getTestConfigPath, instantiateFromConfig } from './Config';
+import { getDefaultVariables } from './Config';
 
 const port = getPort('ServerFetch');
 const baseUrl = `http://localhost:${port}/`;
@@ -12,12 +14,16 @@ describe('A Solid server', (): void => {
   let app: App;
 
   beforeAll(async(): Promise<void> => {
-    const instances = await instantiateFromConfig(
-      'urn:solid-server:test:Instances',
-      getTestConfigPath('server-memory.json'),
+    // Using AppRunner here so it is also tested in an integration test
+    app = await new AppRunner().create(
+      {
+        mainModulePath: resolveModulePath(''),
+        logLevel: 'error',
+        typeChecking: false,
+      },
+      resolveModulePath('config/default.json'),
       getDefaultVariables(port, baseUrl),
-    ) as Record<string, any>;
-    ({ app } = instances);
+    );
     await app.start();
   });
 


### PR DESCRIPTION
#### ✍️ Description

In my previous CLI PR I accidentally broke the server, but none of the integration tests caught it since none of them test the CLI configs. So added a test for this. Changed one integration test to use the `AppRunner` to start the server for similar reasons.

Also changed the default CLI config to have strict CLI parsing. This was disabled when moving the CLI interpretation to a config since it could also receive unknown parameters from the first step, such as `mainModulePath`, but at some point those were also added to the config (so they appear in the help) so strict parsing no longer breaks on these. I want to enable strict parsing so when we move specific CLI params to specific configs, this immediately tells the user that the given parameter is not applicable for what they're trying to do. E.g., in the case of https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1395 an error would be thrown that `rootFilePath` is an unknown parameter when starting a memory based config (although then we might get issues asking why this parameter throws an error 😄 ).