### PR TITLE
docs: Fix link to Identity Provider section

### DIFF
--- a/documentation/markdown/client-credentials.md
+++ b/documentation/markdown/client-credentials.md
@@ -2,7 +2,7 @@
 
 One potential issue for scripts and other applications is that it requires user interaction to log in and authenticate.
 The CSS offers an alternative solution for such cases by making use of Client Credentials.
-Once you have created an account as described in the [Identity Provider section](dependency-injection.md),
+Once you have created an account as described in the [Identity Provider section](identity-provider.md),
 users can request a token that apps can use to authenticate without user input.
 
 All requests to the client credentials API currently require you


### PR DESCRIPTION
#### 📁 Related issues

None

#### ✍️ Description

The link in the documentation of Client Credentials to the Identity Provider section goes to Dependency Injection instead. This PR fixes this.


### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [x] any relevant documentation was updated to reflect the changes in this PR.
