### PR TITLE
fix: Encode WebID ownership tokens

### DIFF
--- a/src/identity/ownership/TokenOwnershipValidator.ts
+++ b/src/identity/ownership/TokenOwnershipValidator.ts
@@ -51,7 +51,7 @@ export class TokenOwnershipValidator extends OwnershipValidator {
    * Creates a key to use with the token storage.
    */
   private getTokenKey(webId: string): string {
-    return `ownershipToken${webId}`;
+    return encodeURIComponent(webId);
   }
 
   /**

--- a/test/integration/Accounts.test.ts
+++ b/test/integration/Accounts.test.ts
@@ -6,15 +6,27 @@ import type { ResourceStore } from '../../src/storage/ResourceStore';
 import { APPLICATION_X_WWW_FORM_URLENCODED } from '../../src/util/ContentTypes';
 import { joinUrl } from '../../src/util/PathUtil';
 import { getPort } from '../util/Util';
-import { getDefaultVariables, getTestConfigPath, instantiateFromConfig } from './Config';
+import { getDefaultVariables, getTestConfigPath, getTestFolder, instantiateFromConfig, removeFolder } from './Config';
 
 const port = getPort('Accounts');
 const baseUrl = `http://localhost:${port}/`;
 
+const rootFilePath = getTestFolder('Accounts');
+const stores: [string, any][] = [
+  [ 'in-memory storage', {
+    config: 'memory-pod.json',
+    teardown: jest.fn(),
+  }],
+  [ 'on-disk storage', {
+    config: 'file-pod.json',
+    teardown: async(): Promise<void> => removeFolder(rootFilePath),
+  }],
+];
+
 // Don't send actual e-mails
 jest.mock('nodemailer');
 
-describe('A server with account management', (): void => {
+describe.each(stores)('A server with account management using %s', (name, { config, teardown }): void => {
   let app: App;
   let store: ResourceStore;
   let sendMail: jest.Mock;
@@ -42,8 +54,11 @@ describe('A server with account management', (): void => {
 
     const instances = await instantiateFromConfig(
       'urn:solid-server:test:Instances',
-      getTestConfigPath('memory-pod.json'),
-      getDefaultVariables(port, baseUrl),
+      getTestConfigPath(config),
+      {
+        ...getDefaultVariables(port, baseUrl),
+        'urn:solid-server:default:variable:rootFilePath': rootFilePath,
+      },
     ) as Record<string, any>;
     ({ app, store } = instances);
     await app.start();
@@ -68,6 +83,7 @@ describe('A server with account management', (): void => {
   });
 
   afterAll(async(): Promise<void> => {
+    await teardown();
     await app.stop();
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1821

#### ✍️ Description

Due to the keys not being encoded it was actually impossible to generate ownership tokens when using a file backend.
