### PR TITLE
Build mkdocs on every push on the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
+      -
+        name: Install jq
+        run: apt-get update && apt-get install -y jq
       - 
         name: Checkout
         uses: actions/checkout@v3
@@ -195,16 +198,24 @@ jobs:
           load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - 
-        name: "Test docker image 'edge'"
-        if: github.ref == 'refs/heads/main'
+      -
+        name: Store built tags in env variable
+        shell: bash
         run: |
-          docker run --rm --pull never solidproject/community-server:edge --version
+          echo 'generated_tags<<EOM' >> $GITHUB_ENV
+          echo '${{ toJSON(fromJSON(steps.meta.outputs.json).tags) }}' >> $GITHUB_ENV
+          echo 'EOM' >> $GITHUB_ENV
       - 
-        name: "Test docker image 'latest'"
-        if: startsWith(github.ref, 'refs/tags/v')
+        name: "Test all docker-built image tags"
+        shell: bash
+        # Loop over all generated image:tag names and docker run them. 
+        # If they aren't built previously, the command will error.
+        # If they don't work, the job will fail.
+        # If they work the --version argument should return a version. and the job succeeds.
         run: |
-          docker run --rm --pull never solidproject/community-server:latest --version
+          jq -rc '.[]' <<< '${{env.generated_tags}}' | while read i; do
+            docker run --rm --pull never $i --version
+          done;
       - 
         name: Build and push
         uses: docker/build-push-action@v3
@@ -292,10 +303,12 @@ jobs:
           path: docs
           retention-days: 1
 
-  mkdocs:
+  mkdocs-tag:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Only trigger on tagged release that doesn't have a prerelease qualifier (like -alpha, -beta, -rc)
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
     needs:
+      - docker-main-branch
       - typedocs
     steps:
       - uses: actions/checkout@v2
@@ -309,11 +322,34 @@ jobs:
       - run: git config user.name ci-bot
       - run: git config user.email ci-bot@example.com
       - run: git fetch origin gh-pages --depth=1
-      - run: cd documentation && mike deploy --push --update-aliases ${{steps.get_version.outputs.major}}.${{steps.get_version.outputs.minor}} latest
+      - run: cd documentation && mike deploy --push --update-aliases ${{steps.get_version.outputs.major}}.x latest
+  
+  mkdocs-latest:
+    runs-on: ubuntu-latest
+    # Runs on main branch commits: thus rebuild documentation of version that has 'latest' alias.
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - docker-main-branch    
+      - typedocs
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material 
+      - run: pip install mike
+      - run: apt-get update && apt-get install -y jq
+      - run: git config user.name ci-bot
+      - run: git config user.email ci-bot@example.com
+      - name: Extract major version from package.json
+        run: VERSION=$(git show origin/main:package.json | jq -r .version | grep -Po '^(\d+)').x
+      - run: git fetch origin gh-pages --depth=1
+      - run: cd documentation && mike deploy --push --update-aliases ${VERSION} latest
 
   publish-docs:
+    # When a new version is tagged, upload the generated typedocs to the appropriate mkdocs <major.x> folder.
     needs:
-      - mkdocs
+      - mkdocs-tag
       - lint
       - test-unit
       - test-integration
@@ -332,4 +368,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          destination_dir:  ${{steps.get_version.outputs.major}}.${{steps.get_version.outputs.minor}}/docs
+          destination_dir:  ${{steps.get_version.outputs.major}}.x/docs


### PR DESCRIPTION
#### ✍️ Description

The idea of this PR is to update the ci pipeline so that mkdocs are being rebuild and updated on every push on the main branch. It is done by splitting it in to 2 jobs. 

The first one is just renamed from the old one and will handle tags (new `major.x` version is being pushed for the docs)

The second one will parse the `versions.json` file that is being hosted, and use jq to query the latest version name. It will then use that version name to update the existing docs.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether
  * [ ] this PR is labeled with the correct semver label
    - semver.patch: Backwards compatible bug fixes.
    - semver.minor: Backwards compatible feature additions.
    - semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  * [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
  * [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
  * [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
