### PR TITLE
fix: Ensure the ETag is representation specific

### DIFF
--- a/src/http/ldp/GetOperationHandler.ts
+++ b/src/http/ldp/GetOperationHandler.ts
@@ -1,5 +1,6 @@
 import type { ResourceStore } from '../../storage/ResourceStore';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { assertReadConditions } from '../../util/ResourceUtil';
 import { OkResponseDescription } from '../output/response/OkResponseDescription';
 import type { ResponseDescription } from '../output/response/ResponseDescription';
 import type { OperationHandlerInput } from './OperationHandler';
@@ -25,6 +26,9 @@ export class GetOperationHandler extends OperationHandler {
 
   public async handle({ operation }: OperationHandlerInput): Promise<ResponseDescription> {
     const body = await this.store.getRepresentation(operation.target, operation.preferences, operation.conditions);
+
+    // Check whether the cached representation is still valid or it is necessary to send a new representation
+    assertReadConditions(body, operation.conditions);
 
     return new OkResponseDescription(body.metadata, body.data);
   }

--- a/src/http/ldp/HeadOperationHandler.ts
+++ b/src/http/ldp/HeadOperationHandler.ts
@@ -1,5 +1,6 @@
 import type { ResourceStore } from '../../storage/ResourceStore';
 import { NotImplementedHttpError } from '../../util/errors/NotImplementedHttpError';
+import { assertReadConditions } from '../../util/ResourceUtil';
 import { OkResponseDescription } from '../output/response/OkResponseDescription';
 import type { ResponseDescription } from '../output/response/ResponseDescription';
 import type { OperationHandlerInput } from './OperationHandler';
@@ -28,6 +29,10 @@ export class HeadOperationHandler extends OperationHandler {
 
     // Close the Readable as we will not return it.
     body.data.destroy();
+
+    // Check whether the cached representation is still valid or it is necessary to send a new representation.
+    // Generally it doesn't make much sense to use condition headers with a HEAD request, but it should be supported.
+    assertReadConditions(body, operation.conditions);
 
     return new OkResponseDescription(body.metadata);
   }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -7,7 +7,6 @@ import { BasicRepresentation } from '../http/representation/BasicRepresentation'
 import type { Patch } from '../http/representation/Patch';
 import type { Representation } from '../http/representation/Representation';
 import { RepresentationMetadata } from '../http/representation/RepresentationMetadata';
-import type { RepresentationPreferences } from '../http/representation/RepresentationPreferences';
 import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
 import { getLoggerFor } from '../logging/LogUtil';
 import { INTERNAL_QUADS } from '../util/ContentTypes';
@@ -18,7 +17,6 @@ import { ForbiddenHttpError } from '../util/errors/ForbiddenHttpError';
 import { MethodNotAllowedHttpError } from '../util/errors/MethodNotAllowedHttpError';
 import { NotFoundHttpError } from '../util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../util/errors/NotImplementedHttpError';
-import { NotModifiedHttpError } from '../util/errors/NotModifiedHttpError';
 import { PreconditionFailedHttpError } from '../util/errors/PreconditionFailedHttpError';
 import type { IdentifierStrategy } from '../util/identifiers/IdentifierStrategy';
 import { concat } from '../util/IterableUtil';
@@ -105,8 +103,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     }
   }
 
