### PR TITLE
chore: Log uncaught exceptions

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -1,3 +1,10 @@
 #!/usr/bin/env node
 const { AppRunner } = require('..');
+
+// Attaching a logger to the uncaughtExceptionMonitor event,
+// such that the default uncaughtException behavior still occurs.
+process.on('uncaughtExceptionMonitor', (err, origin) => {
+  console.error(`Process is halting due to an ${origin} with error ${err.message}`);
+});
+
 new AppRunner().runCliSync(process);


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/314

#### ✍️ Description

The `uncaughtExceptionMonitor` is an event that is emitted right before an `uncaughtException` specifically to allow you to log it.
