### PR TITLE
fix: Make aggregated errors prettier

### DIFF
--- a/test/unit/util/errors/HttpErrorUtil.test.ts
+++ b/test/unit/util/errors/HttpErrorUtil.test.ts
@@ -3,7 +3,7 @@ import { createAggregateError, getStatusCode } from '../../../../src/util/errors
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
 
 describe('ErrorUtil', (): void => {
-  describe('createAggregateError', (): void => {
+  describe('#createAggregateError', (): void => {
     const error401 = new HttpError(401, 'UnauthorizedHttpError');
     const error415 = new HttpError(415, 'UnsupportedMediaTypeHttpError');
     const error501 = new HttpError(501, 'NotImplementedHttpError');
@@ -35,6 +35,19 @@ describe('ErrorUtil', (): void => {
         statusCode: 500,
         name: 'InternalServerError',
       });
+    });
+
+    it('has no error message if none of the errors had one.', async(): Promise<void> => {
+      expect(createAggregateError([ error401, error501 ]).message).toBe('');
+    });
+
+    it('copies the error message if there is one error with a message.', async(): Promise<void> => {
+      expect(createAggregateError([ error, error501 ]).message).toBe('noStatusCode');
+    });
+
+    it('joins the error messages if there are multiple.', async(): Promise<void> => {
+      expect(createAggregateError([ error, error, error501 ]).message)
+        .toBe('Multiple handler errors: noStatusCode, noStatusCode');
     });
   });
 

--- a/test/unit/util/handlers/BooleanHandler.test.ts
+++ b/test/unit/util/handlers/BooleanHandler.test.ts
@@ -26,7 +26,7 @@ describe('A BooleanHandler', (): void => {
 
   it('errors if none of its handlers supports the input.', async(): Promise<void> => {
     const handler = new BooleanHandler([ handlerCanNotHandle, handlerCanNotHandle ]);
-    await expect(handler.canHandle(null)).rejects.toThrow('[Not supported, Not supported]');
+    await expect(handler.canHandle(null)).rejects.toThrow('Not supported, Not supported');
   });
 
   it('returns true if any of its handlers returns true.', async(): Promise<void> => {
@@ -51,6 +51,6 @@ describe('A BooleanHandler', (): void => {
 
   it('throws the canHandle error when calling handleSafe with unsupported input.', async(): Promise<void> => {
     const handler = new BooleanHandler([ handlerCanNotHandle, handlerCanNotHandle ]);
-    await expect(handler.handleSafe(null)).rejects.toThrow('[Not supported, Not supported]');
+    await expect(handler.handleSafe(null)).rejects.toThrow('Not supported, Not supported');
   });
 });

--- a/test/unit/util/handlers/HandlerUtil.test.ts
+++ b/test/unit/util/handlers/HandlerUtil.test.ts
@@ -17,12 +17,12 @@ describe('HandlerUtil', (): void => {
     });
 
     it('errors if there is no matching handler.', async(): Promise<void> => {
-      await expect(findHandler([ handlerFalse, handlerFalse ], null)).rejects.toThrow('[Not supported, Not supported]');
+      await expect(findHandler([ handlerFalse, handlerFalse ], null)).rejects.toThrow('Not supported, Not supported');
     });
 
     it('supports non-native Errors.', async(): Promise<void> => {
       handlerFalse.canHandle = jest.fn().mockRejectedValue('apple');
-      await expect(findHandler([ handlerFalse ], null)).rejects.toThrow('[Unknown error: apple]');
+      await expect(findHandler([ handlerFalse ], null)).rejects.toThrow('Unknown error: apple');
     });
   });
 
@@ -42,7 +42,7 @@ describe('HandlerUtil', (): void => {
 
     it('errors if there is no matching handler.', async(): Promise<void> => {
       await expect(filterHandlers([ handlerFalse, handlerFalse ], null))
-        .rejects.toThrow('[Not supported, Not supported]');
+        .rejects.toThrow('Not supported, Not supported');
     });
   });
 });

--- a/test/unit/util/handlers/WaterfallHandler.test.ts
+++ b/test/unit/util/handlers/WaterfallHandler.test.ts
@@ -42,7 +42,7 @@ describe('A WaterfallHandler', (): void => {
     it('can not handle data if no handler supports it.', async(): Promise<void> => {
       const handler = new WaterfallHandler([ handlerFalse, handlerFalse ]);
 
-      await expect(handler.canHandle(null)).rejects.toThrow('[Not supported, Not supported]');
+      await expect(handler.canHandle(null)).rejects.toThrow('Not supported, Not supported');
     });
 
     it('throws unknown errors if no Error objects are thrown.', async(): Promise<void> => {
@@ -51,7 +51,7 @@ describe('A WaterfallHandler', (): void => {
       };
       const handler = new WaterfallHandler([ handlerFalse, handlerFalse ]);
 
-      await expect(handler.canHandle(null)).rejects.toThrow('[Unknown error: apple, Unknown error: apple]');
+      await expect(handler.canHandle(null)).rejects.toThrow('Unknown error: apple, Unknown error: apple');
     });
 
     it('handles data if a handler supports it.', async(): Promise<void> => {
@@ -79,7 +79,7 @@ describe('A WaterfallHandler', (): void => {
     it('throws the canHandle error when calling handleSafe if the data is not supported.', async(): Promise<void> => {
       const handler = new WaterfallHandler([ handlerFalse, handlerFalse ]);
 
-      await expect(handler.handleSafe(null)).rejects.toThrow('[Not supported, Not supported]');
+      await expect(handler.handleSafe(null)).rejects.toThrow('Not supported, Not supported');
     });
   });
 });


### PR DESCRIPTION
#### ✍️ Description

Prevents those error messages that are arrays of commas because none of the errors had a message. Bothered me while working on something else and was an easy fix.
