### PR TITLE
ci: Add `linux/arm64/v8` as platform to support Apple Silicon architectures

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,6 +89,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm/v8
+          platforms: linux/amd64,linux/arm/v7,linux/arm/v8,linux/arm64/v8
           tags: ${{ needs.docker-meta.outputs.tags }}
           labels: ${{ needs.docker-meta.outputs.labels }}


### PR DESCRIPTION
#### 📁 Related issues

#1697

#### ✍️ Description

This PR adds `linux/arm64/v8` to the platforms to add support for Apple Silicon architectures.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
