### PR TITLE
fix: Convert TemplateEngine to AsyncHandlers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,7 +23,10 @@ The following changes pertain to the imports in the default configs:
 
 The following changes are relevant for v5 custom configs that replaced certain features.
 
-- ...
+- Updated template configs.
+    - `/app/main/general/templates.json` was added to configure a generic template engine handler.
+    - `/app/main/default.json` now imports the above config file.
+    - All files configuring template engines.
 
 ### Interface changes
 

--- a/config/app/init/initializers/prefilled-root.json
+++ b/config/app/init/initializers/prefilled-root.json
@@ -17,10 +17,7 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/prefilled",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": {
-            "@type": "HandlebarsTemplateEngine",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-          },
+          "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
           "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
           "store": { "@id": "urn:solid-server:default:ResourceStore"}
         },

--- a/config/app/init/initializers/root.json
+++ b/config/app/init/initializers/root.json
@@ -17,10 +17,7 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/empty",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": {
-            "@type": "HandlebarsTemplateEngine",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-          },
+          "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
           "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
           "store": { "@id": "urn:solid-server:default:ResourceStore"}
         },

--- a/config/app/main/default.json
+++ b/config/app/main/default.json
@@ -1,5 +1,8 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/main/general/templates.json"
+  ],
   "@graph": [
     {
       "comment": "This is the entry point to the application. It can be used to both start and stop the server.",

--- a/config/app/main/general/templates.json
+++ b/config/app/main/general/templates.json
@@ -1,0 +1,22 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Template engine that finds the appropriate template engine to use based on the template extension.",
+      "@id": "urn:solid-server:default:TemplateEngine",
+      "@type": "WaterfallHandler",
+      "handlers": [
+        {
+          "comment": "Template engine that supports EJS templates.",
+          "@type": "EjsTemplateEngine",
+          "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+        },
+        {
+          "comment": "Template engine that supports Handlebars (HBS) templates",
+          "@type": "HandlebarsTemplateEngine",
+          "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+        }
+      ]
+    }
+  ]
+}

--- a/config/app/setup/handlers/setup.json
+++ b/config/app/setup/handlers/setup.json
@@ -26,15 +26,15 @@
           "engines": [
             {
               "comment": "Renders the main setup template.",
-              "@type": "EjsTemplateEngine",
-              "template": "@css:templates/setup/index.html.ejs",
-              "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+              "@type": "StaticTemplateEngine",
+              "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+              "template": "@css:templates/setup/index.html.ejs"
             },
             {
               "comment": "Will embed the result of the first engine into the main HTML template.",
-              "@type": "EjsTemplateEngine",
-              "template": "@css:templates/main.html.ejs",
-              "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+              "@type": "StaticTemplateEngine",
+              "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+              "template": "@css:templates/main.html.ejs"
             }
           ]
         }
@@ -62,10 +62,7 @@
         "@type": "TemplatedResourcesGenerator",
         "templateFolder": "@css:templates/root/empty",
         "factory": { "@type": "ExtensionBasedMapperFactory" },
-        "templateEngine": {
-          "@type": "HandlebarsTemplateEngine",
-          "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-        },
+        "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
         "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
         "store": { "@id": "urn:solid-server:default:ResourceStore"}
       },

--- a/config/identity/access/initializers/idp.json
+++ b/config/identity/access/initializers/idp.json
@@ -17,10 +17,7 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/empty",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": {
-            "@type": "HandlebarsTemplateEngine",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-          },
+          "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
           "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
           "store": { "@id": "urn:solid-server:default:ResourceStore"}
         },

--- a/config/identity/access/initializers/well-known.json
+++ b/config/identity/access/initializers/well-known.json
@@ -17,10 +17,7 @@
           "@type": "TemplatedResourcesGenerator",
           "templateFolder": "@css:templates/root/empty",
           "factory": { "@type": "ExtensionBasedMapperFactory" },
-          "templateEngine": {
-            "@type": "HandlebarsTemplateEngine",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-          },
+          "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
           "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
           "store": { "@id": "urn:solid-server:default:ResourceStore"}
         },

--- a/config/identity/handler/interaction/routes/forgot-password.json
+++ b/config/identity/handler/interaction/routes/forgot-password.json
@@ -16,9 +16,9 @@
         "@type": "ForgotPasswordHandler",
         "args_accountStore": { "@id": "urn:solid-server:auth:password:AccountStore" },
         "args_templateEngine": {
-          "@type": "EjsTemplateEngine",
-          "template": "@css:templates/identity/email-password/reset-password-email.html.ejs",
-          "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+          "@type": "StaticTemplateEngine",
+          "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+          "template": "@css:templates/identity/email-password/reset-password-email.html.ejs"
         },
         "args_emailSender": { "@id": "urn:solid-server:default:EmailSender" },
         "args_resetRoute": { "@id": "urn:solid-server:auth:password:ResetPasswordRoute" }

