### PR TITLE
feat: Allow JSON-LD contexts to be stored locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
+        "@comunica/context-entries": "^2.2.0",
         "@comunica/query-sparql": "^2.2.1",
         "@rdfjs/types": "^1.1.0",
         "@solid/access-token-verifier": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "templates"
   ],
   "dependencies": {
+    "@comunica/context-entries": "^2.2.0",
     "@comunica/query-sparql": "^2.2.1",
     "@rdfjs/types": "^1.1.0",
     "@solid/access-token-verifier": "^2.0.3",
@@ -193,7 +194,6 @@
     "nodemon": "^2.0.19",
     "set-cookie-parser": "^2.5.1",
     "simple-git": "^3.12.0",
-    "commit-and-tag-version": "^10.1.0",
     "supertest": "^6.2.4",
     "ts-jest": "^27.1.5",
     "ts-node": "^10.9.1",

--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -1,25 +1,61 @@
 import { PassThrough } from 'stream';
+import { KeysRdfParseJsonLd } from '@comunica/context-entries';
 import type { NamedNode } from '@rdfjs/types';
+import fetch from 'cross-fetch';
+import { readJsonSync } from 'fs-extra';
+import { FetchDocumentLoader } from 'jsonld-context-parser';
+import type { IJsonLdContext } from 'jsonld-context-parser';
 import rdfParser from 'rdf-parse';
 import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
 import type { Representation } from '../../http/representation/Representation';
 import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import { INTERNAL_QUADS } from '../../util/ContentTypes';
 import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
+import { resolveAssetPath } from '../../util/PathUtil';
 import { pipeSafely } from '../../util/StreamUtil';
 import { PREFERRED_PREFIX_TERM, SOLID_META } from '../../util/Vocabularies';
 import { BaseTypedRepresentationConverter } from './BaseTypedRepresentationConverter';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
 
 /**
+ * First checks if a context is stored locally before letting the super class do a fetch.
+ */
+class ContextDocumentLoader extends FetchDocumentLoader {
+  private readonly contexts: Record<string, IJsonLdContext>;
+
+  public constructor(contexts: Record<string, string>) {
+    super(fetch);
+    this.contexts = {};
+    for (const [ key, path ] of Object.entries(contexts)) {
+      this.contexts[key] = readJsonSync(resolveAssetPath(path));
+    }
+  }
+
+  public async load(url: string): Promise<IJsonLdContext> {
+    if (url in this.contexts) {
+      return this.contexts[url];
+    }
+    return super.load(url);
+  }
+}
+
+/**
  * Converts most major RDF serializations to `internal/quads`.
+ *
+ * Custom contexts can be defined to be used when parsing JSON-LD.
+ * The keys of the object should be the URL of the context,
+ * and the values the file path of the contexts to use when the JSON-LD parser would fetch the given context.
+ * We use filepaths because embedding them directly into the configurations breaks Components.js.
  */
 export class RdfToQuadConverter extends BaseTypedRepresentationConverter {
-  public constructor() {
+  private readonly documentLoader: ContextDocumentLoader;
+
+  public constructor(contexts: Record<string, string> = {}) {
     const inputTypes = rdfParser.getContentTypes()
       // ContentType application/json MAY NOT be converted to Quad.
       .then((types): string[] => types.filter((type): boolean => type !== 'application/json'));
     super(inputTypes, INTERNAL_QUADS);
+    this.documentLoader = new ContextDocumentLoader(contexts);
   }
 
   public async handle({ representation, identifier }: RepresentationConverterArgs): Promise<Representation> {
@@ -27,7 +63,12 @@ export class RdfToQuadConverter extends BaseTypedRepresentationConverter {
     const rawQuads = rdfParser.parse(representation.data, {
       contentType: representation.metadata.contentType!,
       baseIRI: identifier.path,
-    })
+      // All extra keys get passed in the Comunica ActionContext
+      // and this is the key that is used to define the document loader.
+      // See https://github.com/rubensworks/rdf-parse.js/blob/master/lib/RdfParser.ts
+      // and https://github.com/comunica/comunica/blob/master/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
+      [KeysRdfParseJsonLd.documentLoader.name]: this.documentLoader,
+    } as any)
       // This works only for those cases where the data stream has been completely read before accessing the metadata.
       // Eg. the PATCH operation, which is the main case why we store the prefixes in metadata here if there are any.
       // See also https://github.com/CommunitySolidServer/CommunitySolidServer/issues/126

--- a/test/assets/contexts/test.jsonld
+++ b/test/assets/contexts/test.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "test": "http://example.com/context#",
+    "testPredicate": { "@id": "test:predicate" }
+  }
+}


### PR DESCRIPTION
#### ✍️ Description

Preparation for notification support. The spec requires both a JSON-LD representation and a turtle representation: https://solidproject.org/TR/notifications-protocol#discovery

But the JSON-LD context doesn't exist yet, so we will need to have a local version of it if we want to be able to automatically convert to turtle.

Besides that there are probably also other use cases that would find this useful. Might just be nice to not have to do an HTTP request every time we want to convert from JSON-LD.