### PR TITLE
Do not show PUT in Allow header for existing containers

### DIFF
--- a/src/http/output/metadata/AllowAcceptHeaderWriter.ts
+++ b/src/http/output/metadata/AllowAcceptHeaderWriter.ts
@@ -50,8 +50,12 @@ export class AllowAcceptHeaderWriter extends MetadataWriter {
 
     // POST is only allowed on containers.
     // Metadata only has the resource URI in case it has resource metadata.
-    if (this.isPostAllowed(metadata)) {
+    if (!this.isPostAllowed(metadata)) {
       allowedMethods.delete('POST');
+    }
+
+    if (!this.isPutAllowed(metadata)) {
+      allowedMethods.delete('PUT');
     }
 
     if (!this.isDeleteAllowed(metadata)) {
@@ -76,7 +80,14 @@ export class AllowAcceptHeaderWriter extends MetadataWriter {
    * otherwise it is just a blank node.
    */
   private isPostAllowed(metadata: RepresentationMetadata): boolean {
-    return metadata.has(RDF.terms.type, LDP.terms.Resource) && !isContainerPath(metadata.identifier.value);
+    return !metadata.has(RDF.terms.type, LDP.terms.Resource) || isContainerPath(metadata.identifier.value);
+  }
+
+  /**
+   * PUT is not allowed on existing containers.
+   */
+  private isPutAllowed(metadata: RepresentationMetadata): boolean {
+    return !metadata.has(RDF.terms.type, LDP.terms.Resource) || !isContainerPath(metadata.identifier.value);
   }
 
   /**

--- a/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
+++ b/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
@@ -49,36 +49,33 @@ describe('An AllowAcceptHeaderWriter', (): void => {
     expect(headers['accept-post']).toBeUndefined();
   });
 
-  it('returns all methods for an empty container.', async(): Promise<void> => {
+  it('returns all methods except PUT for an empty container.', async(): Promise<void> => {
     await expect(writer.handleSafe({ response, metadata: emptyContainer })).resolves.toBeUndefined();
     const headers = response.getHeaders();
     expect(typeof headers.allow).toBe('string');
     expect(new Set((headers.allow as string).split(', ')))
-      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH', 'DELETE' ]));
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH', 'DELETE' ]));
     expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
-    expect(headers['accept-put']).toBe('*/*');
     expect(headers['accept-post']).toBe('*/*');
   });
 
-  it('returns all methods except DELETE for a non-empty container.', async(): Promise<void> => {
+  it('returns all methods except PUT/DELETE for a non-empty container.', async(): Promise<void> => {
     await expect(writer.handleSafe({ response, metadata: fullContainer })).resolves.toBeUndefined();
     const headers = response.getHeaders();
     expect(typeof headers.allow).toBe('string');
     expect(new Set((headers.allow as string).split(', ')))
-      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH' ]));
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH' ]));
     expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
-    expect(headers['accept-put']).toBe('*/*');
     expect(headers['accept-post']).toBe('*/*');
   });
 
-  it('returns all methods except DELETE for a storage container.', async(): Promise<void> => {
+  it('returns all methods except PUT/DELETE for a storage container.', async(): Promise<void> => {
     await expect(writer.handleSafe({ response, metadata: storageContainer })).resolves.toBeUndefined();
     const headers = response.getHeaders();
     expect(typeof headers.allow).toBe('string');
     expect(new Set((headers.allow as string).split(', ')))
-      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'PUT', 'POST', 'PATCH' ]));
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH' ]));
     expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
-    expect(headers['accept-put']).toBe('*/*');
     expect(headers['accept-post']).toBe('*/*');
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1666

#### ✍️ Description

Only allows PUT on existing containers. Also fixes inconsistency in how the check was done for POST.
