### PR TITLE
feat: add support for key namespacePrefixes in a RedisLocker instance

### DIFF
--- a/test/unit/util/locking/RedisLocker.test.ts
+++ b/test/unit/util/locking/RedisLocker.test.ts
@@ -101,6 +101,15 @@ const redis: jest.Mocked<Redis & RedisResourceLock & RedisReadWriteLock> = {
 jest.mock('ioredis', (): any => jest.fn().mockImplementation((): Redis => redis));
 
 describe('A RedisLocker', (): void => {
+  it('will generate keys with the given namespacePrefix.', async(): Promise<void> => {
+    const identifier = { path: 'http://test.com/resource' };
+    const lockerPrefixed = new RedisLocker('6379', {}, 'MY_PREFIX');
+    await lockerPrefixed.acquire(identifier);
+    const allLocksPrefixed = Object.keys(store.internal).every((key): boolean => key.startsWith('MY_PREFIX'));
+    await lockerPrefixed.release(identifier);
+    expect(allLocksPrefixed).toBeTruthy();
+  });
+
   describe('with Read-Write logic', (): void => {
     const resource1 = { path: 'http://test.com/resource' };
     const resource2 = { path: 'http://test.com/resource2' };
@@ -392,8 +401,8 @@ describe('A RedisLocker', (): void => {
       const emitter = new EventEmitter();
       const promise = locker.withWriteLock(resource1, (): any =>
         new Promise<void>((resolve): any => emitter.on('release', resolve)));
-      await redis.releaseWriteLock(`__RW__${resource1.path}`);
       await flushPromises();
+      await redis.releaseWriteLock(`__RW__${resource1.path}`);
       emitter.emit('release');
       await expect(promise).rejects.toThrow('Redis operation error detected (value was null).');
     });


### PR DESCRIPTION
#### 📁 Related issues

* #1487 

#### ✍️ Description

This PR extends the constructor signature of the RedisLocker class with an extra argument `namespacePrefix`. This will default to the empty string, making it backwards compatible with current CSS instances using the RedisLocker.

Since keys in RedisLocker are SHA-1 hashes of paths, they were subject to clashing with each other. This change should mitigate this issue. Keys that are generated in Redis, will now be prefixed with this string, effectively namespacing them. This allow a single Redis instance to be used by multiple CSS setups (that might be used for different use cases). 

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
