### PR TITLE
feat: Provide clear error message for unknown clients

### DIFF
--- a/src/identity/configuration/IdentityProviderFactory.ts
+++ b/src/identity/configuration/IdentityProviderFactory.ts
@@ -403,7 +403,7 @@ export class IdentityProviderFactory implements ProviderFactory {
       // so we want to provide a more detailed error message explaining what to do.
       if (oidcError.error_description === 'client is invalid' && oidcError.error_detail === 'client not found') {
         const unknownClientError = new BadRequestHttpError(
-          'Unknown client, you might need to clear your cookies and cached data on the client.', {
+          'Unknown client, you might need to clear the local storage on the client.', {
             errorCode: 'E0003',
             details: {
               client_id: ctx.request.query.client_id,

--- a/templates/error/descriptions/E0003.md.hbs
+++ b/templates/error/descriptions/E0003.md.hbs
@@ -1,15 +1,26 @@
-# Trying to authenticate an unknown client
+# Authenticating with unknown client
+You are trying to log in to an application,
+but we can't proceed
+because the app is using invalid settings.
 
-The server received a request from a client with ID **{{ client_id }}**,
+These steps should force the app to send us the right details:
+1. [Go back](javascript:history.back()) to the app.
+2. Clear your cookies.
+3. Clear your cache.
+
+## Detailed error information
+We received a request from a client with ID `{{ client_id }}`,
 but this client is not registered with the server.
 
-This is quite often caused by the server data being wiped,
-thereby forgetting all clients.
-After clients register they often cache this data in the browser
-and automatically try to reconnect to the server,
-but since the server no longer knows the client this request is rejected.
+Probably,
+this client was registered with the server in the past,
+but it is no longer recognized
+because some internal server data was removed.
+Your data is still safe;
+we just don't recognize the apps's previous authentication anymore.
 
-The only solution to this problem is to remove the data cached by the client.
-This can be done by clearing the cookies and cache in your browser for that specific URL.
-After succes, this client wanted the server to redirect you to <{{ redirect_uri }}>,
-so that is probably the site for which you need to remove your browser data.
+Because your browser still has the old authentication settings stored,
+it tries to use them instead of setting up new ones.
+By clearing those settings,
+the application should automatically create a new client,
+allowing you to log in again.

--- a/templates/error/descriptions/E0003.md.hbs
+++ b/templates/error/descriptions/E0003.md.hbs
@@ -1,0 +1,15 @@
+# Trying to authenticate an unknown client
+
+The server received a request from a client with ID **{{ client_id }}**,
+but this client is not registered with the server.
+
+This is quite often caused by the server data being wiped,
+thereby forgetting all clients.
+After clients register they often cache this data in the browser
+and automatically try to reconnect to the server,
+but since the server no longer knows the client this request is rejected.
+
+The only solution to this problem is to remove the data cached by the client.
+This can be done by clearing the cookies and cache in your browser for that specific URL.
+After succes, this client wanted the server to redirect you to <{{ redirect_uri }}>,
+so that is probably the site for which you need to remove your browser data.

--- a/templates/error/descriptions/E0003.md.hbs
+++ b/templates/error/descriptions/E0003.md.hbs
@@ -3,10 +3,10 @@ You are trying to log in to an application,
 but we can't proceed
 because the app is using invalid settings.
 
-These steps should force the app to send us the right details:
-1. [Go back](javascript:history.back()) to the app.
-2. Clear your cookies.
-3. Clear your cache.
+To force the app to send us the right details,
+delete the local storage in your browser for the site that sent you here.
+Based on the data the app sent us,
+this is probably `{{ redirect_uri }}`.
 
 ## Detailed error information
 We received a request from a client with ID `{{ client_id }}`,
@@ -17,7 +17,7 @@ this client was registered with the server in the past,
 but it is no longer recognized
 because some internal server data was removed.
 Your data is still safe;
-we just don't recognize the apps's previous authentication anymore.
+we just don't recognize the app's previous authentication anymore.
 
 Because your browser still has the old authentication settings stored,
 it tries to use them instead of setting up new ones.

--- a/test/unit/identity/configuration/IdentityProviderFactory.test.ts
+++ b/test/unit/identity/configuration/IdentityProviderFactory.test.ts
@@ -253,7 +253,7 @@ describe('An IdentityProviderFactory', (): void => {
       .toHaveBeenLastCalledWith({ error: expect.objectContaining({
         statusCode: 400,
         name: 'BadRequestHttpError',
-        message: 'Unknown client, you might need to clear your cookies and cached data on the client.',
+        message: 'Unknown client, you might need to clear the local storage on the client.',
         errorCode: 'E0003',
         details: {
           client_id: 'CLIENT_ID',


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/inrupt/solid-client-authn-js/issues/2088

#### ✍️ Description

Shows a clearer error message in case the authorizing client is unknown. This mostly happens when experimenting with new CSS instances but the client stored information in the browser that is no longer relevant. Picture below of what the output of the template looks like.

![image](https://user-images.githubusercontent.com/3447363/217566430-62829085-4b3e-4cd2-93da-e68735deac35.png)

