### PR TITLE
Use Add/Remove notifications for containers

### DIFF
--- a/config/http/notifications/base/handler.json
+++ b/config/http/notifications/base/handler.json
@@ -14,6 +14,12 @@
           "handlers": [
             { "@type": "DeleteNotificationGenerator" },
             {
+              "@type": "AddRemoveNotificationGenerator",
+              "store": {
+                "@id": "urn:solid-server:default:ResourceStore"
+              }
+            },
+            {
               "@type": "ActivityNotificationGenerator",
               "store": {
                 "@id": "urn:solid-server:default:ResourceStore"

--- a/src/http/ldp/PostOperationHandler.ts
+++ b/src/http/ldp/PostOperationHandler.ts
@@ -44,7 +44,7 @@ export class PostOperationHandler extends OperationHandler {
     }
     const changes = await this.store.addResource(operation.target, operation.body, operation.conditions);
     const createdIdentifier = find(changes.keys(), (identifier): boolean =>
-      Boolean(changes.get(identifier)?.has(SOLID_AS.terms.Activity, AS.terms.Create)));
+      Boolean(changes.get(identifier)?.has(SOLID_AS.terms.activity, AS.terms.Create)));
     if (!createdIdentifier) {
       throw new InternalServerError('Operation was successful but no created identifier was returned.');
     }

--- a/src/http/representation/RepresentationMetadata.ts
+++ b/src/http/representation/RepresentationMetadata.ts
@@ -9,7 +9,7 @@ import type { ResourceIdentifier } from './ResourceIdentifier';
 import { isResourceIdentifier } from './ResourceIdentifier';
 
 export type MetadataIdentifier = ResourceIdentifier | NamedNode | BlankNode;
-export type MetadataValue = NamedNode | Literal | string | (NamedNode | Literal | string)[];
+export type MetadataValue = NamedNode | BlankNode | Literal | string | (NamedNode | Literal | BlankNode | string)[];
 export type MetadataRecord = Record<string, MetadataValue>;
 export type MetadataGraph = NamedNode | BlankNode | DefaultGraph | string;
 
@@ -253,7 +253,7 @@ export class RepresentationMetadata {
    * Runs the given function on all predicate/object pairs, but only converts the predicate to a named node once.
    */
   private forQuads(predicate: NamedNode, object: MetadataValue,
-    forFn: (pred: NamedNode, obj: NamedNode | Literal) => void): this {
+    forFn: (pred: NamedNode, obj: NamedNode | BlankNode | Literal) => void): this {
     const objects = Array.isArray(object) ? object : [ object ];
     for (const obj of objects) {
       forFn(predicate, toObjectTerm(obj, true));

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,6 +311,7 @@ export * from './server/middleware/WebSocketAdvertiser';
 
 // Server/Notifications/Generate
 export * from './server/notifications/generate/ActivityNotificationGenerator';
+export * from './server/notifications/generate/AddRemoveNotificationGenerator';
 export * from './server/notifications/generate/DeleteNotificationGenerator';
 export * from './server/notifications/generate/NotificationGenerator';
 export * from './server/notifications/generate/StateNotificationGenerator';

--- a/src/server/notifications/ActivityEmitter.ts
+++ b/src/server/notifications/ActivityEmitter.ts
@@ -1,3 +1,4 @@
+import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import type { GenericEventEmitter } from '../../util/GenericEventEmitter';
 import { createGenericEventEmitterClass } from '../../util/GenericEventEmitter';
@@ -8,8 +9,11 @@ import type { AS, VocabularyTerm, VocabularyValue } from '../../util/Vocabularie
  * Both generic `change` events and ActivityStream-specific events are emitted.
  */
 export type ActivityEmitter =
-  GenericEventEmitter<'changed', (target: ResourceIdentifier, activity: VocabularyTerm<typeof AS>) => void> &
-  GenericEventEmitter<VocabularyValue<typeof AS>, (target: ResourceIdentifier) => void>;
+  GenericEventEmitter<'changed',
+  (target: ResourceIdentifier, activity: VocabularyTerm<typeof AS>, metadata: RepresentationMetadata) => void>
+  &
+  GenericEventEmitter<VocabularyValue<typeof AS>,
+  (target: ResourceIdentifier, metadata: RepresentationMetadata) => void>;
 
 /**
  * A class implementation of {@link ActivityEmitter}.

--- a/src/server/notifications/NotificationHandler.ts
+++ b/src/server/notifications/NotificationHandler.ts
@@ -1,3 +1,4 @@
+import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { AsyncHandler } from '../../util/handlers/AsyncHandler';
 import type { AS, VocabularyTerm } from '../../util/Vocabularies';
@@ -7,6 +8,7 @@ export interface NotificationHandlerInput {
   topic: ResourceIdentifier;
   channel: NotificationChannel;
   activity?: VocabularyTerm<typeof AS>;
+  metadata?: RepresentationMetadata;
 }
 
 /**

--- a/src/server/notifications/generate/AddRemoveNotificationGenerator.ts
+++ b/src/server/notifications/generate/AddRemoveNotificationGenerator.ts
@@ -1,0 +1,56 @@
+import { getETag } from '../../../storage/Conditions';
+import type { ResourceStore } from '../../../storage/ResourceStore';
+import { InternalServerError } from '../../../util/errors/InternalServerError';
+import { NotImplementedHttpError } from '../../../util/errors/NotImplementedHttpError';
+import { AS } from '../../../util/Vocabularies';
+import type { Notification } from '../Notification';
+import { CONTEXT_ACTIVITYSTREAMS, CONTEXT_NOTIFICATION } from '../Notification';
+import type { NotificationHandlerInput } from '../NotificationHandler';
+import { NotificationGenerator } from './NotificationGenerator';
+
+/**
+ * A {@link NotificationGenerator} specifically for Add/Remove notifications.
+ * Creates the notification so the `target` is set to input topic,
+ * and the `object` value is extracted from the provided metadata.
+ */
+export class AddRemoveNotificationGenerator extends NotificationGenerator {
+  private readonly store: ResourceStore;
+
+  public constructor(store: ResourceStore) {
+    super();
+    this.store = store;
+  }
+
+  public async canHandle({ activity }: NotificationHandlerInput): Promise<void> {
+    if (!activity || (!activity.equals(AS.terms.Add) && !activity.equals(AS.terms.Remove))) {
+      throw new NotImplementedHttpError(`Only Add/Remove activity updates are supported.`);
+    }
+  }
+
+  public async handle({ activity, topic, metadata }: NotificationHandlerInput): Promise<Notification> {
+    const representation = await this.store.getRepresentation(topic, {});
+    representation.data.destroy();
+
+    const state = getETag(representation.metadata);
+    const objects = metadata?.getAll(AS.terms.object);
+    if (!objects || objects.length === 0) {
+      throw new InternalServerError(`Missing as:object metadata for ${activity?.value} activity on ${topic.path}`);
+    }
+    if (objects.length > 1) {
+      throw new InternalServerError(`Found more than one as:object for ${activity?.value} activity on ${topic.path}`);
+    }
+
+    return {
+      '@context': [
+        CONTEXT_ACTIVITYSTREAMS,
+        CONTEXT_NOTIFICATION,
+      ],
+      id: `urn:${Date.now()}:${topic.path}`,
+      type: activity!.value.slice(AS.namespace.length),
+      object: objects[0].value,
+      target: topic.path,
+      state,
+      published: new Date().toISOString(),
+    };
+  }
+}

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -708,6 +708,6 @@ export class DataAccessorBasedStore implements ResourceStore {
    * @param activity - Which activity is taking place.
    */
   private addActivityMetadata(map: ChangeMap, id: ResourceIdentifier, activity: NamedNode): void {
-    map.set(id, new RepresentationMetadata(id, { [SOLID_AS.Activity]: activity }));
+    map.set(id, new RepresentationMetadata(id, { [SOLID_AS.activity]: activity }));
   }
 }

--- a/src/storage/MonitoringStore.ts
+++ b/src/storage/MonitoringStore.ts
@@ -55,7 +55,7 @@ export class MonitoringStore<T extends ResourceStore = ResourceStore>
 
   private emitChanged(changes: ChangeMap): ChangeMap {
     for (const [ identifier, metadata ] of changes) {
-      const activity = metadata.get(SOLID_AS.terms.Activity);
+      const activity = metadata.get(SOLID_AS.terms.activity);
       if (this.isKnownActivity(activity)) {
         this.emit('changed', identifier, activity);
         this.emit(activity.value, identifier);

--- a/src/storage/MonitoringStore.ts
+++ b/src/storage/MonitoringStore.ts
@@ -9,7 +9,7 @@ import type { Conditions } from './Conditions';
 import type { ResourceStore, ChangeMap } from './ResourceStore';
 
 // The ActivityStream terms for which we emit an event
-const knownActivities = [ AS.terms.Create, AS.terms.Delete, AS.terms.Update ];
+const knownActivities = [ AS.terms.Add, AS.terms.Create, AS.terms.Delete, AS.terms.Remove, AS.terms.Update ];
 
 /**
  * Store that notifies listeners of changes to its source
@@ -57,8 +57,8 @@ export class MonitoringStore<T extends ResourceStore = ResourceStore>
     for (const [ identifier, metadata ] of changes) {
       const activity = metadata.get(SOLID_AS.terms.activity);
       if (this.isKnownActivity(activity)) {
-        this.emit('changed', identifier, activity);
-        this.emit(activity.value, identifier);
+        this.emit('changed', identifier, activity, metadata);
+        this.emit(activity.value, identifier, metadata);
       }
     }
 

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -243,8 +243,8 @@ export const SOLID = createVocabulary('http://www.w3.org/ns/solid/terms#',
   'InsertDeletePatch',
 );
 
-export const SOLID_AS = createVocabulary('http://www.w3.org/ns/solid/activitystreams#',
-  'Activity',
+export const SOLID_AS = createVocabulary('urn:npm:solid:community-server:activity:',
+  'activity',
 );
 
 export const SOLID_ERROR = createVocabulary('urn:npm:solid:community-server:error:',

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -145,8 +145,12 @@ export const ACP = createVocabulary('http://www.w3.org/ns/solid/acp#',
 );
 
 export const AS = createVocabulary('https://www.w3.org/ns/activitystreams#',
+  'object',
+
+  'Add',
   'Create',
   'Delete',
+  'Remove',
   'Update',
 );
 

--- a/test/unit/http/UnsecureWebSocketsProtocol.test.ts
+++ b/test/unit/http/UnsecureWebSocketsProtocol.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type { Server } from 'http';
+import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
 import { UnsecureWebSocketsProtocol } from '../../../src/http/UnsecureWebSocketsProtocol';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
 import { BaseActivityEmitter } from '../../../src/server/notifications/ActivityEmitter';
@@ -26,6 +27,7 @@ class DummySocket extends EventEmitter {
 describe('An UnsecureWebSocketsProtocol', (): void => {
   let server: Server;
   let webSocket: DummySocket;
+  const metadata = new RepresentationMetadata();
   const source = new BaseActivityEmitter();
   let protocol: UnsecureWebSocketsProtocol;
 
@@ -67,7 +69,7 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
 
     describe('before subscribing to resources', (): void => {
       it('does not emit pub messages.', (): void => {
-        source.emit('changed', { path: 'https://mypod.example/foo/bar' }, AS.terms.Update);
+        source.emit('changed', { path: 'https://mypod.example/foo/bar' }, AS.terms.Update, metadata);
         expect(webSocket.messages).toHaveLength(0);
       });
     });
@@ -83,7 +85,7 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
       });
 
       it('emits pub messages for that resource.', (): void => {
-        source.emit('changed', { path: 'https://mypod.example/foo/bar' }, AS.terms.Update);
+        source.emit('changed', { path: 'https://mypod.example/foo/bar' }, AS.terms.Update, metadata);
         expect(webSocket.messages).toHaveLength(1);
         expect(webSocket.messages.shift()).toBe('pub https://mypod.example/foo/bar');
       });
@@ -100,7 +102,7 @@ describe('An UnsecureWebSocketsProtocol', (): void => {
       });
 
       it('emits pub messages for that resource.', (): void => {
-        source.emit('changed', { path: 'https://mypod.example/relative/foo' }, AS.terms.Update);
+        source.emit('changed', { path: 'https://mypod.example/relative/foo' }, AS.terms.Update, metadata);
         expect(webSocket.messages).toHaveLength(1);
         expect(webSocket.messages.shift()).toBe('pub https://mypod.example/relative/foo');
       });

--- a/test/unit/http/ldp/PostOperationHandler.test.ts
+++ b/test/unit/http/ldp/PostOperationHandler.test.ts
@@ -23,8 +23,8 @@ describe('A PostOperationHandler', (): void => {
     operation = { method: 'POST', target: { path: 'http://test.com/foo' }, body, conditions, preferences: {}};
     store = {
       addResource: jest.fn().mockResolvedValue(new IdentifierMap([
-        [{ path: 'https://example.com/parent/newPath' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Create }) ],
-        [{ path: 'https://example.com/parent/' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Update }) ],
+        [{ path: 'https://example.com/parent/newPath' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Create }) ],
+        [{ path: 'https://example.com/parent/' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Update }) ],
       ])),
     } as any;
     handler = new PostOperationHandler(store);
@@ -64,7 +64,7 @@ describe('A PostOperationHandler', (): void => {
 
   it('errors if the store returns no created identifier.', async(): Promise<void> => {
     store.addResource.mockResolvedValueOnce(new IdentifierMap([
-      [{ path: 'https://example.com/parent/' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Update }) ],
+      [{ path: 'https://example.com/parent/' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Update }) ],
     ]));
     await expect(handler.handle({ operation })).rejects.toThrow(InternalServerError);
   });

--- a/test/unit/server/notifications/generate/AddRemoveNotificationGenerator.test.ts
+++ b/test/unit/server/notifications/generate/AddRemoveNotificationGenerator.test.ts
@@ -1,0 +1,81 @@
+import { BasicRepresentation } from '../../../../../src/http/representation/BasicRepresentation';
+import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
+import {
+  AddRemoveNotificationGenerator,
+} from '../../../../../src/server/notifications/generate/AddRemoveNotificationGenerator';
+import type { NotificationChannel } from '../../../../../src/server/notifications/NotificationChannel';
+import type { ResourceStore } from '../../../../../src/storage/ResourceStore';
+import { AS, DC, LDP, RDF } from '../../../../../src/util/Vocabularies';
+
+describe('An AddRemoveNotificationGenerator', (): void => {
+  const topic: ResourceIdentifier = { path: 'http://example.com/' };
+  const object: ResourceIdentifier = { path: 'http://example.com/foo' };
+  const channel: NotificationChannel = {
+    id: 'id',
+    topic: topic.path,
+    type: 'type',
+  };
+  let metadata: RepresentationMetadata;
+  let store: jest.Mocked<ResourceStore>;
+  let generator: AddRemoveNotificationGenerator;
+
+  beforeEach(async(): Promise<void> => {
+    metadata = new RepresentationMetadata(topic, { [AS.object]: object.path });
+
+    const responseMetadata = new RepresentationMetadata({
+      [RDF.type]: LDP.terms.Resource,
+      // Needed for ETag
+      [DC.modified]: new Date().toISOString(),
+    });
+    store = {
+      getRepresentation: jest.fn().mockResolvedValue(new BasicRepresentation('', responseMetadata)),
+    } as any;
+
+    generator = new AddRemoveNotificationGenerator(store);
+  });
+
+  it('only handles Add/Remove activities.', async(): Promise<void> => {
+    await expect(generator.canHandle({ topic, channel, metadata }))
+      .rejects.toThrow('Only Add/Remove activity updates are supported.');
+    await expect(generator.canHandle({ topic, channel, metadata, activity: AS.terms.Add })).resolves.toBeUndefined();
+    await expect(generator.canHandle({ topic, channel, metadata, activity: AS.terms.Remove })).resolves.toBeUndefined();
+  });
+
+  it('requires one object metadata to be present.', async(): Promise<void> => {
+    metadata = new RepresentationMetadata();
+    await expect(generator.handle({ topic, channel, activity: AS.terms.Add })).rejects.toThrow(
+      'Missing as:object metadata for https://www.w3.org/ns/activitystreams#Add activity on http://example.com/',
+    );
+    await expect(generator.handle({ topic, channel, metadata, activity: AS.terms.Add })).rejects.toThrow(
+      'Missing as:object metadata for https://www.w3.org/ns/activitystreams#Add activity on http://example.com/',
+    );
+
+    metadata = new RepresentationMetadata(topic, { [AS.object]: [ object.path, 'http://example.com/otherObject' ]});
+    await expect(generator.handle({ topic, channel, metadata, activity: AS.terms.Add })).rejects.toThrow(
+      'Found more than one as:object for https://www.w3.org/ns/activitystreams#Add activity on http://example.com/',
+    );
+  });
+
+  it('generates a notification.', async(): Promise<void> => {
+    const date = '1988-03-09T14:48:00.000Z';
+    const ms = Date.parse(date);
+    jest.useFakeTimers();
+    jest.setSystemTime(ms);
+
+    await expect(generator.handle({ topic, channel, metadata, activity: AS.terms.Add })).resolves.toEqual({
+      '@context': [
+        'https://www.w3.org/ns/activitystreams',
+        'https://www.w3.org/ns/solid/notification/v1',
+      ],
+      id: `urn:${ms}:http://example.com/`,
+      type: 'Add',
+      object: 'http://example.com/foo',
+      target: 'http://example.com/',
+      state: expect.stringMatching(/"\d+"/u),
+      published: date,
+    });
+
+    jest.useRealTimers();
+  });
+});

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -10,7 +10,6 @@ import { RepresentationMetadata } from '../../../src/http/representation/Represe
 import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
 import type { DataAccessor } from '../../../src/storage/accessors/DataAccessor';
 import { BasicConditions } from '../../../src/storage/BasicConditions';
-
 import { DataAccessorBasedStore } from '../../../src/storage/DataAccessorBasedStore';
 import { INTERNAL_QUADS } from '../../../src/util/ContentTypes';
 import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
@@ -265,7 +264,7 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.metadata.add(RDF.terms.type, LDP.terms.Container);
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
 
       const generatedID = [ ...result.keys() ].find((id): boolean => id.path !== resourceID.path)!;
       expect(generatedID).toBeDefined();
@@ -278,7 +277,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const result = await store.addResource(resourceID, representation);
 
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
 
       const generatedID = [ ...result.keys() ].find((id): boolean => id.path !== resourceID.path)!;
       expect(generatedID).toBeDefined();
@@ -288,6 +287,8 @@ describe('A DataAccessorBasedStore', (): void => {
       await expect(arrayifyStream(accessor.data[generatedID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[generatedID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
       expect(result.get(generatedID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
+
+      expect(result.get(resourceID)?.get(AS.terms.object)?.value).toEqual(generatedID.path);
     });
 
     it('can write containers.', async(): Promise<void> => {
@@ -296,7 +297,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const result = await store.addResource(resourceID, representation);
 
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
 
       const generatedID = [ ...result.keys() ].find((id): boolean => id.path !== resourceID.path)!;
       expect(generatedID).toBeDefined();
@@ -317,7 +318,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get({ path: `${root}newName` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
@@ -342,7 +343,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get({ path: `${root}newContainer/` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
@@ -366,7 +367,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get({ path: `${root}%26%26` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
@@ -459,7 +460,8 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
+      expect(result.get({ path: root })?.get(AS.terms.object)?.value).toEqual(resourceID.path);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[resourceID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -476,7 +478,7 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.data = guardedStreamFrom([ `<${root}resource/> a <coolContainer>.` ]);
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       expect(accessor.data[resourceID.path]).toBeTruthy();
       expect(accessor.data[resourceID.path].metadata.contentType).toBeUndefined();
@@ -489,7 +491,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[resourceID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -513,7 +515,7 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.metadata.add(namedNode('gen'), 'value', SOLID_META.terms.ResponseMetadata);
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[resourceID.path].metadata.get(namedNode('notGen'))?.value).toBe('value');
@@ -535,7 +537,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}a/b/resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(4);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Add);
       expect(result.get({ path: `${root}a/` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       expect(result.get({ path: `${root}a/b/` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       expect(result.get({ path: `${root}a/b/resource` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
@@ -770,7 +772,8 @@ describe('A DataAccessorBasedStore', (): void => {
       accessor.data[resourceID.path] = representation;
       const result = await store.deleteResource(resourceID);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Remove);
+      expect(result.get({ path: root })?.get(AS.terms.object)?.value).toEqual(resourceID.path);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[resourceID.path]).toBeUndefined();
       expect(accessor.data[root].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -794,7 +797,7 @@ describe('A DataAccessorBasedStore', (): void => {
       auxiliaryStrategy.isRequiredInRoot = jest.fn().mockReturnValue(true);
       const result = await store.deleteResource(auxResourceID);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Remove);
       expect(result.get(auxResourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[auxResourceID.path]).toBeUndefined();
     });
@@ -807,7 +810,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.deleteResource(resourceID);
       expect(result.size).toBe(3);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Remove);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(result.get(auxResourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[resourceID.path]).toBeUndefined();
@@ -830,7 +833,7 @@ describe('A DataAccessorBasedStore', (): void => {
       logger.error = jest.fn();
       const result = await store.deleteResource(resourceID);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Remove);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[resourceID.path]).toBeUndefined();
       expect(accessor.data[auxResourceID.path]).toBeDefined();

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -265,7 +265,7 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.metadata.add(RDF.terms.type, LDP.terms.Container);
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
 
       const generatedID = [ ...result.keys() ].find((id): boolean => id.path !== resourceID.path)!;
       expect(generatedID).toBeDefined();
@@ -278,7 +278,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const result = await store.addResource(resourceID, representation);
 
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
 
       const generatedID = [ ...result.keys() ].find((id): boolean => id.path !== resourceID.path)!;
       expect(generatedID).toBeDefined();
@@ -287,7 +287,7 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(accessor.data[generatedID.path]).toBeDefined();
       await expect(arrayifyStream(accessor.data[generatedID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[generatedID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
-      expect(result.get(generatedID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(generatedID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
     it('can write containers.', async(): Promise<void> => {
@@ -296,7 +296,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const result = await store.addResource(resourceID, representation);
 
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
 
       const generatedID = [ ...result.keys() ].find((id): boolean => id.path !== resourceID.path)!;
       expect(generatedID).toBeDefined();
@@ -304,7 +304,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       expect(accessor.data[generatedID.path]).toBeDefined();
       expect(accessor.data[generatedID.path].metadata.contentType).toBeUndefined();
-      expect(result.get(generatedID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(generatedID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
 
       const { metadata } = await store.getRepresentation(generatedID);
       expect(metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -317,8 +317,8 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get({ path: `${root}newName` })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: `${root}newName` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
     it('errors on a slug ending on / without Link rel:type Container header.', async(): Promise<void> => {
@@ -342,8 +342,8 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get({ path: `${root}newContainer/` })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: `${root}newContainer/` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
     it('generates a new URI if adding the slug would create an existing URI.', async(): Promise<void> => {
@@ -366,8 +366,8 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.addResource(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get({ path: `${root}%26%26` })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: `${root}%26%26` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
     });
 
     it('errors if the slug contains a slash.', async(): Promise<void> => {
@@ -434,7 +434,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(1);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       expect(mock).toHaveBeenCalledTimes(1);
       expect(mock).toHaveBeenLastCalledWith(resourceID);
 
@@ -459,8 +459,8 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[resourceID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
       expect(accessor.data[root].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -476,8 +476,8 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.data = guardedStreamFrom([ `<${root}resource/> a <coolContainer>.` ]);
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       expect(accessor.data[resourceID.path]).toBeTruthy();
       expect(accessor.data[resourceID.path].metadata.contentType).toBeUndefined();
       expect(accessor.data[resourceID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -489,8 +489,8 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[resourceID.path].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
       expect(accessor.data[root].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -500,7 +500,7 @@ describe('A DataAccessorBasedStore', (): void => {
       mockDate.mockReturnValue(later);
       const result2 = await store.setRepresentation(resourceID, representation);
       expect(result2.size).toBe(1);
-      expect(result2.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
+      expect(result2.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ 'updatedText' ]);
       expect(accessor.data[resourceID.path].metadata.get(DC.terms.modified)?.value).toBe(later.toISOString());
       expect(accessor.data[root].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
@@ -513,8 +513,8 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.metadata.add(namedNode('gen'), 'value', SOLID_META.terms.ResponseMetadata);
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[resourceID.path].metadata.get(namedNode('notGen'))?.value).toBe('value');
       expect(accessor.data[resourceID.path].metadata.get(namedNode('gen'))).toBeUndefined();
@@ -526,8 +526,8 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
     });
 
@@ -535,10 +535,10 @@ describe('A DataAccessorBasedStore', (): void => {
       const resourceID = { path: `${root}a/b/resource` };
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(4);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get({ path: `${root}a/` })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
-      expect(result.get({ path: `${root}a/b/` })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
-      expect(result.get({ path: `${root}a/b/resource` })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get({ path: `${root}a/` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: `${root}a/b/` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
+      expect(result.get({ path: `${root}a/b/resource` })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       await expect(arrayifyStream(accessor.data[resourceID.path].data)).resolves.toEqual([ resourceData ]);
       expect(accessor.data[`${root}a/`].metadata.getAll(RDF.terms.type).map((type): string => type.value))
         .toContain(LDP.Container);
@@ -565,7 +565,7 @@ describe('A DataAccessorBasedStore', (): void => {
       representation.data = guardedStreamFrom([]);
       const result = await store.setRepresentation(resourceID, representation);
       expect(result.size).toBe(1);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Create);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Create);
       expect(accessor.data[resourceID.path]).toBeTruthy();
       expect(Object.keys(accessor.data)).toHaveLength(1);
       expect(accessor.data[resourceID.path].metadata.contentType).toBeUndefined();
@@ -583,7 +583,7 @@ describe('A DataAccessorBasedStore', (): void => {
       ) ], resourceID);
 
       const result = await store.setRepresentation(metaResourceID, metaRepresentation);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
       expect(accessor.data[resourceID.path].metadata.quads()).toBeRdfIsomorphic([
         quad(
           namedNode(resourceID.path),
@@ -606,7 +606,7 @@ describe('A DataAccessorBasedStore', (): void => {
       const metaRepresentation = new BasicRepresentation(guardedStreamFrom(quads), resourceID, INTERNAL_QUADS);
 
       const result = await store.setRepresentation(metaResourceID, metaRepresentation);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
       expect(accessor.data[resourceID.path].metadata.quads()).toBeRdfIsomorphic(quads);
     });
 
@@ -770,8 +770,8 @@ describe('A DataAccessorBasedStore', (): void => {
       accessor.data[resourceID.path] = representation;
       const result = await store.deleteResource(resourceID);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Delete);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[resourceID.path]).toBeUndefined();
       expect(accessor.data[root].metadata.get(DC.terms.modified)?.value).toBe(now.toISOString());
       expect(accessor.data[root].metadata.get(GENERATED_PREDICATE)).toBeUndefined();
@@ -781,7 +781,7 @@ describe('A DataAccessorBasedStore', (): void => {
       accessor.data[root] = new BasicRepresentation(representation.data, containerMetadata);
       const result = await store.deleteResource({ path: root });
       expect(result.size).toBe(1);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Delete);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[root]).toBeUndefined();
     });
 
@@ -794,8 +794,8 @@ describe('A DataAccessorBasedStore', (): void => {
       auxiliaryStrategy.isRequiredInRoot = jest.fn().mockReturnValue(true);
       const result = await store.deleteResource(auxResourceID);
       expect(result.size).toBe(2);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(auxResourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Delete);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(auxResourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[auxResourceID.path]).toBeUndefined();
     });
 
@@ -807,9 +807,9 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.deleteResource(resourceID);
       expect(result.size).toBe(3);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Delete);
-      expect(result.get(auxResourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Delete);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
+      expect(result.get(auxResourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[resourceID.path]).toBeUndefined();
       expect(accessor.data[auxResourceID.path]).toBeUndefined();
     });
@@ -830,8 +830,8 @@ describe('A DataAccessorBasedStore', (): void => {
       logger.error = jest.fn();
       const result = await store.deleteResource(resourceID);
       expect(result.size).toBe(2);
-      expect(result.get({ path: root })?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Update);
-      expect(result.get(resourceID)?.get(SOLID_AS.terms.Activity)).toEqual(AS.terms.Delete);
+      expect(result.get({ path: root })?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
+      expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Delete);
       expect(accessor.data[resourceID.path]).toBeUndefined();
       expect(accessor.data[auxResourceID.path]).toBeDefined();
       expect(logger.error).toHaveBeenCalledTimes(1);

--- a/test/unit/storage/MonitoringStore.test.ts
+++ b/test/unit/storage/MonitoringStore.test.ts
@@ -16,20 +16,20 @@ describe('A MonitoringStore', (): void => {
   let deletedCallback: () => void;
 
   const addResourceReturnMock: ChangeMap = new IdentifierMap([
-    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Create }) ],
-    [{ path: 'http://example.org/foo/bar/' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Update }) ],
+    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Create }) ],
+    [{ path: 'http://example.org/foo/bar/' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Update }) ],
   ]);
   const setRepresentationReturnMock: ChangeMap = new IdentifierMap([
-    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Update }) ],
+    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Update }) ],
   ]);
   const deleteResourceReturnMock: ChangeMap = new IdentifierMap([
-    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Delete }) ],
-    [{ path: 'http://example.org/foo/bar/' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Update }) ],
+    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Delete }) ],
+    [{ path: 'http://example.org/foo/bar/' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Update }) ],
   ]);
   const modifyResourceReturnMock: ChangeMap = new IdentifierMap([
-    [{ path: 'http://example.org/foo/bar/old' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Delete }) ],
-    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Create }) ],
-    [{ path: 'http://example.org/foo/bar/' }, new RepresentationMetadata({ [SOLID_AS.Activity]: AS.terms.Update }) ],
+    [{ path: 'http://example.org/foo/bar/old' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Delete }) ],
+    [{ path: 'http://example.org/foo/bar/new' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Create }) ],
+    [{ path: 'http://example.org/foo/bar/' }, new RepresentationMetadata({ [SOLID_AS.activity]: AS.terms.Update }) ],
   ]);
 
   beforeEach(async(): Promise<void> => {
@@ -157,7 +157,7 @@ describe('A MonitoringStore', (): void => {
 
   it('should not emit an event when the Activity is not a valid AS value.', async(): Promise<void> => {
     source.addResource = jest.fn().mockResolvedValue(new IdentifierMap([
-      [{ path: 'http://example.org/path' }, new RepresentationMetadata({ [SOLID_AS.Activity]: 'SomethingRandom' }) ],
+      [{ path: 'http://example.org/path' }, new RepresentationMetadata({ [SOLID_AS.activity]: 'SomethingRandom' }) ],
     ]));
 
     await store.addResource({ path: 'http://example.org/foo/bar' }, {} as Patch);

--- a/test/util/NotificationUtil.ts
+++ b/test/util/NotificationUtil.ts
@@ -35,7 +35,7 @@ export async function subscribe(type: string, webId: string, subscriptionUrl: st
  * @param topic - The topic of the notification.
  * @param type - What type of notification is expected.
  */
-export function expectNotification(notification: unknown, topic: string, type: 'Create' | 'Update' | 'Delete'): void {
+export function expectNotification(notification: unknown, topic: string, type: string): void {
   const expected: any = {
     '@context': [
       'https://www.w3.org/ns/activitystreams',


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1388#issuecomment-1378651775

#### ✍️ Description

Introduces 2 new notification types: Add and Remove. These are emitted on containers and indicate that a resource was created or deleted in the container.

This required some change in how we pass data from the `MonitoringStore`. I decided to just also emit the metadata object so this can be used to provide more information about the change that is taking place.
