### PR TITLE
feat: return clear error when multiple values for a cli flag are given

### DIFF
--- a/src/init/cli/YargsCliExtractor.ts
+++ b/src/init/cli/YargsCliExtractor.ts
@@ -74,10 +74,10 @@ export class YargsCliExtractor extends CliExtractor {
 
     // Error and show help message when multiple values were provided
     // for a non Array type parameter
-    yArgv.check((args): any => {
+    yArgv.check((args): boolean => {
       for (const [ name, options ] of Object.entries(this.yargsArgOptions)) {
         if (options.type !== 'array' && Array.isArray(args[name])) {
-          return `Multiple values for --${name} (-${options.alias}) were provided where only one is allowed`;
+          throw new Error(`Multiple values for --${name} (-${options.alias}) were provided where only one is allowed`);
         }
       }
       return true;

--- a/src/init/cli/YargsCliExtractor.ts
+++ b/src/init/cli/YargsCliExtractor.ts
@@ -71,6 +71,18 @@ export class YargsCliExtractor extends CliExtractor {
    */
   private createYArgv(argv: readonly string[]): Argv {
     let yArgv = yargs(argv.slice(2));
+
+    // Error and show help message when multiple values were provided
+    // for a non Array type parameter
+    yArgv.check((args): any => {
+      for (const [ name, options ] of Object.entries(this.yargsArgOptions)) {
+        if (options.type !== 'array' && Array.isArray(args[name])) {
+          return `Multiple values for --${name} (-${options.alias}) were provided where only one is allowed`;
+        }
+      }
+      return true;
+    });
+
     if (this.yargvOptions.usage !== undefined) {
       yArgv = yArgv.usage(this.yargvOptions.usage);
     }

--- a/test/unit/init/cli/YargsCliExtractor.test.ts
+++ b/test/unit/init/cli/YargsCliExtractor.test.ts
@@ -52,6 +52,14 @@ describe('A YargsCliExtractor', (): void => {
     expect(error).toHaveBeenCalledWith('Unknown argument: unsupported');
   });
 
+  it('can error when multiple values are provided for a non array type parameter.', async(): Promise<void> => {
+    extractor = new YargsCliExtractor(parameters, { strictMode: true });
+    const argv = [ 'node', 'script', '-p', '3000', '-b', 'http://localhost:3000/', '-p', '3001' ];
+    await extractor.handle(argv);
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith('Multiple values for --port (-p) were provided where only one is allowed');
+  });
+
   it('can parse environment variables.', async(): Promise<void> => {
     // While the code below does go into the corresponding values,
     // yargs does not see the new environment variable for some reason.

--- a/test/unit/init/cli/YargsCliExtractor.test.ts
+++ b/test/unit/init/cli/YargsCliExtractor.test.ts
@@ -8,6 +8,7 @@ describe('A YargsCliExtractor', (): void => {
   const parameters: YargsParameter[] = [
     new YargsParameter('baseUrl', { alias: 'b', requiresArg: true, type: 'string' }),
     new YargsParameter('port', { alias: 'p', requiresArg: true, type: 'number' }),
+    new YargsParameter('config', { alias: 'c', requiresArg: false, type: 'array' }),
   ];
   let extractor: YargsCliExtractor;
 
@@ -58,6 +59,13 @@ describe('A YargsCliExtractor', (): void => {
     await extractor.handle(argv);
     expect(exit).toHaveBeenCalledTimes(1);
     expect(error).toHaveBeenCalledWith('Multiple values for --port (-p) were provided where only one is allowed');
+  });
+
+  it('accepts multiple values for array type parameters.', async(): Promise<void> => {
+    const argv = [ 'node', 'script', '-c', './config/a.json', '-c', './config/b.json', '-b', 'http://localhost:3000/', '-p', '3000' ];
+    await expect(extractor.handle(argv)).resolves.toEqual(expect.objectContaining({
+      config: [ './config/a.json', './config/b.json' ],
+    }));
   });
 
   it('can parse environment variables.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1418

#### ✍️ Description

Add yargs argument check to display useful error to the user when multiple values were given for the same non array type parameter/variable.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
  
⬆️  Not sure about this one. If this is supposed to be merged into `main` I'ill create another PR because my laptop really does not like a rebase for some reason.
  
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.