### PR TITLE
refactor: Add imports that allow for HTTPS through CLI params

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,10 +24,12 @@ The following changes pertain to the imports in the default configs:
 - The prefix of all imports was changed from `files-scs` to `css`.
 - All default configurations with a file-based backend now use a file-based locker instead of a memory-based one,
   making them threadsafe.
+- 2 new options have been added for the `/http/server-factory/` imports: `https-websockets.json` and `https-no-websockets.json`,
+  which allow starting the server with HTTPS by adding 2 new CLI parameters `httpsKey` and `httpsCert`.
 
 The following changes are relevant for v4 custom configs that replaced certain features.
-- `config/app/variables/*` was changed to support the new `YargsCliExtractor` format and `SettingsResolver` rename.
-- `config/util/resource-locker/memory.json` had the locker @type changed from `SingleThreadedResourceLocker` to `MemoryResourceLocker`.
+- `/app/variables/*` was changed to support the new `YargsCliExtractor` format and `SettingsResolver` rename.
+- `/util/resource-locker/memory.json` had the locker @type changed from `SingleThreadedResourceLocker` to `MemoryResourceLocker`.
 - The content-length parser has been moved from the default configuration to the quota configurations.
    - `/ldp/metadata-parser/default.json`
    - `/storage/backend/*-quota-file.json`

--- a/config/http/README.md
+++ b/config/http/README.md
@@ -16,7 +16,10 @@ and then pass the request along.
 The factory used to create the actual server object.
 * *no-websockets*: Only HTTP.
 * *websockets*: HTTP and websockets.
-* *https-example*: An example configuration to use HTTPS directly at the server (instead of at a reverse proxy).
+* *https-no-websockets*: Only HTTPS. Adds 2 new CLI params to set the key/cert paths.
+* *https-websockets*: HTTPS and websockets. Adds 2 new CLI params to set the key/cert paths.
+* *https-example*: An example configuration to use HTTPS directly at the server (instead of at a reverse proxy)
+  by adding the key/cert paths to the config itself.
 
 ## Static
 Support for static files that should be found at a specific path.

--- a/config/http/server-factory/https-no-websockets.json
+++ b/config/http/server-factory/https-no-websockets.json
@@ -1,0 +1,21 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Creates a server that supports HTTPS requests.",
+      "@id": "urn:solid-server:default:ServerFactory",
+      "@type": "BaseHttpServerFactory",
+      "handler": { "@id": "urn:solid-server:default:HttpHandler" },
+      "options_showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" },
+      "options_https": true,
+      "options_key": {
+        "@id": "urn:solid-server:custom:variable:httpsKey",
+        "@type": "Variable"
+      },
+      "options_cert": {
+        "@id": "urn:solid-server:custom:variable:httpsCert",
+        "@type": "Variable"
+      }
+    }
+  ]
+}

--- a/config/http/server-factory/https-websockets.json
+++ b/config/http/server-factory/https-websockets.json
@@ -1,0 +1,33 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "import": [
+    "css:config/http/server-factory/https/cli.json",
+    "css:config/http/server-factory/https/resolver.json"
+  ],
+  "@graph": [
+    {
+      "comment": "Creates an HTTPS server with the settings provided via the command line.",
+      "@id": "urn:solid-server:default:ServerFactory",
+      "@type": "WebSocketServerFactory",
+      "baseServerFactory": {
+        "@id": "urn:solid-server:default:HttpServerFactory",
+        "@type": "BaseHttpServerFactory",
+        "handler": { "@id": "urn:solid-server:default:HttpHandler" },
+        "options_showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" },
+        "options_https": true,
+        "options_key": {
+          "@id": "urn:solid-server:custom:variable:httpsKey",
+          "@type": "Variable"
+        },
+        "options_cert": {
+          "@id": "urn:solid-server:custom:variable:httpsCert",
+          "@type": "Variable"
+        }
+      },
+      "webSocketHandler": {
+        "@type": "UnsecureWebSocketsProtocol",
+        "source": { "@id": "urn:solid-server:default:ResourceStore" }
+      }
+    }
+  ]
+}

