### PR TITLE
fix: Prevent error when switching accounts

### DIFF
--- a/src/identity/interaction/InteractionUtil.ts
+++ b/src/identity/interaction/InteractionUtil.ts
@@ -87,9 +87,9 @@ export async function forgetWebId(provider: Provider, oidcInteraction: Interacti
     await session.persist();
   }
 
-  // If a client previously successfully completed an interaction a grant will have been created.
-  // If the same session gets reused to authenticate with a different WebID,
-  // we need to first delete the previous grant as the oidc-provider will try to reuse it.
+  // If a client previously successfully completed an interaction, a grant will have been created.
+  // If such a session is reused to authenticate with a different WebID, we need to
+  // first delete the previously created grant, as the oidc-provider will try to reuse it as well.
   if (oidcInteraction.grantId) {
     const grant = await provider.Grant.find(oidcInteraction.grantId);
     await grant?.destroy();

--- a/src/identity/interaction/InteractionUtil.ts
+++ b/src/identity/interaction/InteractionUtil.ts
@@ -86,4 +86,12 @@ export async function forgetWebId(provider: Provider, oidcInteraction: Interacti
     delete session.accountId;
     await session.persist();
   }
+
+  // If a client previously successfully completed an interaction a grant will have been created.
+  // If the same session gets reused to authenticate with a different WebID,
+  // we need to first delete the previous grant as the oidc-provider will try to reuse it.
+  if (oidcInteraction.grantId) {
+    const grant = await provider.Grant.find(oidcInteraction.grantId);
+    await grant?.destroy();
+  }
 }


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1842

#### ✍️ Description

The problem was the oidc-provider library wanting to reuse the grant that was created for the previous account/WebID.
