### PR TITLE
chore: name http handlers

### DIFF
--- a/config/http/handler/default.json
+++ b/config/http/handler/default.json
@@ -12,6 +12,7 @@
       "handlers": [
         { "@id": "urn:solid-server:default:Middleware" },
         {
+          "@id": "urn:solid-server:default:BaseHttpHandler",
           "@type": "WaterfallHandler",
           "handlers": [
             { "@id": "urn:solid-server:default:StaticAssetHandler" },

--- a/config/http/handler/simple.json
+++ b/config/http/handler/simple.json
@@ -11,6 +11,7 @@
       "handlers": [
         { "@id": "urn:solid-server:default:Middleware" },
         {
+          "@id": "urn:solid-server:simple:BaseHttpHandler",
           "@type": "WaterfallHandler",
           "handlers": [
             { "@id": "urn:solid-server:default:StaticAssetHandler" },

--- a/config/http/handler/simple.json
+++ b/config/http/handler/simple.json
@@ -11,7 +11,7 @@
       "handlers": [
         { "@id": "urn:solid-server:default:Middleware" },
         {
-          "@id": "urn:solid-server:simple:BaseHttpHandler",
+          "@id": "urn:solid-server:default:BaseHttpHandler",
           "@type": "WaterfallHandler",
           "handlers": [
             { "@id": "urn:solid-server:default:StaticAssetHandler" },


### PR DESCRIPTION
Provides ids for some some blank nodes in the config so that they can be overriden.