### PR TITLE
fix: Store internal JWK as JWKS to be backwards compatible

### DIFF
--- a/test/unit/identity/configuration/CachedJwkGenerator.test.ts
+++ b/test/unit/identity/configuration/CachedJwkGenerator.test.ts
@@ -1,5 +1,6 @@
 import { generateKeyPair, importJWK, jwtVerify, SignJWT } from 'jose';
 import * as jose from 'jose';
+import type { JWKS } from 'oidc-provider';
 import { CachedJwkGenerator } from '../../../../src/identity/configuration/CachedJwkGenerator';
 import type { AlgJwk } from '../../../../src/identity/configuration/JwkGenerator';
 import type { KeyValueStorage } from '../../../../src/storage/keyvalue/KeyValueStorage';
@@ -8,7 +9,7 @@ describe('A CachedJwkGenerator', (): void => {
   const alg = 'ES256';
   const storageKey = 'jwks';
   let storageMap: Map<string, AlgJwk>;
-  let storage: jest.Mocked<KeyValueStorage<string, AlgJwk>>;
+  let storage: jest.Mocked<KeyValueStorage<string, JWKS>>;
   let generator: CachedJwkGenerator;
 
   beforeEach(async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1558

#### ✍️ Description

In v5.0 and before we stored keys as a JWKS so we need to keep doing this to be backwards compatible.