### PR TITLE
Add stale action: mark issues as 🏚️ abandoned and auto close them

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,8 +12,13 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
-          stale-issue-message: 'The issue had no activity for 30 days, marking with Stale label.'
-          close-issue-message: 'This issue has been closed due to inactivity.'
+          stale-issue-label: 🏚️ abandoned
+          stale-issue-message: >
+            This issue has been automatically marked as `🏚️ abandoned`
+            because it has not had recent activity. It will be closed if no
+            further activity occurs.
+          close-issue-message: >
+            Closing stale issue. If this issue is still relevant, please reopen it.
           days-before-issue-stale: 30
           days-before-close: 30
           days-before-pr-stale: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/stale@v5
         with:
+          debug-only: true
           stale-issue-label: 🏚️ abandoned
           stale-issue-message: >
             This issue has been automatically marked as `🏚️ abandoned`

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,10 +13,11 @@ jobs:
       - uses: actions/stale@v5
         with:
           stale-issue-message: 'The issue had no activity for 30 days, marking with Stale label.'
-          close-issue-message: 'The issue had no activity for 60 days, closing issue.'
+          close-issue-message: 'This issue has been closed due to inactivity.'
           days-before-issue-stale: 30
           days-before-close: 30
           days-before-pr-stale: -1
           operations-per-run: 700
-          exempt-issue-labels: bug,enhancement,documentation,feature,performance,test,task,worker-threads
+          exempt-issue-labels: "🐛 bug,☀️ enhancement,📚 documentation,➕ feature,🐌 performance,
+            ➕ test,📝 task,:ant: worker threads,👩🏾‍💻 developer experience"
           exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+name: 'Stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          stale-issue-message: 'The issue had no activity for 30 days, marking with Stale label.'
+          close-issue-message: 'The issue had no activity for 60 days, closing issue.'
+          days-before-issue-stale: 30
+          days-before-close: 30
+          days-before-pr-stale: -1
+          operations-per-run: 700
+          exempt-issue-labels: bug,enhancement,documentation,feature,performance,test,task,worker-threads
+          exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
             further activity occurs.
           close-issue-message: >
             Closing stale issue. If this issue is still relevant, please reopen it.
-          days-before-issue-stale: 30
+          days-before-issue-stale: 60
           days-before-close: 30
           days-before-pr-stale: -1
           operations-per-run: 700


### PR DESCRIPTION
#### ✍️ Description

Ading the stale action to mark abandoned issues and close them after a set amount of time:

Current configuration:
- `🏚️ abandoned` Label added after 30 days
- Close abandoned issues after another 30 days (60 days of total inactivity)
- Issues with an assignee are exempted
- Exempted labels:
  - `🐛 bug`
  - `☀️ enhancement`
  - `📚 documentation`
  - `➕ feature`
  - `🐌 performance`
  - `➕ test`
  - `📝 task`
  - `:ant: worker threads`
  - `👩🏾‍💻 developer experience`

Chose to use `abandoned` as a keyword cause I found that several repos default to this and seems more descriptive to me. Can change it to `stale` if wanted.
 
### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.