-  public async getRepresentation(identifier: ResourceIdentifier,
-    preferences?: RepresentationPreferences, conditions?: Conditions): Promise<Representation> {
+  public async getRepresentation(identifier: ResourceIdentifier): Promise<Representation> {
     this.validateIdentifier(identifier);
     let isMetadata = false;
 
@@ -118,8 +115,6 @@ export class DataAccessorBasedStore implements ResourceStore {
     // In the future we want to use getNormalizedMetadata and redirect in case the identifier differs
     let metadata = await this.accessor.getMetadata(identifier);
     let representation: Representation;
-
-    this.validateConditions(true, conditions, metadata);
 
     // Potentially add auxiliary related metadata
     // Solid, §4.3: "Clients can discover auxiliary resources associated with a subject resource by making an HTTP HEAD
@@ -186,7 +181,7 @@ export class DataAccessorBasedStore implements ResourceStore {
       throw new MethodNotAllowedHttpError([ 'POST' ], 'The given path is not a container.');
     }
 
-    this.validateConditions(false, conditions, parentMetadata);
+    this.validateConditions(conditions, parentMetadata);
 
     // Solid, §5.1: "Servers MAY allow clients to suggest the URI of a resource created through POST,
     // using the HTTP Slug header as defined in [RFC5023].
@@ -251,7 +246,7 @@ export class DataAccessorBasedStore implements ResourceStore {
       await this.accessor.canHandle(representation);
     }
 
-    this.validateConditions(false, conditions, oldMetadata);
+    this.validateConditions(conditions, oldMetadata);
 
     if (this.metadataStrategy.isAuxiliaryIdentifier(identifier)) {
       return await this.writeMetadata(identifier, representation);
@@ -273,7 +268,7 @@ export class DataAccessorBasedStore implements ResourceStore {
         }
       }
 
-      this.validateConditions(false, conditions, metadata);
+      this.validateConditions(conditions, metadata);
     }
 
     throw new NotImplementedHttpError('Patches are not supported by the default store.');
@@ -314,7 +309,7 @@ export class DataAccessorBasedStore implements ResourceStore {
       throw new ConflictHttpError('Can only delete empty containers.');
     }
 
-    this.validateConditions(false, conditions, metadata);
+    this.validateConditions(conditions, metadata);
 
     // Solid, §5.4: "When a contained resource is deleted,
     // the server MUST also delete the associated auxiliary resources"
@@ -352,13 +347,10 @@ export class DataAccessorBasedStore implements ResourceStore {
   /**
    * Verify if the given metadata matches the conditions.
    */
-  protected validateConditions(read: boolean, conditions?: Conditions, metadata?: RepresentationMetadata): void {
+  protected validateConditions(conditions?: Conditions, metadata?: RepresentationMetadata): void {
     // The 412 (Precondition Failed) status code indicates
     // that one or more conditions given in the request header fields evaluated to false when tested on the server.
     if (conditions && !conditions.matchesMetadata(metadata)) {
-      if (read) {
-        throw new NotModifiedHttpError();
-      }
       throw new PreconditionFailedHttpError();
     }
   }

--- a/test/integration/Conditions.test.ts
+++ b/test/integration/Conditions.test.ts
@@ -189,6 +189,13 @@ describe.each(stores)('A server supporting conditions with %s', (name, { storeCo
       headers: { 'if-none-match': eTag! },
     });
     expect(response.status).toBe(304);
+
+    // GET succeeds if the ETag header doesn't match
+    response = await fetch(baseUrl, {
+      method: 'GET',
+      headers: { 'if-none-match': '"123456"' },
+    });
+    expect(response.status).toBe(200);
   });
 
   it('prevents operations if the "if-unmodified-since" header is before the modified date.', async(): Promise<void> => {
@@ -217,5 +224,23 @@ describe.each(stores)('A server supporting conditions with %s', (name, { storeCo
       headers: { 'if-unmodified-since': lastModified.toUTCString() },
     });
     expect(response.status).toBe(205);
+  });
+
+  it('returns different ETags for different content-types.', async(): Promise<void> => {
+    let response = await getResource(baseUrl, { accept: 'text/turtle' }, { contentType: 'text/turtle' });
+    const eTagTurtle = response.headers.get('ETag');
+    response = await getResource(baseUrl, { accept: 'application/ld+json' }, { contentType: 'application/ld+json' });
+    const eTagJson = response.headers.get('ETag');
+    expect(eTagTurtle).not.toEqual(eTagJson);
+
+    // Both ETags can be used on the same resource
+    response = await fetch(baseUrl, { headers: { 'if-none-match': eTagTurtle!, accept: 'text/turtle' }});
+    expect(response.status).toBe(304);
+    response = await fetch(baseUrl, { headers: { 'if-none-match': eTagJson!, accept: 'application/ld+json' }});
+    expect(response.status).toBe(304);
+
+    // But not for the other representation
+    response = await fetch(baseUrl, { headers: { 'if-none-match': eTagTurtle!, accept: 'application/ld+json' }});
+    expect(response.status).toBe(200);
   });
 });

--- a/test/unit/http/ldp/HeadOperationHandler.test.ts
+++ b/test/unit/http/ldp/HeadOperationHandler.test.ts
@@ -3,9 +3,11 @@ import { HeadOperationHandler } from '../../../../src/http/ldp/HeadOperationHand
 import type { Operation } from '../../../../src/http/Operation';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
+import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
 import { BasicConditions } from '../../../../src/storage/BasicConditions';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { NotImplementedHttpError } from '../../../../src/util/errors/NotImplementedHttpError';
+import { NotModifiedHttpError } from '../../../../src/util/errors/NotModifiedHttpError';
 
 describe('A HeadOperationHandler', (): void => {
   let operation: Operation;
@@ -15,13 +17,14 @@ describe('A HeadOperationHandler', (): void => {
   let store: ResourceStore;
   let handler: HeadOperationHandler;
   let data: Readable;
+  const metadata = new RepresentationMetadata();
 
   beforeEach(async(): Promise<void> => {
     operation = { method: 'HEAD', target: { path: 'http://test.com/foo' }, preferences, conditions, body };
     data = { destroy: jest.fn() } as any;
     store = {
       getRepresentation: jest.fn(async(): Promise<Representation> =>
-        ({ binary: false, data, metadata: 'metadata' } as any)),
+        ({ binary: false, data, metadata } as any)),
     } as any;
 
     handler = new HeadOperationHandler(store);
@@ -38,10 +41,18 @@ describe('A HeadOperationHandler', (): void => {
   it('returns the representation from the store with the correct response.', async(): Promise<void> => {
     const result = await handler.handle({ operation });
     expect(result.statusCode).toBe(200);
-    expect(result.metadata).toBe('metadata');
+    expect(result.metadata).toBe(metadata);
     expect(result.data).toBeUndefined();
     expect(data.destroy).toHaveBeenCalledTimes(1);
     expect(store.getRepresentation).toHaveBeenCalledTimes(1);
     expect(store.getRepresentation).toHaveBeenLastCalledWith(operation.target, preferences, conditions);
+  });
+
+  it('returns a 304 if the conditions do not match.', async(): Promise<void> => {
+    operation.conditions = {
+      matchesMetadata: (): boolean => false,
+    };
+    await expect(handler.handle({ operation })).rejects.toThrow(NotModifiedHttpError);
+    expect(data.destroy).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/unit/http/output/metadata/ModifiedMetadataWriter.test.ts
+++ b/test/unit/http/output/metadata/ModifiedMetadataWriter.test.ts
@@ -2,21 +2,22 @@ import { createResponse } from 'node-mocks-http';
 import { ModifiedMetadataWriter } from '../../../../../src/http/output/metadata/ModifiedMetadataWriter';
 import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
 import type { HttpResponse } from '../../../../../src/server/HttpResponse';
+import { getETag } from '../../../../../src/storage/Conditions';
 import { updateModifiedDate } from '../../../../../src/util/ResourceUtil';
-import { DC } from '../../../../../src/util/Vocabularies';
+import { CONTENT_TYPE, DC } from '../../../../../src/util/Vocabularies';
 
 describe('A ModifiedMetadataWriter', (): void => {
   const writer = new ModifiedMetadataWriter();
 
   it('adds the Last-Modified and ETag header if there is dc:modified metadata.', async(): Promise<void> => {
     const response = createResponse() as HttpResponse;
-    const metadata = new RepresentationMetadata();
+    const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' });
     updateModifiedDate(metadata);
     const dateTime = metadata.get(DC.terms.modified)!.value;
     await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
     expect(response.getHeaders()).toEqual({
       'last-modified': new Date(dateTime).toUTCString(),
-      etag: `"${new Date(dateTime).getTime()}"`,
+      etag: getETag(metadata),
     });
   });
 

--- a/test/unit/storage/BasicConditions.test.ts
+++ b/test/unit/storage/BasicConditions.test.ts
@@ -1,71 +1,82 @@
 import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
 import { BasicConditions } from '../../../src/storage/BasicConditions';
 import { getETag } from '../../../src/storage/Conditions';
-import { DC } from '../../../src/util/Vocabularies';
+import { CONTENT_TYPE, DC } from '../../../src/util/Vocabularies';
+
+function getMetadata(modified: Date, type = 'application/ld+json'): RepresentationMetadata {
+  return new RepresentationMetadata({
+    [DC.modified]: `${modified.toISOString()}`,
+    [CONTENT_TYPE]: type,
+  });
+}
 
 describe('A BasicConditions', (): void => {
   const now = new Date(2020, 10, 20);
   const tomorrow = new Date(2020, 10, 21);
   const yesterday = new Date(2020, 10, 19);
-  const eTags = [ '123456', 'abcdefg' ];
+  const turtleTag = getETag(getMetadata(now, 'text/turtle'))!;
+  const jsonLdTag = getETag(getMetadata(now))!;
 
   it('copies the input parameters.', async(): Promise<void> => {
+    const eTags = [ '123456', 'abcdefg' ];
     const options = { matchesETag: eTags, notMatchesETag: eTags, modifiedSince: now, unmodifiedSince: now };
     expect(new BasicConditions(options)).toMatchObject(options);
   });
 
   it('always returns false if notMatchesETag contains *.', async(): Promise<void> => {
     const conditions = new BasicConditions({ notMatchesETag: [ '*' ]});
-    expect(conditions.matches()).toBe(false);
+    expect(conditions.matchesMetadata(new RepresentationMetadata())).toBe(false);
   });
 
-  it('requires matchesETag to contain the provided ETag.', async(): Promise<void> => {
-    const conditions = new BasicConditions({ matchesETag: [ '1234' ]});
-    expect(conditions.matches('abcd')).toBe(false);
-    expect(conditions.matches('1234')).toBe(true);
+  it('requires matchesETag to match the provided ETag timestamp.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ matchesETag: [ turtleTag ]});
+    expect(conditions.matchesMetadata(getMetadata(yesterday))).toBe(false);
+    expect(conditions.matchesMetadata(getMetadata(now))).toBe(true);
+  });
+
+  it('requires matchesETag to match the exact provided ETag in strict mode.', async(): Promise<void> => {
+    const turtleConditions = new BasicConditions({ matchesETag: [ turtleTag ]});
+    const jsonLdConditions = new BasicConditions({ matchesETag: [ jsonLdTag ]});
+    expect(turtleConditions.matchesMetadata(getMetadata(now), true)).toBe(false);
+    expect(jsonLdConditions.matchesMetadata(getMetadata(now), true)).toBe(true);
   });
 
   it('supports all ETags if matchesETag contains *.', async(): Promise<void> => {
     const conditions = new BasicConditions({ matchesETag: [ '*' ]});
-    expect(conditions.matches('abcd')).toBe(true);
-    expect(conditions.matches('1234')).toBe(true);
+    expect(conditions.matchesMetadata(getMetadata(yesterday))).toBe(true);
+    expect(conditions.matchesMetadata(getMetadata(now))).toBe(true);
   });
 
-  it('requires notMatchesETag to not contain the provided ETag.', async(): Promise<void> => {
-    const conditions = new BasicConditions({ notMatchesETag: [ '1234' ]});
-    expect(conditions.matches('1234')).toBe(false);
-    expect(conditions.matches('abcd')).toBe(true);
+  it('requires notMatchesETag to not match the provided ETag timestamp.', async(): Promise<void> => {
+    const conditions = new BasicConditions({ notMatchesETag: [ turtleTag ]});
+    expect(conditions.matchesMetadata(getMetadata(yesterday))).toBe(true);
+    expect(conditions.matchesMetadata(getMetadata(now))).toBe(false);
+  });
+
+  it('requires notMatchesETag to not match the exact provided ETag in strict mode.', async(): Promise<void> => {
+    const turtleConditions = new BasicConditions({ notMatchesETag: [ turtleTag ]});
+    const jsonLdConditions = new BasicConditions({ notMatchesETag: [ jsonLdTag ]});
+    expect(turtleConditions.matchesMetadata(getMetadata(now), true)).toBe(true);
+    expect(jsonLdConditions.matchesMetadata(getMetadata(now), true)).toBe(false);
   });
 
   it('requires lastModified to be after modifiedSince.', async(): Promise<void> => {
     const conditions = new BasicConditions({ modifiedSince: now });
-    expect(conditions.matches(undefined, yesterday)).toBe(false);
-    expect(conditions.matches(undefined, tomorrow)).toBe(true);
+    expect(conditions.matchesMetadata(getMetadata(yesterday))).toBe(false);
+    expect(conditions.matchesMetadata(getMetadata(tomorrow))).toBe(true);
   });
 
   it('requires lastModified to be before unmodifiedSince.', async(): Promise<void> => {
     const conditions = new BasicConditions({ unmodifiedSince: now });
-    expect(conditions.matches(undefined, tomorrow)).toBe(false);
-    expect(conditions.matches(undefined, yesterday)).toBe(true);
-  });
-
-  it('can match based on the last modified date in the metadata.', async(): Promise<void> => {
-    const metadata = new RepresentationMetadata({ [DC.modified]: now.toISOString() });
-    const conditions = new BasicConditions({
-      modifiedSince: yesterday,
-      unmodifiedSince: tomorrow,
-      matchesETag: [ getETag(metadata)! ],
-      notMatchesETag: [ '123456' ],
-    });
-    expect(conditions.matchesMetadata(metadata)).toBe(true);
+    expect(conditions.matchesMetadata(getMetadata(yesterday))).toBe(true);
+    expect(conditions.matchesMetadata(getMetadata(tomorrow))).toBe(false);
   });
 
   it('matches if no date is found in the metadata.', async(): Promise<void> => {
-    const metadata = new RepresentationMetadata();
+    const metadata = new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' });
     const conditions = new BasicConditions({
       modifiedSince: yesterday,
       unmodifiedSince: tomorrow,
-      matchesETag: [ getETag(metadata)! ],
       notMatchesETag: [ '123456' ],
     });
     expect(conditions.matchesMetadata(metadata)).toBe(true);

--- a/test/unit/storage/Conditions.test.ts
+++ b/test/unit/storage/Conditions.test.ts
@@ -1,17 +1,53 @@
 import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
-import { getETag } from '../../../src/storage/Conditions';
-import { DC } from '../../../src/util/Vocabularies';
+import { getETag, isCurrentETag } from '../../../src/storage/Conditions';
+import { CONTENT_TYPE, DC } from '../../../src/util/Vocabularies';
 
 describe('Conditions', (): void => {
   describe('#getETag', (): void => {
-    it('creates an ETag based on the date last modified.', async(): Promise<void> => {
+    it('creates an ETag based on the date last modified and content-type.', async(): Promise<void> => {
       const now = new Date();
-      const metadata = new RepresentationMetadata({ [DC.modified]: now.toISOString() });
-      expect(getETag(metadata)).toBe(`"${now.getTime()}"`);
+      const metadata = new RepresentationMetadata({
+        [DC.modified]: now.toISOString(),
+        [CONTENT_TYPE]: 'text/turtle',
+      });
+      expect(getETag(metadata)).toBe(`"${now.getTime()}-text/turtle"`);
     });
 
-    it('returns undefined if no date was found.', async(): Promise<void> => {
+    it('returns undefined if no date or content-type was found.', async(): Promise<void> => {
+      const now = new Date();
       expect(getETag(new RepresentationMetadata())).toBeUndefined();
+      expect(getETag(new RepresentationMetadata({ [DC.modified]: now.toISOString() }))).toBeUndefined();
+      expect(getETag(new RepresentationMetadata({ [CONTENT_TYPE]: 'text/turtle' }))).toBeUndefined();
+    });
+  });
+
+  describe('#isCurrentETag', (): void => {
+    const now = new Date();
+
+    it('compares an ETag with the current resource state.', async(): Promise<void> => {
+      const metadata = new RepresentationMetadata({
+        [DC.modified]: now.toISOString(),
+        [CONTENT_TYPE]: 'text/turtle',
+      });
+      const eTag = getETag(metadata)!;
+      expect(isCurrentETag(eTag, metadata)).toBe(true);
+      expect(isCurrentETag('"ETag"', metadata)).toBe(false);
+    });
+
+    it('ignores the content-type.', async(): Promise<void> => {
+      const metadata = new RepresentationMetadata({
+        [DC.modified]: now.toISOString(),
+        [CONTENT_TYPE]: 'text/turtle',
+      });
+      const eTag = getETag(metadata)!;
+      metadata.contentType = 'application/ld+json';
+      expect(isCurrentETag(eTag, metadata)).toBe(true);
+      expect(isCurrentETag('"ETag"', metadata)).toBe(false);
+    });
+
+    it('returns false if the metadata has no last modified date.', async(): Promise<void> => {
+      const metadata = new RepresentationMetadata();
+      expect(isCurrentETag('"ETag"', metadata)).toBe(false);
     });
   });
 });

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -19,7 +19,6 @@ import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError'
 import { MethodNotAllowedHttpError } from '../../../src/util/errors/MethodNotAllowedHttpError';
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import { NotImplementedHttpError } from '../../../src/util/errors/NotImplementedHttpError';
-import { NotModifiedHttpError } from '../../../src/util/errors/NotModifiedHttpError';
 import { PreconditionFailedHttpError } from '../../../src/util/errors/PreconditionFailedHttpError';
 import type { Guarded } from '../../../src/util/GuardedStream';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
@@ -217,18 +216,6 @@ describe('A DataAccessorBasedStore', (): void => {
         ),
       );
       expect(result.metadata.contentType).toBe(INTERNAL_QUADS);
-    });
-
-    it('throws a 304 if the request is a read type error.', async(): Promise<void> => {
-      const resourceID = { path: root };
-      const conditions = new BasicConditions({ notMatchesETag: [ '*' ]});
-      await expect(store.getRepresentation(resourceID, undefined, conditions)).rejects.toThrow(NotModifiedHttpError);
-    });
-
-    it('has conditions but throws no error.', async(): Promise<void> => {
-      const resourceID = { path: root };
-      const conditions = new BasicConditions({ matchesETag: [ '*' ]});
-      await expect(store.getRepresentation(resourceID, undefined, conditions)).resolves.toBeTruthy();
     });
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1605

#### ✍️ Description

Makes the ETag representation specific by adding the content-type (after content negotiation).
