### PR TITLE
fix: Support new ETag format in notification states

### DIFF
--- a/src/server/notifications/ComposedNotificationHandler.ts
+++ b/src/server/notifications/ComposedNotificationHandler.ts
@@ -1,3 +1,4 @@
+import { sameResourceState } from '../../storage/Conditions';
 import type { NotificationGenerator } from './generate/NotificationGenerator';
 import type { NotificationEmitter } from './NotificationEmitter';
 import type { NotificationHandlerInput } from './NotificationHandler';
@@ -37,7 +38,7 @@ export class ComposedNotificationHandler extends NotificationHandler {
 
     const { state } = input.channel;
     // In case the state matches there is no need to send the notification
-    if (typeof state === 'string' && state === notification.state) {
+    if (typeof state === 'string' && notification.state && sameResourceState(state, notification.state)) {
       return;
     }
 

--- a/src/storage/Conditions.ts
+++ b/src/storage/Conditions.ts
@@ -42,31 +42,21 @@ export interface Conditions {
 export function getETag(metadata: RepresentationMetadata): string | undefined {
   const modified = metadata.get(DC.terms.modified);
   const { contentType } = metadata;
-  if (modified && contentType) {
+  if (modified) {
     const date = new Date(modified.value);
-    return `"${date.getTime()}-${contentType}"`;
+    // It is possible for the content type to be undefined,
+    // such as when only the metadata returned by a `DataAccessor` is used.
+    return `"${date.getTime()}-${contentType ?? ''}"`;
   }
 }
 
 /**
- * Validates whether a given ETag corresponds to the current state of the resource,
- * independent of the representation the ETag corresponds to.
+ * Validates whether 2 ETags correspond to the same state of a resource,
+ * independent of the representation the ETags correspond to.
  * Assumes ETags are made with the {@link getETag} function.
- * Since we base the ETag on the last modified date,
- * we know the ETag still matches as long as that didn't change.
- *
- * @param eTag - ETag to validate.
- * @param metadata - Metadata of the resource.
- *
- * @returns `true` if the ETag represents the current state of the resource.
  */
-export function isCurrentETag(eTag: string, metadata: RepresentationMetadata): boolean {
-  const modified = metadata.get(DC.terms.modified);
-  if (!modified) {
-    return false;
-  }
-  const time = eTag.split('-', 1)[0];
-  const date = new Date(modified.value);
-  // `time` will still have the initial`"` of the ETag string
-  return time === `"${date.getTime()}`;
+export function sameResourceState(eTag1: string, eTag2: string): boolean {
+  // Since we base the ETag on the last modified date,
+  // we know the ETags match as long as the date part is the same.
+  return eTag1.split('-')[0] === eTag2.split('-')[0];
 }

--- a/test/unit/server/notifications/ComposedNotificationHandler.test.ts
+++ b/test/unit/server/notifications/ComposedNotificationHandler.test.ts
@@ -18,7 +18,7 @@ describe('A ComposedNotificationHandler', (): void => {
     type: 'Update',
     object: 'http://example.com/foo',
     published: '123',
-    state: '123',
+    state: '"123456-text/turtle"',
   };
   let channel: NotificationChannel;
   const representation = new BasicRepresentation();
@@ -66,8 +66,8 @@ describe('A ComposedNotificationHandler', (): void => {
     expect(emitter.handleSafe).toHaveBeenLastCalledWith({ channel, representation });
   });
 
-  it('does not emit the notification if its state matches the channel state.', async(): Promise<void> => {
-    channel.state = notification.state;
+  it('does not emit the notification if it has the same resource state as the channel.', async(): Promise<void> => {
+    channel.state = '"123456-application/ld+json"';
     await expect(handler.handle({ channel, topic })).resolves.toBeUndefined();
     expect(generator.handle).toHaveBeenCalledTimes(1);
     expect(generator.handle).toHaveBeenLastCalledWith({ channel, topic });


### PR DESCRIPTION
#### ✍️ Description

Fixed an issue with the ETag being used for the state of notifications, caused by merging the new ETag format of the main branch into the v6.0.0 branch with notifications. Also fixes some edge case issues when there is no content type.