### PR TITLE
fix: Remove URL encoding from base64 strings before decoding

### DIFF
--- a/src/storage/keyvalue/EncodingPathStorage.ts
+++ b/src/storage/keyvalue/EncodingPathStorage.ts
@@ -62,7 +62,15 @@ export class EncodingPathStorage<T> implements KeyValueStorage<string, T> {
    * Converts an internal storage path string into the original path key.
    */
   protected pathToKey(path: string): string {
-    const buffer = Buffer.from(path.slice(this.basePath.length), 'base64');
+    // While the main part of a base64 encoded string is same from any changes from encoding or decoding URL parts,
+    // the `=` symbol that is used for padding is not.
+    // This can cause incorrect results when calling these function,
+    // where the original path contains `YXBwbGU%3D` instead of `YXBwbGU=`.
+    // This does not create any issues when the source store does not encode the string, so is safe to always call.
+    // For consistency, we might want to also always encode when creating the path in `keyToPath()`,
+    // but that would potentially break existing implementations that do not do encoding,
+    // and is not really necessary to solve any issues.
+    const buffer = Buffer.from(decodeURIComponent(path.slice(this.basePath.length)), 'base64');
     return buffer.toString('utf-8');
   }
 }

--- a/test/unit/storage/keyvalue/EncodingPathStorage.test.ts
+++ b/test/unit/storage/keyvalue/EncodingPathStorage.test.ts
@@ -48,4 +48,20 @@ describe('An EncodingPathStorage', (): void => {
     expect(results).toHaveLength(1);
     expect(results[0]).toEqual([ 'key', data ]);
   });
+
+  it('correctly handles keys that have been encoded by the source storage.', async(): Promise<void> => {
+    // Base 64 encoding of 'apple'
+    const encodedKey = 'YXBwbGU=';
+    const generatedPath = `${relativePath}${encodeURIComponent(encodedKey)}`;
+    const data = 'data';
+
+    map.set(generatedPath, data);
+
+    const results = [];
+    for await (const entry of storage.entries()) {
+      results.push(entry);
+    }
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual([ 'apple', data ]);
+  });
 });


### PR DESCRIPTION
#### ✍️ Description

Accidentally discovered this issue. The internal key/value storage uses base64 encoding on the keys before writing them to the backend. The issue is now that that encoding could contain `=` symbols for padding, which will be converted to `%3D` in the backend. When requesting all the keys in the storage that means the returned keys will be, for example, `YXBwbGU%3D` instead of `YXBwbGU=`, which will be decoded to `apple7` instead of `apple`. And if you use that key again on the same storage there will be no match.

This is only relevant on the `entries` call of the storage, as that is the only one that returns a list of keys, which explains why this issue has not yet been noticed. The only time this is currently being used is when iterating over all entries in the storage to delete expired entries for cleanup, as even when those entries are not deleted they will still count as expired and not be used. So potentially long-running servers will have a bunch of files on disk that can be removed but where this hasn't happened yet. This fix resolves that.