### PR TITLE
fix: Use EqualReadWriteLocker with file locker to prevent deadlocks

### DIFF
--- a/config/util/resource-locker/file.json
+++ b/config/util/resource-locker/file.json
@@ -6,18 +6,12 @@
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
       "locker": {
-        "@type": "GreedyReadWriteLocker",
+        "@type": "EqualReadWriteLocker",
         "locker": {
           "@id": "urn:solid-server:default:FileSystemResourceLocker",
           "@type": "FileSystemResourceLocker",
           "args_rootFilePath": { "@id": "urn:solid-server:default:variable:rootFilePath" }
-        },
-        "storage": {
-          "@id": "urn:solid-server:default:LockStorage"
-        },
-        "suffixes_count": "count",
-        "suffixes_read": "read",
-        "suffixes_write": "write"
+        }
       },
       "expiration": 6000
     },

--- a/src/util/locking/FileSystemResourceLocker.ts
+++ b/src/util/locking/FileSystemResourceLocker.ts
@@ -53,6 +53,9 @@ function isCodedError(err: unknown): err is { code: string } & Error {
 /**
  * A resource locker making use of the [proper-lockfile](https://www.npmjs.com/package/proper-lockfile) library.
  * Note that no locks are kept in memory, thus this is considered thread- and process-safe.
+ * While it stores the actual locks on disk, it also tracks them in memory for when they need to be released.
+ * This means only the worker thread that acquired a lock can release it again,
+ * making this implementation unusable in combination with a wrapping read/write lock implementation.
  *
  * This **proper-lockfile** library has its own retry mechanism for the operations, since a lock/unlock call will
  * either resolve successfully or reject immediately with the causing error. The retry function of the library


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1610

#### ✍️ Description

See https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1610#issuecomment-1512948344

Use the `EqualReadWriteLocker` instead of the `GreedyReadWriteLocker` to make sure that locks always get released by the worker thread that acquired the lock.
