### PR TITLE
fix: Only require append when creating with PUT

### DIFF
--- a/src/authorization/permissions/MethodModesExtractor.ts
+++ b/src/authorization/permissions/MethodModesExtractor.ts
@@ -39,11 +39,13 @@ export class MethodModesExtractor extends ModesExtractor {
     if (READ_METHODS.has(method)) {
       requiredModes.add(target, AccessMode.read);
     }
-    // Setting a resource's representation requires Write permissions
     if (method === 'PUT') {
-      requiredModes.add(target, AccessMode.write);
-      // …and, if the resource does not exist yet, Create permissions are required as well
-      if (!await this.resourceSet.hasResource(target)) {
+      if (await this.resourceSet.hasResource(target)) {
+        // Replacing a resource's representation with PUT requires Write permissions
+        requiredModes.add(target, AccessMode.write);
+      } else {
+        // ... while creating a new resource with PUT requires Append and Create permissions.
+        requiredModes.add(target, AccessMode.append);
         requiredModes.add(target, AccessMode.create);
       }
     }

--- a/test/integration/PermissionTable.test.ts
+++ b/test/integration/PermissionTable.test.ts
@@ -83,7 +83,7 @@ const table: [string, string, AM[], AM[] | undefined, string, string, number, nu
   [ 'PUT',     'C/R', [],                     [ AM.append ],          '',     TXT, 401, 401 ],
   [ 'PUT',     'C/R', [],                     [ AM.write ],           '',     TXT, 205, 401 ],
   [ 'PUT',     'C/R', [ AM.read ],            undefined,              '',     TXT, 401, 401 ],
-  [ 'PUT',     'C/R', [ AM.append ],          undefined,              '',     TXT, 401, 401 ],
+  [ 'PUT',     'C/R', [ AM.append ],          undefined,              '',     TXT, 401, 201 ],
   [ 'PUT',     'C/R', [ AM.write ],           undefined,              '',     TXT, 205, 201 ],
   [ 'PUT',     'C/R', [ AM.append ],          [ AM.write ],           '',     TXT, 205, 201 ],
 

--- a/test/unit/authorization/permissions/MethodModesExtractor.test.ts
+++ b/test/unit/authorization/permissions/MethodModesExtractor.test.ts
@@ -58,11 +58,11 @@ describe('A MethodModesExtractor', (): void => {
     compareMaps(await extractor.handle({ ...operation, method: 'PUT' }), getMap([ AccessMode.write ]));
   });
 
-  it('requires create for PUT operations if the target does not exist.', async(): Promise<void> => {
+  it('requires append/create for PUT operations if the target does not exist.', async(): Promise<void> => {
     resourceSet.hasResource.mockResolvedValueOnce(false);
     compareMaps(
       await extractor.handle({ ...operation, method: 'PUT' }),
-      getMap([ AccessMode.write, AccessMode.create ]),
+      getMap([ AccessMode.append, AccessMode.create ]),
     );
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closes #1822 

#### ✍️ Description

Update the modes extractor to require append + create if the target of a PUT does not exist, instead of write + create.


