### PR TITLE
Prevent storage issues with invalid JSON resources

### DIFF
--- a/src/init/migration/SingleContainerJsonStorage.ts
+++ b/src/init/migration/SingleContainerJsonStorage.ts
@@ -1,5 +1,6 @@
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { JsonResourceStorage } from '../../storage/keyvalue/JsonResourceStorage';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
 import { isContainerIdentifier } from '../../util/PathUtil';
 import { readableToString } from '../../util/StreamUtil';
 import { LDP } from '../../util/Vocabularies';
@@ -34,9 +35,14 @@ export class SingleContainerJsonStorage<T> extends JsonResourceStorage<T> {
         continue;
       }
 
-      const json = JSON.parse(await readableToString(document.data)) as T;
       const key = this.identifierToKey(documentId);
-      yield [ key, json ];
+      try {
+        const json = JSON.parse(await readableToString(document.data)) as T;
+        yield [ key, json ];
+      } catch (error: unknown) {
+        this.logger.error(`Unable to parse ${path}. You should probably delete this resource manually. Error: ${
+          createErrorMessage(error)}`);
+      }
     }
   }
 }

--- a/test/assets/migration/v6/.internal/setup/aW52YWxpZFJlc291cmNl$.json
+++ b/test/assets/migration/v6/.internal/setup/aW52YWxpZFJlc291cmNl$.json
@@ -1,0 +1,1 @@
+this is not valid JSON

--- a/test/integration/V6Migration.test.ts
+++ b/test/integration/V6Migration.test.ts
@@ -63,6 +63,8 @@ describe('A server migrating from v6', (): void => {
     // Setup resources should have been migrated
     const setupDir = await readdir(joinFilePath(rootFilePath, '.internal/setup/'));
     expect(setupDir).toEqual([
+      // Invalid JSON file was not deleted, only error was logged. Just in case its data needs to be saved.
+      'aW52YWxpZFJlc291cmNl$.json',
       'current-base-url$.json',
       'current-server-version$.json',
       'setupCompleted-2.0$.json',

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -5,7 +5,7 @@ import type { ResourceIdentifier } from '../../../../src/http/representation/Res
 import { JsonResourceStorage } from '../../../../src/storage/keyvalue/JsonResourceStorage';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
-import { isContainerIdentifier } from '../../../../src/util/PathUtil';
+import { isContainerIdentifier, joinUrl } from '../../../../src/util/PathUtil';
 import { readableToString } from '../../../../src/util/StreamUtil';
 import { LDP } from '../../../../src/util/Vocabularies';
 
@@ -111,6 +111,9 @@ describe('A JsonResourceStorage', (): void => {
     // Need to manually insert the containers as they don't get created by the dummy store above
     data.set(containerIdentifier, '');
     data.set(subContainerIdentifier, '');
+
+    // Manually setting invalid data which will be ignored
+    data.set(joinUrl(containerIdentifier, 'badData'), 'invalid JSON');
 
     const entries = [];
     for await (const entry of storage.entries()) {


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1757

#### ✍️ Description

Although invalid JSON resources shouldn't occur if everything goes fine, the server also shouldn't stop processing if they do find one.

PR prevents this issue both for migration and general storage usage.