--- a/config/identity/handler/interaction/views/html.json
+++ b/config/identity/handler/interaction/views/html.json
@@ -12,14 +12,13 @@
         "engines": [
           {
             "comment": "Will be called with specific templates to generate HTML snippets.",
-            "@type": "EjsTemplateEngine",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+            "@id": "urn:solid-server:default:TemplateEngine"
           },
           {
             "comment": "Will embed the result of the first engine into the main HTML template.",
-            "@type": "EjsTemplateEngine",
-            "template": "@css:templates/main.html.ejs",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+            "@type": "StaticTemplateEngine",
+            "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+            "template": "@css:templates/main.html.ejs"
           }
         ]
       },

--- a/config/identity/pod/resource-generators/templated.json
+++ b/config/identity/pod/resource-generators/templated.json
@@ -9,10 +9,7 @@
       "factory": {
         "@type": "ExtensionBasedMapperFactory"
       },
-      "templateEngine": {
-        "@type": "HandlebarsTemplateEngine",
-        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-      },
+      "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
       "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" },
       "store": { "@id": "urn:solid-server:default:ResourceStore"}
     }

--- a/config/util/representation-conversion/converters/dynamic-json-template.json
+++ b/config/util/representation-conversion/converters/dynamic-json-template.json
@@ -12,14 +12,13 @@
         "engines": [
           {
             "comment": "Will be called with specific templates to generate HTML snippets.",
-            "@type": "EjsTemplateEngine",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+            "@id": "urn:solid-server:default:TemplateEngine"
           },
           {
             "comment": "Will embed the result of the first engine into the main HTML template.",
-            "@type": "EjsTemplateEngine",
-            "template": "@css:templates/main.html.ejs",
-            "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+            "@type": "StaticTemplateEngine",
+            "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+            "template": "@css:templates/main.html.ejs"
           }
         ]
       }

--- a/config/util/representation-conversion/converters/errors.json
+++ b/config/util/representation-conversion/converters/errors.json
@@ -13,10 +13,7 @@
       "comment": "Converts an error into a Markdown description of its details.",
       "@id": "urn:solid-server:default:ErrorToTemplateConverter",
       "@type": "ErrorToTemplateConverter",
-      "templateEngine": {
-        "@type": "HandlebarsTemplateEngine",
-        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
-      }
+      "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" }
     }
   ]
 }

--- a/config/util/representation-conversion/converters/markdown.json
+++ b/config/util/representation-conversion/converters/markdown.json
@@ -6,9 +6,9 @@
       "@id": "urn:solid-server:default:MarkdownToHtmlConverter",
       "@type": "MarkdownToHtmlConverter",
       "templateEngine": {
-        "@type": "EjsTemplateEngine",
-        "template": "@css:templates/main.html.ejs",
-        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+        "@type": "StaticTemplateEngine",
+        "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+        "template": "@css:templates/main.html.ejs"
       }
     },
     {
@@ -16,9 +16,9 @@
       "@id": "urn:solid-server:default:ContainerToTemplateConverter",
       "@type": "ContainerToTemplateConverter",
       "templateEngine": {
-        "@type": "HandlebarsTemplateEngine",
-        "template": "@css:templates/container.md.hbs",
-        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+        "@type": "StaticTemplateEngine",
+        "templateEngine": { "@id": "urn:solid-server:default:TemplateEngine" },
+        "template": "@css:templates/container.md.hbs"
       },
       "contentType": "text/markdown",
       "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" }

--- a/src/identity/interaction/HtmlViewHandler.ts
+++ b/src/identity/interaction/HtmlViewHandler.ts
@@ -55,7 +55,7 @@ export class HtmlViewHandler extends InteractionHandler {
   public async handle({ operation, oidcInteraction }: InteractionHandlerInput): Promise<Representation> {
     const template = this.templates[operation.target.path];
     const contents = { idpIndex: this.idpIndex, authenticating: Boolean(oidcInteraction) };
-    const result = await this.templateEngine.render(contents, { templateFile: template });
+    const result = await this.templateEngine.handleSafe({ contents, template: { templateFile: template }});
     return new BasicRepresentation(result, operation.target, TEXT_HTML);
   }
 }

