### PR TITLE
ci: add more stale bot exempt issue labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,5 +25,7 @@ jobs:
           days-before-pr-stale: -1
           operations-per-run: 700
           exempt-issue-labels: "🐛 bug,☀️ enhancement,📚 documentation,➕ feature,🐌 performance,
-            ➕ test,📝 task,:ant: worker threads,👩🏾‍💻 developer experience"
+            ➕ test,📝 task,:ant: worker threads,👩🏾‍💻 developer experience, :id: identity-provider,
+            :scroll: solid:protocol:v0.9,⚙️ dependencies,⌛ has dependency, error-handling
+            storage:sparql-endpoint,storage:routing"
           exempt-all-assignees: true


### PR DESCRIPTION
#### ✍️ Description

Stale bot has been running for a while now with a debug flag. This PR adds more labels that we should likely exempt from staleness checks.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
