### PR TITLE
fix: Output required OAuth error fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -406,6 +406,7 @@ export * from './util/errors/MethodNotAllowedHttpError';
 export * from './util/errors/MovedPermanentlyHttpError';
 export * from './util/errors/NotFoundHttpError';
 export * from './util/errors/NotImplementedHttpError';
+export * from './util/errors/OAuthHttpError';
 export * from './util/errors/PreconditionFailedHttpError';
 export * from './util/errors/RedirectHttpError';
 export * from './util/errors/SystemError';

--- a/src/storage/conversion/ErrorToJsonConverter.ts
+++ b/src/storage/conversion/ErrorToJsonConverter.ts
@@ -2,6 +2,7 @@ import { BasicRepresentation } from '../../http/representation/BasicRepresentati
 import type { Representation } from '../../http/representation/Representation';
 import { APPLICATION_JSON, INTERNAL_ERROR } from '../../util/ContentTypes';
 import { HttpError } from '../../util/errors/HttpError';
+import { OAuthHttpError } from '../../util/errors/OAuthHttpError';
 import { getSingleItem } from '../../util/StreamUtil';
 import { BaseTypedRepresentationConverter } from './BaseTypedRepresentationConverter';
 import type { RepresentationConverterArgs } from './RepresentationConverter';
@@ -21,6 +22,11 @@ export class ErrorToJsonConverter extends BaseTypedRepresentationConverter {
       name: error.name,
       message: error.message,
     };
+
+    // OAuth errors responses require additional fields
+    if (OAuthHttpError.isInstance(error)) {
+      Object.assign(result, error.mandatoryFields);
+    }
 
     if (HttpError.isInstance(error)) {
       result.statusCode = error.statusCode;

--- a/src/util/errors/OAuthHttpError.ts
+++ b/src/util/errors/OAuthHttpError.ts
@@ -1,0 +1,36 @@
+import type { HttpErrorOptions } from './HttpError';
+import { HttpError } from './HttpError';
+
+/**
+ * These are the fields that can occur in an OAuth error response as described in RFC 6749, §4.1.2.1.
+ * https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
+ *
+ * This interface is identical to the ErrorOut interface of the `oidc-provider` library,
+ * but having our own version reduces the part of the codebase that is dependent on that library.
+ */
+export interface OAuthErrorFields {
+  error: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  error_description?: string | undefined;
+  scope?: string | undefined;
+  state?: string | undefined;
+}
+
+/**
+ * Represents on OAuth error that is being thrown.
+ * OAuth error responses have additional fields that need to be present in the JSON response,
+ * as described in RFC 6749, §4.1.2.1.
+ */
+export class OAuthHttpError extends HttpError {
+  public readonly mandatoryFields: OAuthErrorFields;
+
+  public constructor(mandatoryFields: OAuthErrorFields, name?: string, statusCode?: number, message?: string,
+    options?: HttpErrorOptions) {
+    super(statusCode ?? 500, name ?? 'OAuthHttpError', message, options);
+    this.mandatoryFields = mandatoryFields;
+  }
+
+  public static isInstance(error: unknown): error is OAuthHttpError {
+    return HttpError.isInstance(error) && Boolean((error as OAuthHttpError).mandatoryFields);
+  }
+}

--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -628,6 +628,7 @@ describe('A Solid server with IDP', (): void => {
       expect(json.message).toBe(`invalid_request - unrecognized route or not allowed method (GET on /.oidc/foo)`);
       expect(json.statusCode).toBe(404);
       expect(json.stack).toBeDefined();
+      expect(json.error).toBe('invalid_request');
     });
   });
 });

--- a/test/unit/storage/conversion/ErrorToJsonConverter.test.ts
+++ b/test/unit/storage/conversion/ErrorToJsonConverter.test.ts
@@ -1,6 +1,8 @@
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import { ErrorToJsonConverter } from '../../../../src/storage/conversion/ErrorToJsonConverter';
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
+import type { OAuthErrorFields } from '../../../../src/util/errors/OAuthHttpError';
+import { OAuthHttpError } from '../../../../src/util/errors/OAuthHttpError';
 import { readJsonStream } from '../../../../src/util/StreamUtil';
 
 describe('An ErrorToJsonConverter', (): void => {
@@ -44,6 +46,35 @@ describe('An ErrorToJsonConverter', (): void => {
       errorCode: 'H400',
       details: { important: 'detail' },
       stack: error.stack,
+    });
+  });
+
+  it('adds OAuth fields if present.', async(): Promise<void> => {
+    const out: OAuthErrorFields = {
+      error: 'error',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      error_description: 'error_description',
+      scope: 'scope',
+      state: 'state',
+    };
+    const error = new OAuthHttpError(out, 'InvalidRequest', 400, 'error text');
+    const representation = new BasicRepresentation([ error ], 'internal/error', false);
+    const prom = converter.handle({ identifier, representation, preferences });
+    await expect(prom).resolves.toBeDefined();
+    const result = await prom;
+    expect(result.binary).toBe(true);
+    expect(result.metadata.contentType).toBe('application/json');
+    await expect(readJsonStream(result.data)).resolves.toEqual({
+      name: 'InvalidRequest',
+      message: 'error text',
+      statusCode: 400,
+      errorCode: 'H400',
+      stack: error.stack,
+      error: 'error',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      error_description: 'error_description',
+      scope: 'scope',
+      state: 'state',
     });
   });
 

--- a/test/unit/util/errors/OAuthHttpError.test.ts
+++ b/test/unit/util/errors/OAuthHttpError.test.ts
@@ -1,0 +1,24 @@
+import { OAuthHttpError } from '../../../../src/util/errors/OAuthHttpError';
+
+describe('An OAuthHttpError', (): void => {
+  it('contains relevant information.', async(): Promise<void> => {
+    const error = new OAuthHttpError({ error: 'error!' }, 'InvalidRequest', 400, 'message!');
+    expect(error.mandatoryFields.error).toBe('error!');
+    expect(error.name).toBe('InvalidRequest');
+    expect(error.statusCode).toBe(400);
+    expect(error.message).toBe('message!');
+  });
+
+  it('has optional fields.', async(): Promise<void> => {
+    const error = new OAuthHttpError({ error: 'error!' });
+    expect(error.mandatoryFields.error).toBe('error!');
+    expect(error.name).toBe('OAuthHttpError');
+    expect(error.statusCode).toBe(500);
+  });
+
+  it('can identify OAuth errors.', async(): Promise<void> => {
+    const error = new OAuthHttpError({ error: 'error!' });
+    expect(OAuthHttpError.isInstance('apple')).toBe(false);
+    expect(OAuthHttpError.isInstance(error)).toBe(true);
+  });
+});


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1586

#### ✍️ Description

So turns out an OIDC server needs to add specific fields to the error output if something goes wrong and I removed that by piping all errors to our error converter pipeline. This makes sure the requires fields are back. This is done in such a way so the error conversion part of the code has no references to the OIDC library, which could be relevant if we ever split off the OIDC part.
