### PR TITLE
docs: Add login example to credentials documentation

### DIFF
--- a/documentation/markdown/usage/client-credentials.md
+++ b/documentation/markdown/usage/client-credentials.md
@@ -54,7 +54,7 @@ const { authorization } = await response.json();
 The next step generates the token and assumes you have an authorization value as generated in the example above.
 
 ```ts
-// First we need to request the updated controls from the server now that we are logged in.
+// Now that we are logged in, we need to request the updated controls from the server.
 // These will now have more values than in the previous example.
 const indexResponse = await fetch('http://localhost:3000/.account/', { 
   headers: { authorization: `CSS-Account-Token ${authorization}` }


### PR DESCRIPTION
#### ✍️ Description

Add some clarity for new users on how the default email/password login API can be used when trying to generate credentials tokens.
