### PR TITLE
Feat: pass requestedModes metadata on 401

### DIFF
--- a/src/server/AuthorizingHttpHandler.ts
+++ b/src/server/AuthorizingHttpHandler.ts
@@ -83,7 +83,7 @@ export class AuthorizingHttpHandler extends OperationHttpHandler {
       await this.authorizer.handleSafe({ credentials, requestedModes, availablePermissions });
     } catch (error: unknown) {
       this.logger.verbose(`Authorization failed: ${(error as any).message}`);
-      if (error instanceof HttpError) {
+      if (HttpError.isInstance(error)) {
         this.addAccessModesToError(error, requestedModes);
       }
       throw error;

--- a/src/server/AuthorizingHttpHandler.ts
+++ b/src/server/AuthorizingHttpHandler.ts
@@ -95,11 +95,13 @@ export class AuthorizingHttpHandler extends OperationHttpHandler {
   }
 
   private addAccessModesToError(error: HttpError, requestedModes: AccessMap): void {
-    for (const [ identifier, mode ] of requestedModes.entries()) {
+    for (const [ identifier, modes ] of requestedModes.entrySets()) {
       const bnode = blankNode();
       error.metadata.add(SOLID_META.terms.requestedAccess, bnode);
       error.metadata.addQuad(bnode, SOLID_META.terms.accessTarget, namedNode(identifier.path));
-      error.metadata.addQuad(bnode, SOLID_META.terms.accessMode, literal(mode));
+      for (const mode of modes.values()) {
+        error.metadata.addQuad(bnode, SOLID_META.terms.accessMode, literal(mode));
+      }
     }
   }
 }

--- a/src/server/AuthorizingHttpHandler.ts
+++ b/src/server/AuthorizingHttpHandler.ts
@@ -1,12 +1,18 @@
+import { DataFactory } from 'n3';
 import type { Credentials } from '../authentication/Credentials';
 import type { CredentialsExtractor } from '../authentication/CredentialsExtractor';
 import type { Authorizer } from '../authorization/Authorizer';
 import type { PermissionReader } from '../authorization/PermissionReader';
 import type { ModesExtractor } from '../authorization/permissions/ModesExtractor';
+import type { AccessMap } from '../authorization/permissions/Permissions';
 import type { ResponseDescription } from '../http/output/response/ResponseDescription';
 import { getLoggerFor } from '../logging/LogUtil';
+import { HttpError } from '../util/errors/HttpError';
+import { SOLID_META } from '../util/Vocabularies';
 import type { OperationHttpHandlerInput } from './OperationHttpHandler';
 import { OperationHttpHandler } from './OperationHttpHandler';
+
+const { blankNode, namedNode, literal } = DataFactory;
 
 export interface AuthorizingHttpHandlerArgs {
   /**
@@ -77,11 +83,23 @@ export class AuthorizingHttpHandler extends OperationHttpHandler {
       await this.authorizer.handleSafe({ credentials, requestedModes, availablePermissions });
     } catch (error: unknown) {
       this.logger.verbose(`Authorization failed: ${(error as any).message}`);
+      if (error instanceof HttpError) {
+        this.addAccessModesToError(error, requestedModes);
+      }
       throw error;
     }
 
     this.logger.verbose(`Authorization succeeded, calling source handler`);
 
     return this.operationHandler.handleSafe(input);
+  }
+
+  private addAccessModesToError(error: HttpError, requestedModes: AccessMap): void {
+    for (const [ identifier, mode ] of requestedModes.entries()) {
+      const bnode = blankNode();
+      error.metadata.add(SOLID_META.terms.requestedAccess, bnode);
+      error.metadata.addQuad(bnode, SOLID_META.terms.accessTarget, namedNode(identifier.path));
+      error.metadata.addQuad(bnode, SOLID_META.terms.accessMode, literal(mode));
+    }
   }
 }

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -287,6 +287,10 @@ export const SOLID_META = createVocabulary('urn:npm:solid:community-server:meta:
   'value',
   // This is used to indicate whether metadata should be preserved or not during a PUT operation
   'preserve',
+  // These predicates are used to describe the requested access in case of an unauthorized request
+  'requestedAccess',
+  'accessTarget',
+  'accessMode',
 );
 
 export const VANN = createVocabulary('http://purl.org/vocab/vann/',


### PR DESCRIPTION
#### 📁 Related issues

No related issue. Discussed in person with @joachimvh.

#### ✍️ Description

This PR makes the AuthorizingHttpHandler add the data of the AccessMap (requested modes and targets) to the RepresentationMetadata in case of an UnauthorizedError (401).

### ✅ PR check list

* [x] this PR is labeled with the correct semver label
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
