### PR TITLE
fix: updated WrappedExpiringStorage tests and timer.unref calls

### DIFF
--- a/config/identity/handler/account-store/default.json
+++ b/config/identity/handler/account-store/default.json
@@ -24,17 +24,6 @@
         "relativePath": "/forgot-password/",
         "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
       }
-    },
-    {
-      "comment": "Makes sure the expiring storage cleanup timer is stopped when the application needs to stop.",
-      "@id": "urn:solid-server:default:Finalizer",
-      "@type": "ParallelHandler",
-      "handlers": [ 
-        { 
-          "@type": "FinalizableHandler",
-          "finalizable": { "@id": "urn:solid-server:default:ExpiringForgotPasswordStorage" }
-        }
-      ]
     }
   ]
 }

--- a/config/identity/ownership/token.json
+++ b/config/identity/ownership/token.json
@@ -17,17 +17,6 @@
         "relativePath": "/idp/tokens/",
         "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
       }
-    },
-    {
-      "comment": "Makes sure the expiring storage cleanup timer is stopped when the application needs to stop.",
-      "@id": "urn:solid-server:default:Finalizer",
-      "@type": "ParallelHandler",
-      "handlers": [ 
-        { 
-          "@type": "FinalizableHandler",
-          "finalizable": { "@id": "urn:solid-server:default:ExpiringTokenStorage" }
-        } 
-      ]
     }
   ]
 }

--- a/config/ldp/authorization/readers/access-checkers/agent-group.json
+++ b/config/ldp/authorization/readers/access-checkers/agent-group.json
@@ -10,17 +10,6 @@
         "@type": "WrappedExpiringStorage",
         "source": { "@type": "MemoryMapStorage" }
       }
-    },
-    {
-      "comment": "Makes sure the expiring storage cleanup timer is stopped when the application needs to stop.",
-      "@id": "urn:solid-server:default:Finalizer",
-      "@type": "ParallelHandler",
-      "handlers": [ 
-        { 
-          "@type": "FinalizableHandler",
-          "finalizable": { "@id": "urn:solid-server:default:ExpiringAclCache" }
-        } 
-      ]
     }
   ]
 }

--- a/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
+++ b/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
@@ -123,9 +123,9 @@ describe('A WrappedExpiringStorage', (): void => {
     const mockInterval = jest.spyOn(global, 'setInterval');
 
     // We only need to call the timer.unref() once when the object is created
-    const mockFn = jest.fn().mockReturnValueOnce({unref: jest.fn()});
+    const mockFn = jest.fn().mockReturnValueOnce({ unref: jest.fn() });
     mockInterval.mockImplementationOnce(mockFn);
-    
+
     // Timeout of 1 minute
     storage = new WrappedExpiringStorage(source, 1);
     const data = [
@@ -151,5 +151,4 @@ describe('A WrappedExpiringStorage', (): void => {
     expect(source.delete).toHaveBeenLastCalledWith('key2');
     mockInterval.mockRestore();
   });
-
 });

--- a/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
+++ b/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
@@ -123,7 +123,8 @@ describe('A WrappedExpiringStorage', (): void => {
     const mockInterval = jest.spyOn(global, 'setInterval');
 
     // We only need to call the timer.unref() once when the object is created
-    const mockFn = jest.fn().mockReturnValueOnce({ unref: jest.fn() });
+    const mockTimer = { unref: jest.fn() };
+    const mockFn = jest.fn().mockReturnValueOnce(mockTimer);
     mockInterval.mockImplementationOnce(mockFn);
 
     // Timeout of 1 minute
@@ -146,6 +147,8 @@ describe('A WrappedExpiringStorage', (): void => {
     await (mockInterval.mock.calls[0][0] as () => Promise<void>)();
 
     // Make sure timer.unref() is called on initialization
+    expect(mockTimer.unref).toHaveBeenCalledTimes(1);
+    // Make sure setSafeInterval has been called once as well
     expect(mockFn).toHaveBeenCalledTimes(1);
     expect(source.delete).toHaveBeenCalledTimes(1);
     expect(source.delete).toHaveBeenLastCalledWith('key2');


### PR DESCRIPTION
#### 📁 Related issues
(https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1456)

#### ✍️ Description
CSS Version: 5.1.0
Required to remove all classes which implemented the Finalizable interface only to ensure a timer was cleared in the .finalize() implementation, and replace it with a timer.unref() call after the timer is created. The references to the Finalizable Handlers were removed from the configuration files. The tests associated with the changed classes were updated where errors occurred in the test suite. To the best of my knowledge, this only occurred in the WrappedExpiringStorage class. 

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