--- a/src/identity/interaction/email-password/handler/ForgotPasswordHandler.ts
+++ b/src/identity/interaction/email-password/handler/ForgotPasswordHandler.ts
@@ -75,7 +75,7 @@ export class ForgotPasswordHandler extends BaseInteractionHandler {
   private async sendResetMail(recordId: string, email: string): Promise<void> {
     this.logger.info(`Sending password reset to ${email}`);
     const resetLink = `${this.resetRoute.getPath()}?rid=${encodeURIComponent(recordId)}`;
-    const renderedEmail = await this.templateEngine.render({ resetLink });
+    const renderedEmail = await this.templateEngine.handleSafe({ contents: { resetLink }});
     await this.emailSender.handleSafe({
       recipient: email,
       subject: 'Reset your password',

--- a/src/index.ts
+++ b/src/index.ts
@@ -453,8 +453,11 @@ export * from './util/map/WrappedSetMultiMap';
 // Util/Templates
 export * from './util/templates/ChainedTemplateEngine';
 export * from './util/templates/EjsTemplateEngine';
+export * from './util/templates/ExtensionBasedTemplateEngine';
 export * from './util/templates/HandlebarsTemplateEngine';
+export * from './util/templates/StaticTemplateEngine';
 export * from './util/templates/TemplateEngine';
+export * from './util/templates/TemplateUtil';
 
 // Util
 export * from './util/ContentTypes';

--- a/src/init/setup/SetupHttpHandler.ts
+++ b/src/init/setup/SetupHttpHandler.ts
@@ -76,7 +76,7 @@ export class SetupHttpHandler extends OperationHttpHandler {
    * Returns the HTML representation of the setup page.
    */
   private async handleGet(operation: Operation): Promise<ResponseDescription> {
-    const result = await this.templateEngine.render({});
+    const result = await this.templateEngine.handleSafe({ contents: {}});
     const representation = new BasicRepresentation(result, operation.target, TEXT_HTML);
     return new OkResponseDescription(representation.metadata, representation.data);
   }

--- a/src/pods/generate/TemplatedResourcesGenerator.ts
+++ b/src/pods/generate/TemplatedResourcesGenerator.ts
@@ -206,9 +206,9 @@ export class TemplatedResourcesGenerator implements ResourcesGenerator {
   /**
    * Creates a read stream from the file and applies the template if necessary.
    */
-  private async processFile(link: TemplateResourceLink, options: Dict<string>): Promise<Guarded<Readable>> {
+  private async processFile(link: TemplateResourceLink, contents: Dict<string>): Promise<Guarded<Readable>> {
     if (link.isTemplate) {
-      const rendered = await this.templateEngine.render(options, { templateFile: link.filePath });
+      const rendered = await this.templateEngine.handleSafe({ contents, template: { templateFile: link.filePath }});
       return guardedStreamFrom(rendered);
     }
     return guardStream(createReadStream(link.filePath));

--- a/src/storage/conversion/ContainerToTemplateConverter.ts
+++ b/src/storage/conversion/ContainerToTemplateConverter.ts
@@ -43,13 +43,13 @@ export class ContainerToTemplateConverter extends BaseTypedRepresentationConvert
   }
 
   public async handle({ identifier, representation }: RepresentationConverterArgs): Promise<Representation> {
-    const rendered = await this.templateEngine.render({
+    const rendered = await this.templateEngine.handleSafe({ contents: {
       identifier: identifier.path,
       name: this.getLocalName(identifier.path),
       container: true,
       children: await this.getChildResources(identifier, representation.data),
       parents: this.getParentContainers(identifier),
-    });
+    }});
     return new BasicRepresentation(rendered, representation.metadata, this.contentType);
   }
 

--- a/src/storage/conversion/DynamicJsonToTemplateConverter.ts
+++ b/src/storage/conversion/DynamicJsonToTemplateConverter.ts
@@ -58,9 +58,9 @@ export class DynamicJsonToTemplateConverter extends RepresentationConverter {
       return representation;
     }
 
-    const json = JSON.parse(await readableToString(representation.data));
+    const contents = JSON.parse(await readableToString(representation.data));
 
-    const rendered = await this.templateEngine.render(json, { templateFile: typeMap[type] });
+    const rendered = await this.templateEngine.handleSafe({ contents, template: { templateFile: typeMap[type] }});
     const metadata = new RepresentationMetadata(representation.metadata, { [CONTENT_TYPE]: type });
 
     return new BasicRepresentation(rendered, metadata);

--- a/src/storage/conversion/ErrorToTemplateConverter.ts
+++ b/src/storage/conversion/ErrorToTemplateConverter.ts
@@ -65,8 +65,8 @@ export class ErrorToTemplateConverter extends BaseTypedRepresentationConverter {
       try {
         const templateFile = `${error.errorCode}${this.extension}`;
         assert(isValidFileName(templateFile), 'Invalid error template name');
-        description = await this.templateEngine.render(error.details ?? {},
-          { templateFile, templatePath: this.codeTemplatesPath });
+        description = await this.templateEngine.handleSafe({ contents: error.details ?? {},
+          template: { templateFile, templatePath: this.codeTemplatesPath }});
       } catch {
         // In case no template is found, or rendering errors, we still want to convert
       }
@@ -74,8 +74,9 @@ export class ErrorToTemplateConverter extends BaseTypedRepresentationConverter {
 
     // Render the main template, embedding the rendered error description
     const { name, message, stack } = error;
-    const variables = { name, message, stack, description };
-    const rendered = await this.templateEngine.render(variables, { templateFile: this.mainTemplatePath });
+    const contents = { name, message, stack, description };
+    const rendered = await this.templateEngine
+      .handleSafe({ contents, template: { templateFile: this.mainTemplatePath }});
 
     return new BasicRepresentation(rendered, representation.metadata, this.contentType);
   }

--- a/src/storage/conversion/MarkdownToHtmlConverter.ts
+++ b/src/storage/conversion/MarkdownToHtmlConverter.ts
@@ -24,7 +24,7 @@ export class MarkdownToHtmlConverter extends BaseTypedRepresentationConverter {
   public async handle({ representation }: RepresentationConverterArgs): Promise<Representation> {
     const markdown = await readableToString(representation.data);
     const htmlBody = marked(markdown);
-    const html = await this.templateEngine.render({ htmlBody });
+    const html = await this.templateEngine.handleSafe({ contents: { htmlBody }});
 
     return new BasicRepresentation(html, representation.metadata, TEXT_HTML);
   }

--- a/src/util/templates/ExtensionBasedTemplateEngine.ts
+++ b/src/util/templates/ExtensionBasedTemplateEngine.ts
@@ -1,0 +1,34 @@
+import { NotImplementedHttpError } from '../errors/NotImplementedHttpError';
+import { getExtension } from '../PathUtil';
+import type { TemplateEngineInput } from './TemplateEngine';
+import { TemplateEngine } from './TemplateEngine';
+import { getTemplateFilePath } from './TemplateUtil';
+import Dict = NodeJS.Dict;
+
+/**
+ * Parent class for template engines that accept handling based on whether the template extension is supported.
+ */
+export abstract class ExtensionBasedTemplateEngine<T extends Dict<any> = Dict<any>> extends TemplateEngine<T> {
+  protected readonly supportedExtensions: string[];
+
+  /**
+   * Constructor for ExtensionBasedTemplateEngine.
+   *
+   * @param supportedExtensions - Array of the extensions supported by the template engine (e.g. [ 'ejs' ]).
+   */
+  protected constructor(supportedExtensions: string[]) {
+    super();
+    this.supportedExtensions = supportedExtensions;
+  }
+
+  public async canHandle({ template }: TemplateEngineInput<T>): Promise<void> {
+    if (typeof template === 'undefined') {
+      throw new NotImplementedHttpError('No template was provided.');
+    }
+    // Check if the target template extension is supported.
+    const filepath = getTemplateFilePath(template);
+    if (typeof filepath === 'undefined' || !this.supportedExtensions.includes(getExtension(filepath))) {
+      throw new NotImplementedHttpError('The provided template is not supported.');
+    }
+  }
+}

--- a/src/util/templates/StaticTemplateEngine.ts
+++ b/src/util/templates/StaticTemplateEngine.ts
@@ -1,0 +1,36 @@
+import type { AsyncHandler } from '../handlers/AsyncHandler';
+import type { TemplateEngineInput, Template } from './TemplateEngine';
+import { TemplateEngine } from './TemplateEngine';
+import Dict = NodeJS.Dict;
+
+/**
+ * Template engine that renders output based on a static template file.
+ */
+export class StaticTemplateEngine<T extends Dict<any> = Dict<any>> extends TemplateEngine<T> {
+  private readonly template: Template;
+  private readonly templateEngine: AsyncHandler<TemplateEngineInput<T>, string>;
+
+  /**
+   * Creates a new StaticTemplateEngine.
+   *
+   * @param templateEngine - The template engine that should be used for processing the template.
+   * @param template - The static template to be used.
+   */
+  public constructor(templateEngine: AsyncHandler<TemplateEngineInput<T>, string>, template: Template) {
+    super();
+    this.template = template;
+    this.templateEngine = templateEngine;
+  }
+
+  public async canHandle({ contents, template }: TemplateEngineInput<T>): Promise<void> {
+    if (typeof template !== 'undefined') {
+      throw new Error('StaticTemplateEngine does not support template as handle input, ' +
+          'provide a template via the constructor instead!');
+    }
+    return this.templateEngine.canHandle({ contents, template: this.template });
+  }
+
+  public async handle({ contents }: TemplateEngineInput<T>): Promise<string> {
+    return this.templateEngine.handle({ contents, template: this.template });
+  }
+}

--- a/src/util/templates/TemplateEngine.ts
+++ b/src/util/templates/TemplateEngine.ts
@@ -1,5 +1,4 @@
-import { promises as fsPromises } from 'fs';
-import { joinFilePath, resolveAssetPath } from '../PathUtil';
+import { AsyncHandler } from '../handlers/AsyncHandler';
 import Dict = NodeJS.Dict;
 
 export type Template = TemplateFileName | TemplateString | TemplatePath;
@@ -18,50 +17,19 @@ export interface TemplatePath {
   templatePath?: string;
 }
 
-/* eslint-disable @typescript-eslint/method-signature-style */
 /**
+ * Utility interface for representing TemplateEngine input.
+ */
+export interface TemplateEngineInput<T> {
+  // The contents to render
+  contents: T;
+  // The template to use for rendering (optional)
+  template?: Template;
+}
+
+/**
+ * Generic interface for classes that implement a template engine.
  * A template engine renders content into a template.
  */
-export interface TemplateEngine<T extends Dict<any> = Dict<any>> {
-  /**
-   * Renders the given contents into the template.
-   *
-   * @param contents - The contents to render.
-   * @param template - The template to use for rendering;
-   *                   if omitted, a default template is used.
-   * @returns The rendered contents.
-   */
-  render(contents: T): Promise<string>;
-  render<TCustom = T>(contents: TCustom, template: Template): Promise<string>;
-}
-/* eslint-enable @typescript-eslint/method-signature-style */
-
-/**
- * Returns the absolute path to the template.
- * Returns undefined if the input does not contain a file path.
- */
-export function getTemplateFilePath(template?: Template): string | undefined {
-  // The template has been passed as a filename
-  if (typeof template === 'string') {
-    return getTemplateFilePath({ templateFile: template });
-  }
-  // The template has already been given as a string so no known path
-  if (!template || 'templateString' in template) {
-    return;
-  }
-  const { templateFile, templatePath } = template;
-  const fullTemplatePath = templatePath ? joinFilePath(templatePath, templateFile) : templateFile;
-  return resolveAssetPath(fullTemplatePath);
-}
-
-/**
- * Reads the template and returns it as a string.
- */
-export async function readTemplate(template: Template = { templateString: '' }): Promise<string> {
-  // The template has already been given as a string
-  if (typeof template === 'object' && 'templateString' in template) {
-    return template.templateString;
-  }
-  // The template needs to be read from disk
-  return fsPromises.readFile(getTemplateFilePath(template)!, 'utf8');
-}
+export abstract class TemplateEngine<T extends Dict<any> = Dict<any>>
+  extends AsyncHandler<TemplateEngineInput<T>, string> {}

--- a/src/util/templates/TemplateUtil.ts
+++ b/src/util/templates/TemplateUtil.ts
@@ -1,0 +1,33 @@
+import { promises as fsPromises } from 'fs';
+import { joinFilePath, resolveAssetPath } from '../PathUtil';
+import type { Template } from './TemplateEngine';
+
+/**
+ * Returns the absolute path to the template.
+ * Returns undefined if the input does not contain a file path.
+ */
+export function getTemplateFilePath(template?: Template): string | undefined {
+  // The template has been passed as a filename
+  if (typeof template === 'string') {
+    return getTemplateFilePath({ templateFile: template });
+  }
+  // The template has already been given as a string so no known path
+  if (!template || 'templateString' in template) {
+    return;
+  }
+  const { templateFile, templatePath } = template;
+  const fullTemplatePath = templatePath ? joinFilePath(templatePath, templateFile) : templateFile;
+  return resolveAssetPath(fullTemplatePath);
+}
+
+/**
+ * Reads the template and returns it as a string.
+ */
+export async function readTemplate(template: Template = { templateString: '' }): Promise<string> {
+  // The template has already been given as a string
+  if (typeof template === 'object' && 'templateString' in template) {
+    return template.templateString;
+  }
+  // The template needs to be read from disk
+  return fsPromises.readFile(getTemplateFilePath(template)!, 'utf8');
+}

--- a/templates/config/defaults.json
+++ b/templates/config/defaults.json
@@ -1,6 +1,7 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
   "import": [
+    "css:config/app/main/general/templates.json",
     "css:config/util/auxiliary/acl.json",
     "css:config/util/index/default.json",
     "css:config/util/representation-conversion/default.json",

--- a/test/unit/identity/interaction/HtmlViewHandler.test.ts
+++ b/test/unit/identity/interaction/HtmlViewHandler.test.ts
@@ -35,8 +35,8 @@ describe('An HtmlViewHandler', (): void => {
     };
 
     templateEngine = {
-      render: jest.fn().mockReturnValue(Promise.resolve('<html>')),
-    };
+      handleSafe: jest.fn().mockReturnValue(Promise.resolve('<html>')),
+    } as any;
 
     handler = new HtmlViewHandler(index, templateEngine, templates);
   });
@@ -70,17 +70,23 @@ describe('An HtmlViewHandler', (): void => {
     const result = await handler.handle({ operation });
     expect(result.metadata.contentType).toBe(TEXT_HTML);
     await expect(readableToString(result.data)).resolves.toBe('<html>');
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render)
-      .toHaveBeenLastCalledWith({ idpIndex, authenticating: false }, { templateFile: '/templates/login.html.ejs' });
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe)
+      .toHaveBeenLastCalledWith({
+        contents: { idpIndex, authenticating: false },
+        template: { templateFile: '/templates/login.html.ejs' },
+      });
   });
 
   it('sets authenticating to true if there is an active interaction.', async(): Promise<void> => {
     const result = await handler.handle({ operation, oidcInteraction: {} as any });
     expect(result.metadata.contentType).toBe(TEXT_HTML);
     await expect(readableToString(result.data)).resolves.toBe('<html>');
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render)
-      .toHaveBeenLastCalledWith({ idpIndex, authenticating: true }, { templateFile: '/templates/login.html.ejs' });
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe)
+      .toHaveBeenLastCalledWith({
+        contents: { idpIndex, authenticating: true },
+        template: { templateFile: '/templates/login.html.ejs' },
+      });
   });
 });

--- a/test/unit/identity/interaction/email-password/handler/ForgotPasswordHandler.test.ts
+++ b/test/unit/identity/interaction/email-password/handler/ForgotPasswordHandler.test.ts
@@ -28,7 +28,7 @@ describe('A ForgotPasswordHandler', (): void => {
     } as any;
 
     templateEngine = {
-      render: jest.fn().mockResolvedValue(html),
+      handleSafe: jest.fn().mockResolvedValue(html),
     } as any;
 
     resetRoute = {

--- a/test/unit/init/setup/SetupHttpHandler.test.ts
+++ b/test/unit/init/setup/SetupHttpHandler.test.ts
@@ -37,8 +37,8 @@ describe('A SetupHttpHandler', (): void => {
     };
 
     templateEngine = {
-      render: jest.fn().mockReturnValue(Promise.resolve('<html>')),
-    };
+      handleSafe: jest.fn().mockReturnValue(Promise.resolve('<html>')),
+    } as any;
 
     converter = {
       handleSafe: jest.fn((input: RepresentationConverterArgs): Representation => {

--- a/test/unit/storage/conversion/ContainerToTemplateConverter.test.ts
+++ b/test/unit/storage/conversion/ContainerToTemplateConverter.test.ts
@@ -15,8 +15,8 @@ describe('A ContainerToTemplateConverter', (): void => {
 
   beforeEach(async(): Promise<void> => {
     templateEngine = {
-      render: jest.fn().mockReturnValue(Promise.resolve('<html>')),
-    };
+      handleSafe: jest.fn().mockReturnValue(Promise.resolve('<html>')),
+    } as any;
     converter = new ContainerToTemplateConverter(templateEngine, 'text/html', identifierStrategy);
   });
 
@@ -51,50 +51,52 @@ describe('A ContainerToTemplateConverter', (): void => {
     expect(converted.metadata.contentType).toBe('text/html');
     await expect(readableToString(converted.data)).resolves.toBe('<html>');
 
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render).toHaveBeenCalledWith({
-      identifier: container.path,
-      name: 'my-container',
-      container: true,
-      children: [
-        {
-          identifier: `${container.path}d/`,
-          name: 'd',
-          container: true,
-        },
-        {
-          identifier: `${container.path}a`,
-          name: 'a',
-          container: false,
-        },
-        {
-          identifier: `${container.path}b`,
-          name: 'b',
-          container: false,
-        },
-        {
-          identifier: `${container.path}c%20c`,
-          name: 'c c',
-          container: false,
-        },
-      ],
-      parents: [
-        {
-          identifier: 'http://test.com/',
-          name: 'test.com',
-          container: true,
-        },
-        {
-          identifier: 'http://test.com/foo/',
-          name: 'foo',
-          container: true,
-        },
-        {
-          identifier: 'http://test.com/foo/bar/',
-          name: 'bar',
-          container: true,
-        },
-      ],
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe).toHaveBeenCalledWith({
+      contents: {
+        identifier: container.path,
+        name: 'my-container',
+        container: true,
+        children: [
+          {
+            identifier: `${container.path}d/`,
+            name: 'd',
+            container: true,
+          },
+          {
+            identifier: `${container.path}a`,
+            name: 'a',
+            container: false,
+          },
+          {
+            identifier: `${container.path}b`,
+            name: 'b',
+            container: false,
+          },
+          {
+            identifier: `${container.path}c%20c`,
+            name: 'c c',
+            container: false,
+          },
+        ],
+        parents: [
+          {
+            identifier: 'http://test.com/',
+            name: 'test.com',
+            container: true,
+          },
+          {
+            identifier: 'http://test.com/foo/',
+            name: 'foo',
+            container: true,
+          },
+          {
+            identifier: 'http://test.com/foo/bar/',
+            name: 'bar',
+            container: true,
+          },
+        ],
+      },
     });
   });
 
@@ -108,13 +110,15 @@ describe('A ContainerToTemplateConverter', (): void => {
     ], 'internal/quads', false);
     await converter.handle({ identifier: container, representation, preferences });
 
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render).toHaveBeenCalledWith({
-      identifier: container.path,
-      name: 'test.com',
-      container: true,
-      children: expect.objectContaining({ length: 3 }),
-      parents: [],
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe).toHaveBeenCalledWith({
+      contents: {
+        identifier: container.path,
+        name: 'test.com',
+        container: true,
+        children: expect.objectContaining({ length: 3 }),
+        parents: [],
+      },
     });
   });
 
@@ -124,13 +128,15 @@ describe('A ContainerToTemplateConverter', (): void => {
     jest.spyOn(identifierStrategy, 'isRootContainer').mockReturnValueOnce(true);
     await converter.handle({ identifier: container, representation, preferences });
 
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render).toHaveBeenCalledWith({
-      identifier: container.path,
-      name: container.path,
-      container: true,
-      children: [],
-      parents: [],
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe).toHaveBeenCalledWith({
+      contents: {
+        identifier: container.path,
+        name: container.path,
+        container: true,
+        children: [],
+        parents: [],
+      },
     });
   });
 });

--- a/test/unit/storage/conversion/DynamicJsonToTemplateConverter.test.ts
+++ b/test/unit/storage/conversion/DynamicJsonToTemplateConverter.test.ts
@@ -33,8 +33,8 @@ describe('A DynamicJsonToTemplateConverter', (): void => {
     input = { identifier, representation, preferences };
 
     templateEngine = {
-      render: jest.fn().mockReturnValue(Promise.resolve('<html>')),
-    };
+      handleSafe: jest.fn().mockReturnValue(Promise.resolve('<html>')),
+    } as any;
     converter = new DynamicJsonToTemplateConverter(templateEngine);
   });
 
@@ -63,8 +63,8 @@ describe('A DynamicJsonToTemplateConverter', (): void => {
     await expect(readableToString(result.data)).resolves.toBe('<html>');
     expect(result.binary).toBe(true);
     expect(result.metadata.contentType).toBe('text/html');
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render).toHaveBeenLastCalledWith({ json: true }, { templateFile });
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe).toHaveBeenLastCalledWith({ contents: { json: true }, template: { templateFile }});
   });
 
   it('supports missing type preferences.', async(): Promise<void> => {

--- a/test/unit/storage/conversion/MarkdownToHtmlConverter.test.ts
+++ b/test/unit/storage/conversion/MarkdownToHtmlConverter.test.ts
@@ -11,8 +11,8 @@ describe('A MarkdownToHtmlConverter', (): void => {
 
   beforeEach(async(): Promise<void> => {
     templateEngine = {
-      render: jest.fn().mockReturnValue(Promise.resolve('<html>')),
-    };
+      handleSafe: jest.fn().mockReturnValue(Promise.resolve('<html>')),
+    } as any;
     converter = new MarkdownToHtmlConverter(templateEngine);
   });
 
@@ -29,9 +29,9 @@ describe('A MarkdownToHtmlConverter', (): void => {
     expect(result.binary).toBe(true);
     expect(result.metadata.contentType).toBe('text/html');
     await expect(readableToString(result.data)).resolves.toBe('<html>');
-    expect(templateEngine.render).toHaveBeenCalledTimes(1);
-    expect(templateEngine.render).toHaveBeenLastCalledWith(
-      { htmlBody: '<p>Text <code>code</code> more text.</p>\n' },
+    expect(templateEngine.handleSafe).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handleSafe).toHaveBeenLastCalledWith(
+      { contents: { htmlBody: '<p>Text <code>code</code> more text.</p>\n' }},
     );
   });
 });

--- a/test/unit/util/templates/EjsTemplateEngine.test.ts
+++ b/test/unit/util/templates/EjsTemplateEngine.test.ts
@@ -1,24 +1,31 @@
+import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
 import { EjsTemplateEngine } from '../../../../src/util/templates/EjsTemplateEngine';
 
-jest.mock('../../../../src/util/templates/TemplateEngine', (): any => ({
-  getTemplateFilePath: jest.fn((): string => `filename`),
-  readTemplate: jest.fn(async({ templateString }): Promise<string> => `${templateString}: <%= detail %>`),
+jest.mock('../../../../src/util/templates/TemplateUtil', (): any => ({
+  getTemplateFilePath: jest.fn((template): string => template),
+  readTemplate: jest.fn(async(): Promise<string> => `<%= detail %>`),
 }));
 
 describe('A EjsTemplateEngine', (): void => {
-  const defaultTemplate = { templateString: 'xyz' };
   const contents = { detail: 'a&b' };
   let templateEngine: EjsTemplateEngine;
 
   beforeEach((): void => {
-    templateEngine = new EjsTemplateEngine('http://localhost:3000', defaultTemplate);
-  });
-
-  it('uses the default template when no template was passed.', async(): Promise<void> => {
-    await expect(templateEngine.render(contents)).resolves.toBe('xyz: a&amp;b');
+    templateEngine = new EjsTemplateEngine('http://localhost:3000');
   });
 
   it('uses the passed template.', async(): Promise<void> => {
-    await expect(templateEngine.render(contents, { templateString: 'my' })).resolves.toBe('my: a&amp;b');
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.ejs' }))
+      .resolves.toBe('a&amp;b');
+  });
+
+  it('throws an exception for unsupported template files.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.txt' }))
+      .rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('throws an exception if no template was passed.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents }))
+      .rejects.toThrow(NotImplementedHttpError);
   });
 });

--- a/test/unit/util/templates/HandlebarsTemplateEngine.test.ts
+++ b/test/unit/util/templates/HandlebarsTemplateEngine.test.ts
@@ -1,23 +1,31 @@
+import { NotImplementedHttpError } from '../../../../src';
 import { HandlebarsTemplateEngine } from '../../../../src/util/templates/HandlebarsTemplateEngine';
 
-jest.mock('../../../../src/util/templates/TemplateEngine', (): any => ({
-  readTemplate: jest.fn(async({ templateString }): Promise<string> => `${templateString}: {{detail}}`),
+jest.mock('../../../../src/util/templates/TemplateUtil', (): any => ({
+  getTemplateFilePath: jest.fn((template): string => template),
+  readTemplate: jest.fn(async(): Promise<string> => `{{detail}}`),
 }));
 
 describe('A HandlebarsTemplateEngine', (): void => {
-  const template = { templateString: 'xyz' };
   const contents = { detail: 'a&b' };
   let templateEngine: HandlebarsTemplateEngine;
 
   beforeEach((): void => {
-    templateEngine = new HandlebarsTemplateEngine('http://localhost:3000/', template);
-  });
-
-  it('uses the default template when no template was passed.', async(): Promise<void> => {
-    await expect(templateEngine.render(contents)).resolves.toBe('xyz: a&amp;b');
+    templateEngine = new HandlebarsTemplateEngine('http://localhost:3000/');
   });
 
   it('uses the passed template.', async(): Promise<void> => {
-    await expect(templateEngine.render(contents, { templateString: 'my' })).resolves.toBe('my: a&amp;b');
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.hbs' }))
+      .resolves.toBe('a&amp;b');
+  });
+
+  it('throws an exception for unsupported template files.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents, template: 'someTemplate.txt' }))
+      .rejects.toThrow(NotImplementedHttpError);
+  });
+
+  it('throws an exception if no template was passed.', async(): Promise<void> => {
+    await expect(templateEngine.handleSafe({ contents }))
+      .rejects.toThrow(NotImplementedHttpError);
   });
 });

--- a/test/unit/util/templates/StaticTemplateEngine.test.ts
+++ b/test/unit/util/templates/StaticTemplateEngine.test.ts
@@ -1,0 +1,47 @@
+import { StaticTemplateEngine, NotFoundHttpError } from '../../../../src';
+import type { AsyncHandler, TemplateEngineInput } from '../../../../src';
+import Dict = NodeJS.Dict;
+
+describe('A StaticTemplateEngine', (): void => {
+  let templateEngine: jest.Mocked<AsyncHandler<TemplateEngineInput<Dict<any>>, string>>;
+
+  it('forwards calls to the handle method of the provided templateEngine, adding the template as an argument.',
+    async(): Promise<void> => {
+      templateEngine = {
+        canHandle: jest.fn(),
+        handle: jest.fn().mockResolvedValue(''),
+      } as any;
+      const input = { contents: {}};
+      const engine = new StaticTemplateEngine(templateEngine, 'template');
+      await expect(engine.handleSafe(input)).resolves.toBe('');
+      expect(templateEngine.canHandle).toHaveBeenCalledTimes(1);
+      expect(templateEngine.canHandle).toHaveBeenLastCalledWith({ contents: {}, template: 'template' });
+      expect(templateEngine.handle).toHaveBeenCalledTimes(1);
+      expect(templateEngine.handle).toHaveBeenLastCalledWith({ contents: {}, template: 'template' });
+    });
+
+  it('propagates errors that occur in the handle method of the provided handler.', async(): Promise<void> => {
+    templateEngine = {
+      canHandle: jest.fn(),
+      handle: jest.fn().mockRejectedValue(new NotFoundHttpError()),
+    } as any;
+    const input = { contents: {}};
+    const engine = new StaticTemplateEngine(templateEngine, 'template');
+    await expect(engine.handleSafe(input)).rejects.toThrow(NotFoundHttpError);
+    expect(templateEngine.canHandle).toHaveBeenCalledTimes(1);
+    expect(templateEngine.canHandle).toHaveBeenLastCalledWith({ contents: input.contents, template: 'template' });
+    expect(templateEngine.handle).toHaveBeenCalledTimes(1);
+    expect(templateEngine.handle).toHaveBeenLastCalledWith({ contents: input.contents, template: 'template' });
+  });
+
+  it('results in an error when calling handle with template defined.', async(): Promise<void> => {
+    templateEngine = {
+      canHandle: jest.fn(),
+      handle: jest.fn().mockResolvedValue(''),
+    } as any;
+    const input = { contents: {}, template: 'template2' };
+    const engine = new StaticTemplateEngine(templateEngine, 'template1');
+    await expect(engine.handleSafe(input)).rejects
+      .toThrow('StaticTemplateEngine does not support template as handle input');
+  });
+});

--- a/test/unit/util/templates/TemplateUtil.test.ts
+++ b/test/unit/util/templates/TemplateUtil.test.ts
@@ -1,10 +1,10 @@
 import { resolveAssetPath } from '../../../../src/util/PathUtil';
-import { getTemplateFilePath, readTemplate } from '../../../../src/util/templates/TemplateEngine';
+import { getTemplateFilePath, readTemplate } from '../../../../src/util/templates/TemplateUtil';
 import { mockFileSystem } from '../../../util/Util';
 
 jest.mock('fs');
 
-describe('TemplateEngine', (): void => {
+describe('TemplateUtil', (): void => {
   describe('#getTemplateFilePath', (): void => {
     const templateFile = 'template.xyz';
     const templatePath = 'other';


### PR DESCRIPTION
#### 📁 Related issues

<!-- 
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose
-->
#919 

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->
This PR introduces the abstract class `TemplateEngineHandler` which provides a base type for template engine implementations and enables instances of the child classes to be used as AsyncHandlers.

`EjsTemplateEngine` and `HandlebarsTemplateEngine` have been modified to extend `TemplateEngineHandler`. A new implementation `GenericTemplateEngine` was added that allows processing templates based on a compatible AsyncHandler.

Using this 'framework', a configuration for a GenericTemplateEngine AsyncHandler (based on WaterfallHandler) was defined in `/app/main/general/templates.json` to be used as a generic handler for `GenericTemplateEngine` instances. All existing Ejs/HandlebarsTemplateEngine configurations were modified to use this generic template engine instead.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
