### PR TITLE
Make node v18 the minimum supported version

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -23,10 +23,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - '14.14'
-          - '14.x'
-          - '16.0'
-          - '16.x'
           - '18.0'
           - '18.x'
           - '20.0'
@@ -60,8 +56,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14.x'
-          - '16.x'
           - '18.x'
           - '20.x'
     env:
@@ -96,8 +90,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14.x'
-          - '16.x'
           - '18.x'
           - '20.x'
     timeout-minutes: 20

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -29,6 +29,8 @@ jobs:
           - '16.x'
           - '18.0'
           - '18.x'
+          - '20.0'
+          - '20.x'
     timeout-minutes: 15
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
@@ -61,6 +63,7 @@ jobs:
           - '14.x'
           - '16.x'
           - '18.x'
+          - '20.x'
     env:
       TEST_DOCKER: true
     services:
@@ -96,6 +99,7 @@ jobs:
           - '14.x'
           - '16.x'
           - '18.x'
+          - '20.x'
     timeout-minutes: 20
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ And, of course, for many others who like to experience Solid.
 
 ## ⚡ Running the Community Solid Server
 
-Use [Node.js](https://nodejs.org/en/) 14.14 or up and execute:
+Use [Node.js](https://nodejs.org/en/) 18.0 or up and execute:
 
 ```shell
 npx @solid/community-server

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- The minimum supported Node version is now v18.
 - The `StaticAssetHandler` can now be used to link static pages to containers.
   This can be used to set a static page for the root container of a server.
   See the `/config/app/init/static-root.json` config for an example.

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -2,7 +2,7 @@
 
 ## Quickly spinning up a server
 
-Use [Node.js](https://nodejs.org/en/) 14.14 or up and execute:
+Use [Node.js](https://nodejs.org/en/) 18.0 or up and execute:
 
 ```shell
 npx @solid/community-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "@inrupt/solid-client-authn-core": "1.14.0",
         "@inrupt/solid-client-authn-node": "1.14.0",
         "@microsoft/tsdoc-config": "^0.16.2",
-        "@tsconfig/node14": "^1.0.3",
+        "@tsconfig/node18": "^2.0.1",
         "@types/cheerio": "^0.22.31",
         "@types/jest": "^29.5.1",
         "@types/set-cookie-parser": "^2.4.2",
@@ -119,7 +119,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=18.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4515,6 +4515,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node18": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-2.0.1.tgz",
+      "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
       "dev": true
     },
     "node_modules/@types/accepts": {
@@ -19446,6 +19452,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
+    "@tsconfig/node18": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-2.0.1.tgz",
+      "integrity": "sha512-UqdfvuJK0SArA2CxhKWwwAWfnVSXiYe63bVpMutc27vpngCntGUZQETO24pEJ46zU6XM+7SpqYoMgcO3bM11Ew==",
       "dev": true
     },
     "@types/accepts": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": ">=14.14"
+    "node": ">=18.0"
   },
   "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server",
   "lsd:components": "dist/components/components.jsonld",
@@ -172,7 +172,7 @@
     "@inrupt/solid-client-authn-core": "1.14.0",
     "@inrupt/solid-client-authn-node": "1.14.0",
     "@microsoft/tsdoc-config": "^0.16.2",
-    "@tsconfig/node14": "^1.0.3",
+    "@tsconfig/node18": "^2.0.1",
     "@types/cheerio": "^0.22.31",
     "@types/jest": "^29.5.1",
     "@types/set-cookie-parser": "^2.4.2",

--- a/src/http/auxiliary/RoutingAuxiliaryStrategy.ts
+++ b/src/http/auxiliary/RoutingAuxiliaryStrategy.ts
@@ -12,10 +12,11 @@ import { RoutingAuxiliaryIdentifierStrategy } from './RoutingAuxiliaryIdentifier
  * or only the matching strategy if the input is an auxiliary identifier.
  */
 export class RoutingAuxiliaryStrategy extends RoutingAuxiliaryIdentifierStrategy implements AuxiliaryStrategy {
-  protected readonly sources!: AuxiliaryStrategy[];
+  protected readonly sources: AuxiliaryStrategy[] = [];
 
   public constructor(sources: AuxiliaryStrategy[]) {
     super(sources);
+    this.sources = sources;
   }
 
   public usesOwnAuthorization(identifier: ResourceIdentifier): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "lib": [ "es2021" ],
     "declaration": true,
     "incremental": true,
     "inlineSources": true,


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1637

#### ✍️ Description

Adds Node 20 testing and makes Node 18 the minimum supported version. The reason for also immediately cutting of Node 16 is that oidc-provider v8 only supports Node 18 and up.