### PR TITLE
feat: SeededPodInitializer log exceptions as warning instead of crashing

### DIFF
--- a/src/init/SeededPodInitializer.ts
+++ b/src/init/SeededPodInitializer.ts
@@ -1,6 +1,7 @@
 import { readJson } from 'fs-extra';
 import type { RegistrationManager } from '../identity/interaction/email-password/util/RegistrationManager';
 import { getLoggerFor } from '../logging/LogUtil';
+import { createErrorMessage } from '../util/errors/ErrorUtil';
 import { Initializer } from './Initializer';
 
 /**
@@ -42,10 +43,15 @@ export class SeededPodInitializer extends Initializer {
       this.logger.debug(`Validated input: ${JSON.stringify(validated)}`);
 
       // Register and/or create a pod as requested. Potentially does nothing if all booleans are false.
-      await this.registrationManager.register(validated, true);
-      this.logger.info(`Initialized seeded pod and account for "${input.podName}".`);
-      count += 1;
+      try {
+        await this.registrationManager.register(validated, true);
+        this.logger.info(`Initialized seeded pod and account for "${input.podName}".`);
+        count += 1;
+      } catch (error: unknown) {
+        this.logger.warn(`Error while initializing seeded pod: ${createErrorMessage(error)})}`);
+      }
     }
+
     this.logger.info(`Initialized ${count} seeded pods.`);
   }
 }

--- a/test/unit/init/SeededPodInitializer.test.ts
+++ b/test/unit/init/SeededPodInitializer.test.ts
@@ -45,4 +45,11 @@ describe('A SeededPodInitializer', (): void => {
     expect(registrationManager.validateInput).toHaveBeenCalledTimes(2);
     expect(registrationManager.register).toHaveBeenCalledTimes(2);
   });
+
+  it('does not throw exceptions when a seeded pod already exists.', async(): Promise<void> => {
+    registrationManager.register = jest.fn().mockRejectedValueOnce(new Error('Pod already exists'));
+    await new SeededPodInitializer(registrationManager, configFilePath).handle();
+    expect(registrationManager.validateInput).toHaveBeenCalledTimes(2);
+    expect(registrationManager.register).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
#### 📁 Related issues

Closes #1561 

#### ✍️ Description

Added a try-catch block to log warnings instead of throwing exceptions in SeededPodInitializer

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
