### PR TITLE
fix: Always render OIDC errors correctly

### DIFF
--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -621,9 +621,13 @@ describe('A Solid server with IDP', (): void => {
     });
 
     it('should return correct error output.', async(): Promise<void> => {
-      const res = await fetch(`${baseUrl}.oidc/auth`);
-      expect(res.status).toBe(400);
-      await expect(res.text()).resolves.toContain('InvalidRequest: invalid_request');
+      const res = await fetch(`${baseUrl}.oidc/foo`, { headers: { accept: 'application/json' }});
+      expect(res.status).toBe(404);
+      const json = await res.json();
+      expect(json.name).toBe(`InvalidRequest`);
+      expect(json.message).toBe(`invalid_request - unrecognized route or not allowed method (GET on /.oidc/foo)`);
+      expect(json.statusCode).toBe(404);
+      expect(json.stack).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1061

#### ✍️ Description

I discovered yesterday that the `renderError` function that we provide to the OIDC library does not always get called when an HTTP request causes an error. Only in cases where HTML is preferred and some other cases. The hack introduced in this PR makes it so it also gets called in other cases so we have full control over the error output. The comments in the code add more explanation.

We had an integration test that checked this, but apparently that happened to be one of those cases where the `renderError` function did get called even though no HTML accept header was sent.
