### PR TITLE
Allow multiple configurations to be used during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,19 @@ by passing parameters to the server command.
 These parameters give you direct access
 to some commonly used settings:
 
-| parameter name         | default value              | description                                                                                                                          |
-|------------------------|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `--port, -p`           | `3000`                     | The TCP port on which the server should listen.                                                                                      |
-| `--baseUrl, -b`        | `http://localhost:$PORT/`  | The base URL used internally to generate URLs. Change this if your server does not run on `http://localhost:$PORT/`.                 |
-| `--loggingLevel, -l`   | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                        |
-| `--config, -c`         | `@css:config/default.json` | The configuration for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json` |
-| `--rootFilePath, -f`   | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                     |
-| `--sparqlEndpoint, -s` |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                              |
-| `--showStackTrace, -t` | false                      | Enables detailed logging on error output.                                                                                            |
-| `--podConfigJson`      | `./pod-config.json`        | Path to the file that keeps track of dynamic Pod configurations. Only relevant when using `@css:config/dynamic.json`.                |
-| `--seededPodConfigJson`|                            | Path to the file that keeps track of seeded Pod configurations.                                                                      |
-| `--mainModulePath, -m` |                            | Path from where Components.js will start its lookup when initializing configurations.                                                |
-| `--workers, -w`        | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded).     |
+| parameter name         | default value              | description                                                                                                                                   |
+|------------------------|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `--port, -p`           | `3000`                     | The TCP port on which the server should listen.                                                                                               |
+| `--baseUrl, -b`        | `http://localhost:$PORT/`  | The base URL used internally to generate URLs. Change this if your server does not run on `http://localhost:$PORT/`.                          |
+| `--loggingLevel, -l`   | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                                 |
+| `--config, -c`         | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`       |
+| `--rootFilePath, -f`   | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                              |
+| `--sparqlEndpoint, -s` |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                                       |
+| `--showStackTrace, -t` | false                      | Enables detailed logging on error output.                                                                                                     |
+| `--podConfigJson`      | `./pod-config.json`        | Path to the file that keeps track of dynamic Pod configurations. Only relevant when using `@css:config/dynamic.json`.                         |
+| `--seededPodConfigJson`|                            | Path to the file that keeps track of seeded Pod configurations.                                                                               |
+| `--mainModulePath, -m` |                            | Path from where Components.js will start its lookup when initializing configurations.                                                         |
+| `--workers, -w`        | `1`                        | Run in multithreaded mode using workers. Special values are `-1` (scale to `num_cores-1`), `0` (scale to `num_cores`) and 1 (singlethreaded). |
 
 ### 🔀 Multithreading
 The Community Solid Server can be started in multithreaded mode with any config. The config must only contain components that are threadsafe though. If a non-threadsafe component is used in multithreaded mode, the server will describe with an error which class is the culprit.

--- a/config/app/variables/cli/cli.json
+++ b/config/app/variables/cli/cli.json
@@ -12,8 +12,8 @@
           "options": {
             "alias": "c",
             "requiresArg": true,
-            "type": "string",
-            "describe": "The configuration for the server. The default only stores data in memory; to persist to your filesystem, use @css:config/file.json."
+            "type": "array",
+            "describe": "The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use @css:config/file.json."
           }
         },
         {

--- a/test/integration/Cli.test.ts
+++ b/test/integration/Cli.test.ts
@@ -29,7 +29,7 @@ describe('An instantiated CliResolver', (): void => {
       '-s', 's',
       '-w', '2',
     ]);
-    expect(shorthand.config).toBe('c');
+    expect(shorthand.config).toEqual([ 'c' ]);
     expect(shorthand.mainModulePath).toBe('m');
     expect(shorthand.loggingLevel).toBe('l');
     expect(shorthand.baseUrl).toBe('b');


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1430

#### ✍️ Description

Doing some smaller issues as I didn't want to immediately jump into something big after ACP 😄.

This change is non-breaking so can target main.

The main advantage of this change is that if you, for example, want to update the locker timeout, you can just have the following config:
```json
{
  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^5.0.0/components/context.jsonld",
  "@graph": [
    {
      "@type": "Override",
      "overrideInstance": { "@id": "urn:solid-server:default:ResourceLocker" },
      "overrideParameters": {
        "@type": "WrappedExpiringReadWriteLocker",
        "expiration": 10000
      }
    }
  ]
}
```
and then start the server with `npm start -- -c @css:config/file.json my-config.json`. Where before this you would have to copy all the imports from `file.json` to your own config.

After this I really should write some more documentation about how users can modify and customize the configuration.