--- a/config/http/server-factory/https/cli.json
+++ b/config/http/server-factory/https/cli.json
@@ -1,0 +1,31 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "@id": "urn:solid-server-app-setup:default:CliExtractor",
+      "@type": "YargsCliExtractor",
+      "parameters": [
+        {
+          "@type": "YargsParameter",
+          "name": "httpsKey",
+          "options": {
+            "demandOption": true,
+            "requiresArg": true,
+            "type": "string",
+            "describe": "File path to the HTTPS key."
+          }
+        },
+        {
+          "@type": "YargsParameter",
+          "name": "httpsCert",
+          "options": {
+            "demandOption": true,
+            "requiresArg": true,
+            "type": "string",
+            "describe": "File path to the HTTPS certificate."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/config/http/server-factory/https/resolver.json
+++ b/config/http/server-factory/https/resolver.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Adds resolvers to assign the HTTPS CLI values to the Components.js variables.",
+      "@id": "urn:solid-server-app-setup:default:ShorthandResolver",
+      "@type": "CombinedShorthandResolver",
+      "resolvers": [
+        {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:custom:variable:httpsKey",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "httpsKey"
+          }
+        },
+        {
+          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:custom:variable:httpsCert",
+          "CombinedShorthandResolver:_resolvers_value": {
+            "@type": "KeyExtractor",
+            "key": "httpsCert"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/config/https-file-cli.json
+++ b/config/https-file-cli.json
@@ -7,7 +7,7 @@
     "css:config/app/variables/default.json",
     "css:config/http/handler/default.json",
     "css:config/http/middleware/websockets.json",
-
+    "css:config/http/server-factory/https-websockets.json",
     "css:config/http/static/default.json",
     "css:config/identity/access/public.json",
     "css:config/identity/email/default.json",
@@ -34,84 +34,7 @@
   ],
   "@graph": [
     {
-      "comment": [
-        "Adds CLI options --httpsKey and --httpsCert and uses those to start an HTTPS server.",
-        "The http/server-factory import above has been omitted since that feature is set below."
-      ]
-    },
-    {
-      "@id": "urn:solid-server-app-setup:default:CliExtractor",
-      "@type": "YargsCliExtractor",
-      "parameters": [
-        {
-          "@type": "YargsParameter",
-          "name": "httpsKey",
-          "options": {
-            "demandOption": true,
-            "requiresArg": true,
-            "type": "string",
-            "describe": "File path to the HTTPS key."
-          }
-        },
-        {
-          "@type": "YargsParameter",
-          "name": "httpsCert",
-          "options": {
-            "demandOption": true,
-            "requiresArg": true,
-            "type": "string",
-            "describe": "File path to the HTTPS certificate."
-          }
-        }
-      ]
-    },
-    {
-      "comment": "Adds resolvers to assign the CLI values to the Components.js variables.",
-      "@id": "urn:solid-server-app-setup:default:ShorthandResolver",
-      "@type": "CombinedShorthandResolver",
-      "resolvers": [
-        {
-          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:custom:variable:httpsKey",
-          "CombinedShorthandResolver:_resolvers_value": {
-            "@type": "KeyExtractor",
-            "key": "httpsKey"
-          }
-        },
-        {
-          "CombinedShorthandResolver:_resolvers_key": "urn:solid-server:custom:variable:httpsCert",
-          "CombinedShorthandResolver:_resolvers_value": {
-            "@type": "KeyExtractor",
-            "key": "httpsCert"
-          }
-        }
-      ]
-    },
-    {
-      "comment": [
-        "Creates an HTTPS server with the settings provided via the command line.",
-        "Replaces the example import from config/http/server-factory.https-example.json."
-      ],
-      "@id": "urn:solid-server:default:ServerFactory",
-      "@type": "WebSocketServerFactory",
-      "baseServerFactory": {
-        "@id": "urn:solid-server:default:HttpServerFactory",
-        "@type": "BaseHttpServerFactory",
-        "handler": { "@id": "urn:solid-server:default:HttpHandler" },
-        "options_showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" },
-        "options_https": true,
-        "options_key": {
-          "@id": "urn:solid-server:custom:variable:httpsKey",
-          "@type": "Variable"
-        },
-        "options_cert": {
-          "@id": "urn:solid-server:custom:variable:httpsCert",
-          "@type": "Variable"
-        }
-      },
-      "webSocketHandler": {
-        "@type": "UnsecureWebSocketsProtocol",
-        "source": { "@id": "urn:solid-server:default:ResourceStore" }
-      }
+      "comment": "Adds CLI options --httpsKey and --httpsCert and uses those to start an HTTPS server."
     }
   ]
 }


### PR DESCRIPTION
#### ✍️ Description

Moves all the stuff that enables extra CLI params for an HTTPS server to an import option, making it easier to combine with other custom configurations (e.g., mashlib recipe).

I don't really like how HTTP/HTTPS is tied to websockets/no-websockets, but splitting those up would require a larger refactor which would have an impact on existing configs so perhaps something for the future.

Sort of an example of how we can move other CLI params to specific imports in the future (`rootFilePath`, `sparqlEndpoint`, etc.).
