### PR TITLE
Allow StaticAssetHandler to link a container to a single file

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,9 @@
 
 ### New features
 
-- ...
+- The `StaticAssetHandler` can now be used to link static pages to containers.
+  This can be used to set a static page for the root container of a server.
+  See the `/config/app/init/static-root.json` config for an example.
 
 ### Data migration
 
@@ -18,15 +20,18 @@ The `@context` needs to be updated to
 `https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld`.
 
 The following changes pertain to the imports in the default configs:
- - ...
+
+- There is a new `static-root.json` import option for `app/init`, setting a static page for the root container.
 
 The following changes are relevant for v5 custom configs that replaced certain features.
- - ...
+
+- `/app/init/*` imports have changed. Functionality remained the same though.
 
 ### Interface changes
 
 These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.
- - ...
+
+- ...
 
 ## v6.0.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,33 @@
 # Community Solid Server release notes
 
+## v7.0.0
+
+### New features
+
+- ...
+
+### Data migration
+
+No actions are required to migrate data.
+
+### Configuration changes
+
+You might need to make changes to your v6 configuration if you use a custom config.
+
+The `@context` needs to be updated to
+`https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld`.
+
+The following changes pertain to the imports in the default configs:
+ - ...
+
+The following changes are relevant for v5 custom configs that replaced certain features.
+ - ...
+
+### Interface changes
+
+These changes are relevant if you wrote custom modules for the server that depend on existing interfaces.
+ - ...
+
 ## v6.0.0
 
 ### New features

--- a/config/app/README.md
+++ b/config/app/README.md
@@ -10,6 +10,7 @@ Contains a list of initializer that need to be run when starting the server.
 * *initialize-root*: Makes sure the root container has the necessary resources to function properly.
                      This is only relevant if setup is disabled but root container access is still required.
 * *initialize-prefilled-root*: Similar to `initialize-root` but adds some introductory resources to the root container.
+* *static-root*: Shows a static introduction page at the server root. This is not a Solid resource.
 
 ## Main
 

--- a/config/app/init/initialize-prefilled-root.json
+++ b/config/app/init/initialize-prefilled-root.json
@@ -1,23 +1,17 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
   "import": [
-    "css:config/app/init/base/init.json",
+    "css:config/app/init/default.json",
     "css:config/app/init/initializers/prefilled-root.json"
   ],
   "@graph": [
     {
-      "comment": "These handlers are called only for the Primary process whenever the server is started, and can be used to ensure that all necessary resources for booting are available. (in singlethreaded mode, these are always called)",
+      "comment": "Initializes the root container resource.",
       "@id": "urn:solid-server:default:PrimaryParallelInitializer",
       "@type": "ParallelHandler",
       "handlers": [
         { "@id": "urn:solid-server:default:RootInitializer" }
       ]
-    },
-    {
-      "comment": "These handlers are called only for the workers processes whenever the server is started, and can be used to ensure that all necessary resources for booting are available. (in singlethreaded mode, these are always called)",
-      "@id": "urn:solid-server:default:WorkerParallelInitializer",
-      "@type": "ParallelHandler",
-      "handlers": [ ]
     }
   ]
 }

--- a/config/app/init/initialize-root.json
+++ b/config/app/init/initialize-root.json
@@ -1,23 +1,17 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
   "import": [
-    "css:config/app/init/base/init.json",
+    "css:config/app/init/default.json",
     "css:config/app/init/initializers/root.json"
   ],
   "@graph": [
     {
-      "comment": "These handlers are called only for the Primary process whenever the server is started, and can be used to ensure that all necessary resources for booting are available. (in singlethreaded mode, these are always called)",
+      "comment": "Initializes the root container resource.",
       "@id": "urn:solid-server:default:PrimaryParallelInitializer",
       "@type": "ParallelHandler",
       "handlers": [
         { "@id": "urn:solid-server:default:RootInitializer" }
       ]
-    },
-    {
-      "comment": "These handlers are called only for the workers processes whenever the server is started, and can be used to ensure that all necessary resources for booting are available. (in singlethreaded mode, these are always called)",
-      "@id": "urn:solid-server:default:WorkerParallelInitializer",
-      "@type": "ParallelHandler",
-      "handlers": [ ]
     }
   ]
 }

--- a/config/app/init/static-root.json
+++ b/config/app/init/static-root.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^6.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/init/default.json"
+  ],
+  "@graph": [
+    {
+      "comment": "Sets the root of the server to a static page.",
+      "@id": "urn:solid-server:default:StaticAssetHandler",
+      "@type": "StaticAssetHandler",
+      "assets": [
+        {
+          "StaticAssetHandler:_assets_key": "/",
+          "StaticAssetHandler:_assets_value": "@css:templates/root/prefilled/base/index.html"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
#### ✍️ Description

As the title says. This makes it easy to set the root container to a static file instead of a Solid resource, preventing overlapping storages when registration is enabled while still showing something when the root is accessed.

The IDP refactor will probably remove everything setup related so this will also be useful to make sure users still see something when they boot up a server.
