### PR TITLE
feat: Allow vocabularies to be extended

### DIFF
--- a/test/unit/util/Vocabularies.test.ts
+++ b/test/unit/util/Vocabularies.test.ts
@@ -1,22 +1,50 @@
 import { DataFactory } from 'n3';
-import { LDP } from '../../../src/util/Vocabularies';
+import { createVocabulary, extendVocabulary } from '../../../src/util/Vocabularies';
 
 describe('Vocabularies', (): void => {
-  describe('LDP', (): void => {
+  const vocabulary = createVocabulary('http://www.w3.org/ns/ldp#', 'contains', 'Container');
+
+  describe('createVocabulary', (): void => {
     it('contains its own URI.', (): void => {
-      expect(LDP.namespace).toBe('http://www.w3.org/ns/ldp#');
+      expect(vocabulary.namespace).toBe('http://www.w3.org/ns/ldp#');
     });
 
     it('contains its own URI as a term.', (): void => {
-      expect(LDP.terms.namespace).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#'));
+      expect(vocabulary.terms.namespace).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#'));
     });
 
-    it('exposes ldp:contains.', (): void => {
-      expect(LDP.contains).toBe('http://www.w3.org/ns/ldp#contains');
+    it('exposes the defined URIs.', (): void => {
+      expect(vocabulary.contains).toBe('http://www.w3.org/ns/ldp#contains');
+      expect(vocabulary.Container).toBe('http://www.w3.org/ns/ldp#Container');
     });
 
-    it('exposes ldp:contains as a term.', (): void => {
-      expect(LDP.terms.contains).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#contains'));
+    it('exposes the defined URIs as terms.', (): void => {
+      expect(vocabulary.terms.contains).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#contains'));
+      expect(vocabulary.terms.Container).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#Container'));
+    });
+  });
+
+  describe('extendVocabulary', (): void => {
+    const extended = extendVocabulary(vocabulary, 'extended', 'extra');
+
+    it('still contains all the original values.', async(): Promise<void> => {
+      expect(extended.namespace).toBe('http://www.w3.org/ns/ldp#');
+      expect(extended.terms.namespace).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#'));
+      expect(extended.contains).toBe('http://www.w3.org/ns/ldp#contains');
+      expect(extended.Container).toBe('http://www.w3.org/ns/ldp#Container');
+      expect(extended.terms.contains).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#contains'));
+      expect(extended.terms.Container).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#Container'));
+    });
+
+    it('contains the new values.', async(): Promise<void> => {
+      expect(extended.extended).toBe('http://www.w3.org/ns/ldp#extended');
+      expect(extended.extra).toBe('http://www.w3.org/ns/ldp#extra');
+      expect(extended.terms.extended).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#extended'));
+      expect(extended.terms.extra).toEqual(DataFactory.namedNode('http://www.w3.org/ns/ldp#extra'));
+    });
+
+    it('does not modify the original vocabulary.', async(): Promise<void> => {
+      expect((vocabulary as any).extended).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
#### ✍️ Description

Allows vocabularies to be extended. Can be useful for external modules that want to use one of our vocabularies but want to add an extra field to it (which is the case in https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1000 for example). This depends on the breaking type changes so is part of the v6 branch. After this PR is merged I might also add the same in the main branch so it can be a feature release and already be used.
