### PR TITLE
chore: Remove Docker arm builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,6 +89,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm/v7,linux/arm/v8,linux/arm64/v8
+          platforms: linux/amd64
           tags: ${{ needs.docker-meta.outputs.tags }}
           labels: ${{ needs.docker-meta.outputs.labels }}


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1761

#### ✍️ Description

Arm builds are preventing the Docker build from succeeding. This way we at least still build the linux/amd64 Docker build until https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1761 can be resolved.
