### PR TITLE
Prevent integration test failing during CI

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -40,6 +40,7 @@ module.exports = {
   ],
   testEnvironment: 'node',
   globalSetup: '<rootDir>/test/util/SetupTests.ts',
+  globalTeardown: '<rootDir>/test/util/TeardownTests.ts',
   setupFilesAfterEnv: [ 'jest-rdf' ],
   collectCoverage: false,
   // See https://github.com/matthieubosquet/ts-dpop/issues/13

--- a/test/integration/Quota.test.ts
+++ b/test/integration/Quota.test.ts
@@ -93,7 +93,7 @@ describe('A quota server', (): void => {
     });
 
     afterAll(async(): Promise<void> => {
-      await removeFolder(rootFilePath);
+      // Not cleaning up `rootFilePath` as this intermittently causes issues during CI
       await app.stop();
     });
 
@@ -178,7 +178,7 @@ describe('A quota server', (): void => {
     });
 
     afterAll(async(): Promise<void> => {
-      await removeFolder(rootFilePath);
+      // Not cleaning up `rootFilePath` as this intermittently causes issues during CI
       await app.stop();
     });
 

--- a/test/util/TeardownTests.ts
+++ b/test/util/TeardownTests.ts
@@ -1,0 +1,7 @@
+import { getTestFolder, removeFolder } from '../integration/Config';
+
+// Jest global teardown requires a single function to be exported
+export default async function(): Promise<void> {
+  // Clean up the root test folder
+  await removeFolder(getTestFolder(''));
+}


### PR DESCRIPTION
CI kept failing quite often on the quota integration test. E.g., https://github.com/CommunitySolidServer/CommunitySolidServer/actions/runs/6420125694/job/17432588104?pr=1662

This fixes the issue by delaying the cleanup until later.