### PR TITLE
Suggest usage of `npx` in readme rather than global npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,21 @@ you can run a [Docker](https://www.docker.com/) version instead.
 ### 💻 Installing and running locally
 
 After installing Node.js,
-install the latest server version
+to run the server with in-memory storage, use:
+
+```shell
+npx @solid/community-server
+```
+
+To run the server with your current folder as storage, use:
+
+```shell
+npx @solid/community-server -c @css:config/file.json
+```
+
+### 📃 Installing and running locally with a global npm install
+
+After installing Node.js, install the latest server version
 from the [npm package repository](https://www.npmjs.com/):
 
 ```shell


### PR DESCRIPTION
This PR serves as a suggestion to start the solid server via `npx` rather than a global `npm install`.

Importantly this reduces the likelihood of running into componentsjs versioning issues as conflicting versions of componentsjs are less likely to be globally installed (either by having different versions of CSS installed globally, or versions of Comunica that have conflicting componentsjs versioning).
