### PR TITLE
test: Consistently clean up folder before stopping server

### DIFF
--- a/test/integration/Quota.test.ts
+++ b/test/integration/Quota.test.ts
@@ -112,8 +112,8 @@ describe('A quota server', (): void => {
     });
 
     afterAll(async(): Promise<void> => {
-      await app.stop();
       await removeFolder(rootFilePath);
+      await app.stop();
     });
 
     // Test quota in the first pod
@@ -198,8 +198,8 @@ describe('A quota server', (): void => {
     });
 
     afterAll(async(): Promise<void> => {
-      await app.stop();
       await removeFolder(rootFilePath);
+      await app.stop();
     });
 
     it('should return 413 when global quota is exceeded.', async(): Promise<void> => {

--- a/test/integration/ResourceLockCleanup.test.ts
+++ b/test/integration/ResourceLockCleanup.test.ts
@@ -53,11 +53,8 @@ void => {
   });
 
   afterAll(async(): Promise<void> => {
-    // Stop the server
-    await app.stop();
-
-    // Execute the configured teardown
     await teardown();
+    await app.stop();
   });
 
   it('should not be affected by dangling locks.', async(): Promise<void> => {

--- a/test/integration/SeedingPods.test.ts
+++ b/test/integration/SeedingPods.test.ts
@@ -45,8 +45,8 @@ describe('A server with seeded pods', (): void => {
   });
 
   afterAll(async(): Promise<void> => {
-    await app.stop();
     await removeFolder(rootFilePath);
+    await app.stop();
   });
 
   it('has created the requested pods.', async(): Promise<void> => {

--- a/test/integration/WebHookChannel2023.test.ts
+++ b/test/integration/WebHookChannel2023.test.ts
@@ -74,8 +74,8 @@ describe.each(stores)('A server supporting WebHookChannel2023 using %s', (name, 
 
   afterAll(async(): Promise<void> => {
     clientServer.close();
-    await app.stop();
     await teardown();
+    await app.stop();
   });
 
   it('links to the storage description.', async(): Promise<void> => {


### PR DESCRIPTION
There seems to be some integration tests that sometimes fail on tests where the order is reversed.
Hopefully this resolves the problem.