### PR TITLE
chore: Update to TypeScript 5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typedoc": "^0.25.2",
-        "typescript": "^5.0.4"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=18.0"
@@ -16507,16 +16507,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -30150,9 +30150,9 @@
       }
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typedoc": "^0.25.2",
-    "typescript": "^5.0.4"
+    "typescript": "^5.2.2"
   },
   "husky": {
     "hooks": {

--- a/src/identity/interaction/account/util/BaseLoginAccountStorage.ts
+++ b/src/identity/interaction/account/util/BaseLoginAccountStorage.ts
@@ -48,7 +48,7 @@ export class BaseLoginAccountStorage<T extends IndexTypeCollection<T>> implement
   Promise<void> {
     // Determine potential new key pointing to account ID
     this.accountKeys[type] = Object.entries(description)
-      .find(([ , desc ]): boolean => desc === `id:${ACCOUNT_TYPE}`)?.[0];
+      .find(([ , desc ]): boolean => desc === `id:${ACCOUNT_TYPE}` as `id:${string & keyof T}`)?.[0];
 
     if (type === ACCOUNT_TYPE) {
       description = { ...description, ...MINIMUM_ACCOUNT_DESCRIPTION };

--- a/test/deploy/tsconfig.json
+++ b/test/deploy/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "."
+  ]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "es2022",
     "moduleResolution": "node"
   },
   "include": [


### PR DESCRIPTION
#### ✍️ Description

Upgrades TypeScript to v5.2.2. Had to do some tsconfig shenanigans in the test folders to make sure `jest` could still handle the esm dependencies without breaking our deploy script for the CTH.