### PR TITLE
feat: add arrays to IndexedStorage typings

### DIFF
--- a/src/storage/keyvalue/IndexedStorage.ts
+++ b/src/storage/keyvalue/IndexedStorage.ts
@@ -8,17 +8,20 @@ export const INDEX_ID_KEY = 'id';
  * Valid values are `"string"`, `"boolean"`, `"number"` and `"id:TYPE"`,
  * with TYPE being one of the types in the definition.
  * In the latter case this means that key points to an identifier of the specified type.
+ * A `[]` can be appended to the type to indicate the value is an array.
  * A `?` can be appended to the type to indicate this key is optional.
  */
 export type ValueTypeDescription<TType = string> =
   `${('string' | 'boolean' | 'number' | (TType extends string ? `${typeof INDEX_ID_KEY}:${TType}` : never))}${
+  '[]' | ''}${
   '?' | ''}`;
 
 /**
  * Converts a {@link ValueTypeDescription} to the type it should be interpreted as.
  */
 export type ValueType<T extends ValueTypeDescription> =
-  (T extends 'boolean' | 'boolean?' ? boolean : T extends 'number' | 'number?' ? number : string) |
+  (T extends `${infer E extends ValueTypeDescription}[]${'?' | ''}` ? ValueType<E>[] :
+    T extends 'boolean' | 'boolean?' ? boolean : T extends 'number' | 'number?' ? number : string) |
   (T extends `${string}?` ? undefined : never);
 
 /**


### PR DESCRIPTION
Putting this here should it be of any value. I added this for the work on UMA, but no longer use it. The typings compile and work with the CRUD operations of the `WrappedIndexedStorage`, but something goes wrong when using the `find` features. That code is rather hard to follow, though, so if we want to keep this, maybe you can take a look, @joachimvh?
