### PR TITLE
fix: Add priorities to RDF types when converting

### DIFF
--- a/src/storage/conversion/RdfToQuadConverter.ts
+++ b/src/storage/conversion/RdfToQuadConverter.ts
@@ -5,7 +5,7 @@ import rdfParser from 'rdf-parse';
 import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
 import type { Representation } from '../../http/representation/Representation';
 import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
-import { INTERNAL_QUADS } from '../../util/ContentTypes';
+import { APPLICATION_JSON, INTERNAL_QUADS } from '../../util/ContentTypes';
 import { BadRequestHttpError } from '../../util/errors/BadRequestHttpError';
 import { pipeSafely } from '../../util/StreamUtil';
 import { PREFERRED_PREFIX_TERM, SOLID_META } from '../../util/Vocabularies';
@@ -25,9 +25,12 @@ export class RdfToQuadConverter extends BaseTypedRepresentationConverter {
   private readonly documentLoader: ContextDocumentLoader;
 
   public constructor(contexts: Record<string, string> = {}) {
-    const inputTypes = rdfParser.getContentTypes()
+    const inputTypes = rdfParser.getContentTypesPrioritized()
       // ContentType application/json MAY NOT be converted to Quad.
-      .then((types): string[] => types.filter((type): boolean => type !== 'application/json'));
+      .then((types): Record<string, number> => {
+        delete types[APPLICATION_JSON];
+        return types;
+      });
     super(inputTypes, INTERNAL_QUADS);
     this.documentLoader = new ContextDocumentLoader(contexts);
   }

--- a/test/unit/storage/conversion/RdfToQuadConverter.test.ts
+++ b/test/unit/storage/conversion/RdfToQuadConverter.test.ts
@@ -35,10 +35,11 @@ describe('A RdfToQuadConverter', (): void => {
   const converter = new RdfToQuadConverter();
   const identifier: ResourceIdentifier = { path: 'http://example.com/resource' };
   it('supports serializing as quads.', async(): Promise<void> => {
-    const types = rdfParser.getContentTypes()
-      .then((inputTypes): string[] => inputTypes.filter((type): boolean => type !== 'application/json'));
-    for (const type of await types) {
-      await expect(converter.getOutputTypes(type)).resolves.toEqual({ [INTERNAL_QUADS]: 1 });
+    const types = await rdfParser.getContentTypesPrioritized();
+    // JSON is not supported
+    delete types['application/json'];
+    for (const [ type, priority ] of Object.entries(types)) {
+      await expect(converter.getOutputTypes(type)).resolves.toEqual({ [INTERNAL_QUADS]: priority });
     }
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closes #1866 

#### ✍️ Description

After this change, `Accept: text/turtle, */*;q=0.5` on a markdown document will return the markdown, while `Accept: text/turtle, */*;q=0.1` will (try to) convert the markdown to turtle through RDFa.
