### PR TITLE
Allow server to support both new and old websocket protocols simultaneously

### DIFF
--- a/config/http/README.md
+++ b/config/http/README.md
@@ -27,6 +27,7 @@ Determines how notifications should be sent out from the server when resources c
 * *legacy-websocket*: Follows the legacy Solid WebSocket
   [specification](https://github.com/solid/solid-spec/blob/master/api-websockets.md).
   Will be removed in future versions.
+* *new-old-websockets.json*: Support for both the legacy Solid Websockets and the new WebSocketChannel2023.
 * *webhooks*: Follows the WebHookChannel2023
   [specification](https://solid.github.io/notifications/webhook-channel-2023) draft.
 * *websockets*: Follows the WebSocketChannel2023

--- a/config/http/notifications/new-old-websockets.json
+++ b/config/http/notifications/new-old-websockets.json
@@ -1,11 +1,16 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
+  "import": [
+    "css:config/http/notifications/base/description.json",
+    "css:config/http/notifications/base/handler.json",
+    "css:config/http/notifications/base/http.json",
+    "css:config/http/notifications/base/listener.json",
+    "css:config/http/notifications/base/storage.json",
+    "css:config/http/notifications/websockets/handler.json",
+    "css:config/http/notifications/websockets/http.json",
+    "css:config/http/notifications/websockets/subscription.json"
+  ],
   "@graph": [
-    {
-      "comment": "Disables notification routing.",
-      "@id": "urn:solid-server:default:NotificationHttpHandler",
-      "@type": "UnsupportedAsyncHandler"
-    },
     {
       "@id": "urn:solid-server:default:WebSocketHandler",
       "@type": "WaterfallHandler",

--- a/config/http/notifications/websockets/http.json
+++ b/config/http/notifications/websockets/http.json
@@ -6,7 +6,7 @@
       "@id": "urn:solid-server:default:WebSocket2023Listener",
       "@type": "WebSocket2023Listener",
       "storage": { "@id": "urn:solid-server:default:SubscriptionStorage" },
-      "route": { "@id": "urn:solid-server:default:WebSocket2023Route" },
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
       "handler": {
         "@type": "SequenceHandler",
         "handlers": [

--- a/config/http/notifications/websockets/http.json
+++ b/config/http/notifications/websockets/http.json
@@ -36,8 +36,8 @@
     },
 
     {
-      "@id": "urn:solid-server:default:ServerConfigurator",
-      "@type": "ParallelHandler",
+      "@id": "urn:solid-server:default:WebSocketHandler",
+      "@type": "WaterfallHandler",
       "handlers": [
         { "@id": "urn:solid-server:default:WebSocket2023Listener" }
       ]

--- a/config/http/server-factory/configurator/default.json
+++ b/config/http/server-factory/configurator/default.json
@@ -11,6 +11,16 @@
           "@type": "HandlerServerConfigurator",
           "handler": { "@id": "urn:solid-server:default:HttpHandler" },
           "showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" }
+        },
+        {
+          "comment": "Handles all WebSocket connections to the server.",
+          "@id": "urn:solid-server:default:WebSocketServerConfigurator",
+          "@type": "WebSocketServerConfigurator",
+          "handler": {
+            "@id": "urn:solid-server:default:WebSocketHandler",
+            "@type": "WaterfallHandler",
+            "handlers": []
+          }
         }
       ]
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,7 @@ export * from './server/OperationHttpHandler';
 export * from './server/ParsingHttpHandler';
 export * from './server/ServerConfigurator';
 export * from './server/WacAllowHttpHandler';
+export * from './server/WebSocketHandler';
 export * from './server/WebSocketServerConfigurator';
 
 // Server/Description

--- a/src/server/WebSocketHandler.ts
+++ b/src/server/WebSocketHandler.ts
@@ -1,0 +1,13 @@
+import type { WebSocket } from 'ws';
+import { AsyncHandler } from '../util/handlers/AsyncHandler';
+import type { HttpRequest } from './HttpRequest';
+
+export interface WebSocketHandlerInput {
+  webSocket: WebSocket;
+  upgradeRequest: HttpRequest;
+}
+
+/**
+ * A handler to support requests trying to open a WebSocket connection.
+ */
+export abstract class WebSocketHandler extends AsyncHandler<WebSocketHandlerInput> {}

--- a/src/server/WebSocketServerConfigurator.ts
+++ b/src/server/WebSocketServerConfigurator.ts
@@ -4,27 +4,38 @@ import type { WebSocket } from 'ws';
 import { WebSocketServer } from 'ws';
 import { getLoggerFor } from '../logging/LogUtil';
 import { createErrorMessage } from '../util/errors/ErrorUtil';
+import { guardStream } from '../util/GuardedStream';
 import { ServerConfigurator } from './ServerConfigurator';
+import type { WebSocketHandler } from './WebSocketHandler';
 
 /**
  * {@link ServerConfigurator} that adds WebSocket functionality to an existing {@link Server}.
  *
- * Implementations need to implement the `handleConnection` function to receive the necessary information.
+ * Listens for WebSocket requests and sends them to its handler.
  */
-export abstract class WebSocketServerConfigurator extends ServerConfigurator {
+export class WebSocketServerConfigurator extends ServerConfigurator {
   protected readonly logger = getLoggerFor(this);
+
+  private readonly handler: WebSocketHandler;
+
+  public constructor(handler: WebSocketHandler) {
+    super();
+    this.handler = handler;
+  }
 
   public async handle(server: Server): Promise<void> {
     // Create WebSocket server
     const webSocketServer = new WebSocketServer({ noServer: true });
     server.on('upgrade', (upgradeRequest: IncomingMessage, socket: Socket, head: Buffer): void => {
-      webSocketServer.handleUpgrade(upgradeRequest, socket, head, (webSocket: WebSocket): void => {
-        this.handleConnection(webSocket, upgradeRequest).catch((error: Error): void => {
+      webSocketServer.handleUpgrade(upgradeRequest, socket, head, async(webSocket: WebSocket): Promise<void> => {
+        try {
+          await this.handler.handleSafe({ upgradeRequest: guardStream(upgradeRequest), webSocket });
+        } catch (error: unknown) {
           this.logger.error(`Something went wrong handling a WebSocket connection: ${createErrorMessage(error)}`);
-        });
+          webSocket.send(`There was an error opening this WebSocket: ${createErrorMessage(error)}`);
+          webSocket.close();
+        }
       });
     });
   }
-
-  protected abstract handleConnection(webSocket: WebSocket, upgradeRequest: IncomingMessage): Promise<void>;
 }

--- a/src/server/notifications/WebSocketChannel2023/WebSocketChannel2023Type.ts
+++ b/src/server/notifications/WebSocketChannel2023/WebSocketChannel2023Type.ts
@@ -43,7 +43,7 @@ export class WebSocketChannel2023Type extends BaseChannelType {
     return {
       ...channel,
       type: NOTIFY.WebSocketChannel2023,
-      receiveFrom: generateWebSocketUrl(this.path, channel.id),
+      receiveFrom: generateWebSocketUrl(channel.id),
     };
   }
 }

--- a/test/integration/WebSocketChannel2023.test.ts
+++ b/test/integration/WebSocketChannel2023.test.ts
@@ -220,7 +220,7 @@ describe.each(stores)('A server supporting WebSocketChannel2023 using %s', (name
     await new Promise<void>((resolve): any => socket.on('close', resolve));
 
     const message = (await messagePromise).toString();
-    expect(message).toBe('Notification channel has expired');
+    expect(message).toContain('There was an error opening this WebSocket');
   });
 
   it('emits container notifications if contents get added or removed.', async(): Promise<void> => {

--- a/test/unit/server/WebSocketServerConfigurator.test.ts
+++ b/test/unit/server/WebSocketServerConfigurator.test.ts
@@ -4,6 +4,7 @@ import type { WebSocket } from 'ws';
 import type { Logger } from '../../../src/logging/Logger';
 import { getLoggerFor } from '../../../src/logging/LogUtil';
 import type { HttpRequest } from '../../../src/server/HttpRequest';
+import type { WebSocketHandler } from '../../../src/server/WebSocketHandler';
 import { WebSocketServerConfigurator } from '../../../src/server/WebSocketServerConfigurator';
 import { flushPromises } from '../../util/Util';
 
@@ -22,18 +23,13 @@ jest.mock('../../../src/logging/LogUtil', (): any => {
   return { getLoggerFor: (): Logger => logger };
 });
 
-class SimpleWebSocketConfigurator extends WebSocketServerConfigurator {
-  public async handleConnection(): Promise<void> {
-    // Will be overwritten
-  }
-}
-
 describe('A WebSocketServerConfigurator', (): void => {
   const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   let server: Server;
   let webSocket: WebSocket;
   let upgradeRequest: HttpRequest;
-  let listener: jest.Mocked<SimpleWebSocketConfigurator>;
+  let handler: jest.Mocked<WebSocketHandler>;
+  let configurator: WebSocketServerConfigurator;
 
   beforeEach(async(): Promise<void> => {
     // Clearing the logger mock
@@ -43,17 +39,20 @@ describe('A WebSocketServerConfigurator', (): void => {
     webSocket.send = jest.fn();
     webSocket.close = jest.fn();
 
-    upgradeRequest = { url: `/foo` } as any;
+    upgradeRequest = new EventEmitter() as any;
 
-    listener = new SimpleWebSocketConfigurator() as any;
-    listener.handleConnection = jest.fn().mockResolvedValue('');
-    await listener.handle(server);
+    handler = {
+      handleSafe: jest.fn(),
+    } as any;
+
+    configurator = new WebSocketServerConfigurator(handler);
+    await configurator.handle(server);
   });
 
   it('attaches an upgrade listener to any server it gets.', async(): Promise<void> => {
     server = new EventEmitter() as any;
     expect(server.listenerCount('upgrade')).toBe(0);
-    await listener.handle(server);
+    await configurator.handle(server);
     expect(server.listenerCount('upgrade')).toBe(1);
   });
 
@@ -62,19 +61,22 @@ describe('A WebSocketServerConfigurator', (): void => {
 
     await flushPromises();
 
-    expect(listener.handleConnection).toHaveBeenCalledTimes(1);
-    expect(listener.handleConnection).toHaveBeenLastCalledWith(webSocket, upgradeRequest);
+    expect(handler.handleSafe).toHaveBeenCalledTimes(1);
+    expect(handler.handleSafe).toHaveBeenLastCalledWith({ webSocket, upgradeRequest });
     expect(logger.error).toHaveBeenCalledTimes(0);
   });
 
   it('logs an error if something went wrong handling the connection.', async(): Promise<void> => {
-    listener.handleConnection.mockRejectedValue(new Error('bad input'));
+    handler.handleSafe.mockRejectedValue(new Error('bad input'));
     server.emit('upgrade', upgradeRequest, webSocket);
 
     await flushPromises();
 
-    expect(listener.handleConnection).toHaveBeenCalledTimes(1);
+    expect(handler.handleSafe).toHaveBeenCalledTimes(1);
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(logger.error).toHaveBeenLastCalledWith('Something went wrong handling a WebSocket connection: bad input');
+    expect(webSocket.send).toHaveBeenCalledTimes(1);
+    expect(webSocket.send).toHaveBeenLastCalledWith('There was an error opening this WebSocket: bad input');
+    expect(webSocket.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Listener.test.ts
+++ b/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Listener.test.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events';
-import type { Server } from 'http';
 import type { WebSocket } from 'ws';
 
 import type { HttpRequest } from '../../../../../src/server/HttpRequest';
@@ -13,7 +12,7 @@ import type {
 import {
   WebSocket2023Listener,
 } from '../../../../../src/server/notifications/WebSocketChannel2023/WebSocket2023Listener';
-import { flushPromises } from '../../../../util/Util';
+import { NotImplementedHttpError } from '../../../../../src/util/errors/NotImplementedHttpError';
 
 jest.mock('ws', (): any => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -30,7 +29,6 @@ describe('A WebSocket2023Listener', (): void => {
     topic: 'http://example.com/foo',
     type: 'type',
   };
-  let server: Server;
   let webSocket: WebSocket;
   let upgradeRequest: HttpRequest;
   let storage: jest.Mocked<NotificationChannelStorage>;
@@ -39,7 +37,6 @@ describe('A WebSocket2023Listener', (): void => {
   let listener: WebSocket2023Listener;
 
   beforeEach(async(): Promise<void> => {
-    server = new EventEmitter() as any;
     webSocket = new EventEmitter() as any;
     webSocket.send = jest.fn();
     webSocket.close = jest.fn();
@@ -55,26 +52,16 @@ describe('A WebSocket2023Listener', (): void => {
     } as any;
 
     listener = new WebSocket2023Listener(storage, handler, baseUrl);
-    await listener.handle(server);
   });
 
   it('rejects requests with an unknown target.', async(): Promise<void> => {
+    await expect(listener.canHandle({ upgradeRequest, webSocket })).resolves.toBeUndefined();
     storage.get.mockResolvedValue(undefined);
-    server.emit('upgrade', upgradeRequest, webSocket);
-
-    await flushPromises();
-
-    expect(webSocket.send).toHaveBeenCalledTimes(1);
-    expect(webSocket.send).toHaveBeenLastCalledWith(`Notification channel has expired`);
-    expect(webSocket.close).toHaveBeenCalledTimes(1);
-    expect(handler.handleSafe).toHaveBeenCalledTimes(0);
+    await expect(listener.canHandle({ upgradeRequest, webSocket })).rejects.toThrow(NotImplementedHttpError);
   });
 
   it('calls the handler when receiving a valid request.', async(): Promise<void> => {
-    server.emit('upgrade', upgradeRequest, webSocket);
-
-    await flushPromises();
-
+    await expect(listener.handle({ upgradeRequest, webSocket })).resolves.toBeUndefined();
     expect(webSocket.send).toHaveBeenCalledTimes(0);
     expect(webSocket.close).toHaveBeenCalledTimes(0);
     expect(handler.handleSafe).toHaveBeenCalledTimes(1);

--- a/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Util.test.ts
+++ b/test/unit/server/notifications/WebSocketChannel2023/WebSocket2023Util.test.ts
@@ -2,26 +2,32 @@ import type { IncomingMessage } from 'http';
 import {
   generateWebSocketUrl, parseWebSocketRequest,
 } from '../../../../../src/server/notifications/WebSocketChannel2023/WebSocket2023Util';
+import { BadRequestHttpError } from '../../../../../src/util/errors/BadRequestHttpError';
 
 describe('WebSocket2023Util', (): void => {
   describe('#generateWebSocketUrl', (): void => {
-    it('generates a WebSocket link with a query parameter.', async(): Promise<void> => {
-      expect(generateWebSocketUrl('http://example.com/', '123456')).toBe('ws://example.com/?auth=123456');
+    it('generates a WebSocket link.', async(): Promise<void> => {
+      expect(generateWebSocketUrl('http://example.com/123456')).toBe('ws://example.com/123456');
 
-      expect(generateWebSocketUrl('https://example.com/foo/bar', '123456'))
-        .toBe('wss://example.com/foo/bar?auth=123456');
+      expect(generateWebSocketUrl('https://example.com/foo/bar/123456'))
+        .toBe('wss://example.com/foo/bar/123456');
     });
   });
 
   describe('#parseWebSocketRequest', (): void => {
     it('parses the request.', async(): Promise<void> => {
-      const request: IncomingMessage = { url: '/foo/bar?auth=123%24456' } as any;
-      expect(parseWebSocketRequest(request)).toEqual({ path: '/foo/bar', id: '123$456' });
+      const request: IncomingMessage = { url: '/foo/bar/123%24456' } as any;
+      expect(parseWebSocketRequest('http://example.com/', request)).toBe('http://example.com/foo/bar/123%24456');
     });
 
-    it('returns an empty path and no id if the url parameter is undefined.', async(): Promise<void> => {
+    it('throws an error if the url parameter is not defined.', async(): Promise<void> => {
       const request: IncomingMessage = {} as any;
-      expect(parseWebSocketRequest(request)).toEqual({ path: '/' });
+      expect((): string => parseWebSocketRequest('http://example.com/', request)).toThrow(BadRequestHttpError);
+    });
+
+    it('can handle non-root base URLs.', async(): Promise<void> => {
+      const request: IncomingMessage = { url: '/foo/bar/123%24456' } as any;
+      expect(parseWebSocketRequest('http://example.com/foo/bar/', request)).toBe('http://example.com/foo/bar/123%24456');
     });
   });
 });

--- a/test/unit/server/notifications/WebSocketChannel2023/WebSocketChannel2023Type.test.ts
+++ b/test/unit/server/notifications/WebSocketChannel2023/WebSocketChannel2023Type.test.ts
@@ -39,7 +39,7 @@ describe('A WebSocketChannel2023', (): void => {
       id,
       type: NOTIFY.WebSocketChannel2023,
       topic,
-      receiveFrom: generateWebSocketUrl(route.getPath(), id),
+      receiveFrom: generateWebSocketUrl(id),
     };
 
     channelType = new WebSocketChannel2023Type(route);


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1220

#### ✍️ Description

Like it says in the title. Allows server to support both the old and new specification simultaneously to potentially have a transitionary period.

There is now 1 class that catches all WebSocket requests and calls its handler, allowing us to combine multiple handlers for specific targets.

Also updates the new WebSocket implementation to just use the channel identifier for the WebSocket instead of using 1 fixed URL with a query parameter.