### PR TITLE
feat: Take preferences as input in `RepresentationConvertingStore`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -63,6 +63,7 @@ These changes are relevant if you wrote custom modules for the server that depen
 - `AgentGroupAccessChecker` no longer accepts any input parameters.
 - The functions in `Vocabularies.ts` were renamed,
   the typings have been made more precise and several utility types were added.
+- The `RepresentationConvetingStore` `options.inType` was replaced with `options.inPreferences`.
 - Several changes to support ACP.
     - `WebAclAuxiliaryReader` was renamed to `AuthAuxiliaryReader`.
     - `OwnerPermissionReader` input parameter `aclStrategy` was renamed to `authStrategy`.

--- a/config/sparql-file-storage.json
+++ b/config/sparql-file-storage.json
@@ -81,7 +81,10 @@
       "@type": "RepresentationConvertingStore",
       "metadataStrategy":{ "@id": "urn:solid-server:default:MetadataStrategy" },
       "options_inConverter": { "@id": "urn:solid-server:default:RepresentationConverter" },
-      "options_inType": "internal/quads",
+      "options_inPreferences_type": {
+        "RepresentationConvertingStore:_options_inPreferences_type_key": "internal/quads",
+        "RepresentationConvertingStore:_options_inPreferences_type_value": 1
+      },
       "source": {
         "@type": "DataAccessorBasedStore",
         "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },

--- a/config/storage/backend/regex.json
+++ b/config/storage/backend/regex.json
@@ -67,7 +67,10 @@
       "@type": "RepresentationConvertingStore",
       "metadataStrategy":{ "@id": "urn:solid-server:default:MetadataStrategy" },
       "options_inConverter": { "@id": "urn:solid-server:default:RepresentationConverter" },
-      "options_inType": "internal/quads",
+      "options_inPreferences_type": {
+        "RepresentationConvertingStore:_options_inPreferences_type_key": "internal/quads",
+        "RepresentationConvertingStore:_options_inPreferences_type_value": 1
+      },
       "source": {
         "@type": "DataAccessorBasedStore",
         "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },

--- a/config/storage/backend/sparql.json
+++ b/config/storage/backend/sparql.json
@@ -17,7 +17,10 @@
       "comment": "This makes it so all incoming data is converted to quad objects.",
       "@id": "urn:solid-server:default:ResourceStore_Converting",
       "@type": "RepresentationConvertingStore",
-      "options_inType": "internal/quads"
+      "options_inPreferences_type": {
+        "RepresentationConvertingStore:_options_inPreferences_type_key": "internal/quads",
+        "RepresentationConvertingStore:_options_inPreferences_type_value": 1
+      }
     }
   ]
 }

--- a/src/storage/RepresentationConvertingStore.ts
+++ b/src/storage/RepresentationConvertingStore.ts
@@ -22,19 +22,25 @@ export class RepresentationConvertingStore<T extends ResourceStore = ResourceSto
   private readonly inPreferences: RepresentationPreferences;
 
   /**
-   * TODO: This should take RepresentationPreferences instead of a type string when supported by Components.js.
+   * @param source - Store we retrieve data from and send data to.
+   * @param metadataStrategy - Used to distinguish regular resources (which may be converted)
+   *                           from metadata resources (which always need conversion).
+   * @param options - Determines when data should be converted.
+   *   * outConverter: Converts data after retrieval from the source store.
+   *   * inConverter: Converts data before passing to the source store.
+   *   * inPreferences: The preferred input format for the source store, as passed to the inConverter.
    */
   public constructor(source: T, metadataStrategy: AuxiliaryStrategy, options: {
     outConverter?: RepresentationConverter;
     inConverter?: RepresentationConverter;
-    inType?: string;
+    inPreferences?: RepresentationPreferences;
   }) {
     super(source);
+    const { inConverter, outConverter, inPreferences } = options;
     this.metadataStrategy = metadataStrategy;
-    const { inConverter, outConverter, inType } = options;
     this.inConverter = inConverter ?? new PassthroughConverter();
     this.outConverter = outConverter ?? new PassthroughConverter();
-    this.inPreferences = !inType ? {} : { type: { [inType]: 1 }};
+    this.inPreferences = inPreferences ?? {};
   }
 
   public async getRepresentation(identifier: ResourceIdentifier, preferences: RepresentationPreferences,

--- a/test/unit/storage/RepresentationConvertingStore.test.ts
+++ b/test/unit/storage/RepresentationConvertingStore.test.ts
@@ -1,4 +1,5 @@
 import type { Representation } from '../../../src/http/representation/Representation';
+import type { RepresentationPreferences } from '../../../src/http/representation/RepresentationPreferences';
 import type { RepresentationConverter } from '../../../src/storage/conversion/RepresentationConverter';
 import { RepresentationConvertingStore } from '../../../src/storage/RepresentationConvertingStore';
 import type { ResourceStore } from '../../../src/storage/ResourceStore';
@@ -23,9 +24,11 @@ describe('A RepresentationConvertingStore', (): void => {
   const inConverter: RepresentationConverter = { handleSafe: jest.fn().mockResolvedValue(convertedIn) } as any;
   const outConverter: RepresentationConverter = { handleSafe: jest.fn().mockResolvedValue(convertedOut) } as any;
 
-  const inType = 'text/turtle';
+  const inPreferences: RepresentationPreferences = { type: { 'text/turtle': 1 }};
   const metadataStrategy = new SimpleSuffixStrategy('.meta');
-  const store = new RepresentationConvertingStore(source, metadataStrategy, { inType, inConverter, outConverter });
+  const store = new RepresentationConvertingStore(source,
+    metadataStrategy,
+    { inPreferences, inConverter, outConverter });
 
   beforeEach(async(): Promise<void> => {
     jest.clearAllMocks();


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/297

#### ✍️ Description

Apparently this is possible now (and probably was for some time), although the configuration is less pretty.

The `metadataStrategy` field is because of https://github.com/CommunitySolidServer/CommunitySolidServer/commit/f7742cffefa2875442798a478a5d7a9960dbfa7e
