### PR TITLE
fix: Allow path segments to start with 2 or more dots

### DIFF
--- a/src/storage/mapping/BaseFileIdentifierMapper.ts
+++ b/src/storage/mapping/BaseFileIdentifierMapper.ts
@@ -205,9 +205,9 @@ export class BaseFileIdentifierMapper implements FileIdentifierMapper {
       throw new BadRequestHttpError('URL needs a / after the base');
     }
 
-    if (path.includes('/..')) {
-      this.logger.warn(`Disallowed /.. segment in URL ${identifier.path}.`);
-      throw new BadRequestHttpError('Disallowed /.. segment in URL');
+    if (path.includes('/../') || path.endsWith('/..')) {
+      this.logger.warn(`Disallowed /../ segment in URL ${identifier.path}.`);
+      throw new BadRequestHttpError('Disallowed /../ segment in URL');
     }
   }
 

--- a/test/unit/storage/mapping/BaseFileIdentifierMapper.test.ts
+++ b/test/unit/storage/mapping/BaseFileIdentifierMapper.test.ts
@@ -22,9 +22,13 @@ describe('An BaseFileIdentifierMapper', (): void => {
     });
 
     it('throws 400 if the input path contains relative parts.', async(): Promise<void> => {
-      const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` }, false);
+      let result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` }, false);
       await expect(result).rejects.toThrow(BadRequestHttpError);
-      await expect(result).rejects.toThrow('Disallowed /.. segment in URL');
+      await expect(result).rejects.toThrow('Disallowed /../ segment in URL');
+
+      result = mapper.mapUrlToFilePath({ path: `${base}test/..` }, false);
+      await expect(result).rejects.toThrow(BadRequestHttpError);
+      await expect(result).rejects.toThrow('Disallowed /../ segment in URL');
     });
 
     it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {

--- a/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
+++ b/test/unit/storage/mapping/ExtensionBasedMapper.test.ts
@@ -38,7 +38,7 @@ describe('An ExtensionBasedMapper', (): void => {
     it('throws 400 if the input path contains relative parts.', async(): Promise<void> => {
       const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` }, false);
       await expect(result).rejects.toThrow(BadRequestHttpError);
-      await expect(result).rejects.toThrow('Disallowed /.. segment in URL');
+      await expect(result).rejects.toThrow('Disallowed /../ segment in URL');
     });
 
     it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {

--- a/test/unit/storage/mapping/FixedContentTypeMapper.test.ts
+++ b/test/unit/storage/mapping/FixedContentTypeMapper.test.ts
@@ -25,7 +25,7 @@ describe('An FixedContentTypeMapper', (): void => {
       it('throws 400 if the input path contains relative parts.', async(): Promise<void> => {
         const result = mapper.mapUrlToFilePath({ path: `${base}test/../test2` }, false);
         await expect(result).rejects.toThrow(BadRequestHttpError);
-        await expect(result).rejects.toThrow('Disallowed /.. segment in URL');
+        await expect(result).rejects.toThrow('Disallowed /../ segment in URL');
       });
 
       it('returns the corresponding file path for container identifiers.', async(): Promise<void> => {


### PR DESCRIPTION
#### ✍️ Description

This was causing issues with paths like `/foo/...bar`. The restrictions are there to prevent potential issues when converting to a file path, but the ones we had were too strict.
