### PR TITLE
fix: Extract root as possible pod when using subdomains

### DIFF
--- a/src/pods/generate/SubdomainIdentifierGenerator.ts
+++ b/src/pods/generate/SubdomainIdentifierGenerator.ts
@@ -7,6 +7,8 @@ import type { IdentifierGenerator } from './IdentifierGenerator';
 /**
  * Generates identifiers by using the name as a subdomain on the base URL.
  * Non-alphanumeric characters will be replaced with `-`.
+ *
+ * When extracting the pod, the base URl is also seen as a pod as there is no issue of nested containers here.
  */
 export class SubdomainIdentifierGenerator implements IdentifierGenerator {
   private readonly baseParts: { scheme: string; rest: string };
@@ -32,8 +34,8 @@ export class SubdomainIdentifierGenerator implements IdentifierGenerator {
 
     const idx = path.indexOf(this.baseParts.rest);
 
-    // If the idx is smaller than this, either there was no match, or there is no subdomain
-    if (idx <= this.baseParts.scheme.length) {
+    // If the idx is smaller than this, there was no match
+    if (idx < 0) {
       throw new BadRequestHttpError(`Invalid identifier ${path}`);
     }
 

--- a/test/unit/pods/generate/SubdomainIdentifierGenerator.test.ts
+++ b/test/unit/pods/generate/SubdomainIdentifierGenerator.test.ts
@@ -30,6 +30,11 @@ describe('A SubdomainIdentifierGenerator', (): void => {
 
   it('errors when extracting if there is no pod.', async(): Promise<void> => {
     const identifier = { path: 'http://example.com/bar/baz' };
+    expect(generator.extractPod(identifier)).toEqual({ path: 'http://example.com/' });
+  });
+
+  it('errors when extracting if the domain is wrong.', async(): Promise<void> => {
+    const identifier = { path: 'http://foo.example.org/bar/baz' };
     expect((): any => generator.extractPod(identifier)).toThrow(BadRequestHttpError);
   });
 });


### PR DESCRIPTION
#### 📁 Related issues

Discovered in https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1852

#### ✍️ Description

When using subdomains, the root container can be used as a pod even if there are other pods on the server, as in this case the pods are not contained within the root container.
