### PR TITLE
Add target metadata to errors

### DIFF
--- a/config/ldp/handler/components/error-handler.json
+++ b/config/ldp/handler/components/error-handler.json
@@ -15,7 +15,7 @@
           "@type": "WaterfallHandler",
           "handlers": [
             {
-              "comment": "Internally redirects are created by throwing a specific error, this handler converts them to the correct response.",
+              "comment": "Redirects are created internally by throwing a specific error; this handler converts them to the correct response.",
               "@type": "RedirectingErrorHandler"
             },
             {

--- a/config/ldp/handler/components/error-handler.json
+++ b/config/ldp/handler/components/error-handler.json
@@ -7,20 +7,26 @@
       "@type": "SafeErrorHandler",
       "showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" },
       "errorHandler": {
-        "@type": "WaterfallHandler",
-        "handlers": [
-          {
-            "comment": "Internally redirects are created by throwing a specific error, this handler converts them to the correct response.",
-            "@type": "RedirectingErrorHandler"
-          },
-          {
-            "comment": "Converts an Error object into a representation for an HTTP response.",
-            "@type": "ConvertingErrorHandler",
-            "converter": { "@id": "urn:solid-server:default:UiEnabledConverter" },
-            "preferenceParser": { "@id": "urn:solid-server:default:PreferenceParser" },
-            "showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" }
-          }
-        ]
+        "@id": "urn:solid-server:default:TargetExtractorErrorHandler",
+        "@type": "TargetExtractorErrorHandler",
+        "targetExtractor": { "@id": "urn:solid-server:default:TargetExtractor" },
+        "errorHandler": {
+          "@id": "urn:solid-server:default:WaterfallErrorHandler",
+          "@type": "WaterfallHandler",
+          "handlers": [
+            {
+              "comment": "Internally redirects are created by throwing a specific error, this handler converts them to the correct response.",
+              "@type": "RedirectingErrorHandler"
+            },
+            {
+              "comment": "Converts an Error object into a representation for an HTTP response.",
+              "@type": "ConvertingErrorHandler",
+              "converter": { "@id": "urn:solid-server:default:UiEnabledConverter" },
+              "preferenceParser": { "@id": "urn:solid-server:default:PreferenceParser" },
+              "showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" }
+            }
+          ]
+        }
       }
     }
   ]

--- a/src/http/output/error/TargetExtractorErrorHandler.ts
+++ b/src/http/output/error/TargetExtractorErrorHandler.ts
@@ -1,0 +1,30 @@
+import { DataFactory } from 'n3';
+import { SOLID_ERROR } from '../../../util/Vocabularies';
+import type { TargetExtractor } from '../../input/identifier/TargetExtractor';
+import type { ResponseDescription } from '../response/ResponseDescription';
+import type { ErrorHandlerArgs } from './ErrorHandler';
+import { ErrorHandler } from './ErrorHandler';
+
+/**
+ * Adds metadata to an error to indicate what the identifier was of the resource originally being targeted.
+ */
+export class TargetExtractorErrorHandler extends ErrorHandler {
+  protected readonly errorHandler: ErrorHandler;
+  protected readonly targetExtractor: TargetExtractor;
+
+  public constructor(errorHandler: ErrorHandler, targetExtractor: TargetExtractor) {
+    super();
+    this.errorHandler = errorHandler;
+    this.targetExtractor = targetExtractor;
+  }
+
+  public async canHandle(input: ErrorHandlerArgs): Promise<void> {
+    return this.errorHandler.canHandle(input);
+  }
+
+  public async handle(input: ErrorHandlerArgs): Promise<ResponseDescription> {
+    const target = await this.targetExtractor.handleSafe(input);
+    input.error.metadata.add(SOLID_ERROR.terms.target, DataFactory.namedNode(target.path));
+    return this.errorHandler.handle(input);
+  }
+}

--- a/src/http/output/error/TargetExtractorErrorHandler.ts
+++ b/src/http/output/error/TargetExtractorErrorHandler.ts
@@ -6,7 +6,7 @@ import type { ErrorHandlerArgs } from './ErrorHandler';
 import { ErrorHandler } from './ErrorHandler';
 
 /**
- * Adds metadata to an error to indicate what the identifier was of the resource originally being targeted.
+ * Adds metadata to an error to indicate the identifier of the originally targeted resource.
  */
 export class TargetExtractorErrorHandler extends ErrorHandler {
   protected readonly errorHandler: ErrorHandler;

--- a/src/http/output/metadata/AllowAcceptHeaderWriter.ts
+++ b/src/http/output/metadata/AllowAcceptHeaderWriter.ts
@@ -84,7 +84,7 @@ export class AllowAcceptHeaderWriter extends MetadataWriter {
     // If we are sure the resource does not exist: only keep methods that can create a new resource.
     if (metadata.has(SOLID_ERROR.terms.errorResponse, NotFoundHttpError.uri)) {
       for (const method of allowedMethods) {
-        // Containers can only be created by PUT, documents also by PATCH
+        // Containers can only be created by PUT; documents by PUT or PATCH
         if (method !== 'PUT' && (method !== 'PATCH' || resourceType === ResourceType.container)) {
           allowedMethods.delete(method);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ export * from './http/output/error/ConvertingErrorHandler';
 export * from './http/output/error/ErrorHandler';
 export * from './http/output/error/RedirectingErrorHandler';
 export * from './http/output/error/SafeErrorHandler';
+export * from './http/output/error/TargetExtractorErrorHandler';
 
 // HTTP/Output/Metadata
 export * from './http/output/metadata/AllowAcceptHeaderWriter';

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -283,6 +283,7 @@ export const SOLID_ERROR = createVocabulary(
   'errorCode',
   'errorResponse',
   'stack',
+  'target',
 );
 
 // Used to pass parameters to error templates

--- a/src/util/handlers/StaticThrowHandler.ts
+++ b/src/util/handlers/StaticThrowHandler.ts
@@ -1,11 +1,11 @@
-import type { HttpError } from '../errors/HttpError';
+import type { HttpError, HttpErrorClass } from '../errors/HttpError';
 import { AsyncHandler } from './AsyncHandler';
 
 /**
- * Utility handler that can handle all input and always throws the given error.
+ * Utility handler that can handle all input and always throws an instance of the given error.
  */
 export class StaticThrowHandler extends AsyncHandler<unknown, never> {
-  private readonly error: HttpError;
+  protected readonly error: HttpError;
 
   public constructor(error: HttpError) {
     super();
@@ -13,6 +13,8 @@ export class StaticThrowHandler extends AsyncHandler<unknown, never> {
   }
 
   public async handle(): Promise<never> {
-    throw this.error;
+    // We are creating a new instance of the error instead of rethrowing the error,
+    // as reusing the same error can cause problem as the metadata is then also reused.
+    throw new (this.error.constructor as HttpErrorClass)();
   }
 }

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -506,7 +506,11 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
   });
 
   it('returns 405 for unsupported methods.', async(): Promise<void> => {
-    const response = await fetch(baseUrl, { method: 'TRACE' });
+    let response = await fetch(baseUrl, { method: 'TRACE' });
+    expect(response.status).toBe(405);
+
+    // Testing two different URLs as there used to be a problem with this
+    response = await fetch(joinUrl(baseUrl, 'foo'), { method: 'TRACE' });
     expect(response.status).toBe(405);
   });
 

--- a/test/unit/http/output/error/TargetExtractorErrorHandler.test.ts
+++ b/test/unit/http/output/error/TargetExtractorErrorHandler.test.ts
@@ -1,0 +1,47 @@
+import type { TargetExtractor } from '../../../../../src/http/input/identifier/TargetExtractor';
+import type { ErrorHandler, ErrorHandlerArgs } from '../../../../../src/http/output/error/ErrorHandler';
+import { TargetExtractorErrorHandler } from '../../../../../src/http/output/error/TargetExtractorErrorHandler';
+import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
+import { NotFoundHttpError } from '../../../../../src/util/errors/NotFoundHttpError';
+import { SOLID_ERROR } from '../../../../../src/util/Vocabularies';
+
+describe('A TargetExtractorErrorHandler', (): void => {
+  const identifier: ResourceIdentifier = { path: 'http://example.com/foo' };
+  let input: ErrorHandlerArgs;
+  let source: jest.Mocked<ErrorHandler>;
+  let targetExtractor: jest.Mocked<TargetExtractor>;
+  let handler: TargetExtractorErrorHandler;
+
+  beforeEach(async(): Promise<void> => {
+    input = {
+      request: 'request' as any,
+      error: new NotFoundHttpError(),
+    };
+
+    source = {
+      canHandle: jest.fn(),
+      handle: jest.fn().mockResolvedValue('response'),
+    } satisfies Partial<ErrorHandler> as any;
+
+    targetExtractor = {
+      handleSafe: jest.fn().mockResolvedValue(identifier),
+    } satisfies Partial<TargetExtractor> as any;
+
+    handler = new TargetExtractorErrorHandler(source, targetExtractor);
+  });
+
+  it('can handle input its source can handle.', async(): Promise<void> => {
+    await expect(handler.canHandle(input)).resolves.toBeUndefined();
+    expect(source.canHandle).toHaveBeenLastCalledWith(input);
+
+    const error = new Error('bad data');
+    source.canHandle.mockRejectedValueOnce(error);
+    await expect(handler.canHandle(input)).rejects.toThrow(error);
+  });
+
+  it('adds the identifier as metadata.', async(): Promise<void> => {
+    await expect(handler.handle(input)).resolves.toBe('response');
+    expect(input.error.metadata.get(SOLID_ERROR.terms.target)?.value).toEqual(identifier.path);
+    expect(targetExtractor.handleSafe).toHaveBeenLastCalledWith(input);
+  });
+});

--- a/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
+++ b/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
@@ -30,6 +30,14 @@ describe('An AllowAcceptHeaderWriter', (): void => {
     { [RDF.type]: [ LDP.terms.Resource, LDP.terms.Container, PIM.terms.Storage ]},
   );
   const error404 = new RepresentationMetadata({ [SOLID_ERROR.errorResponse]: NotFoundHttpError.uri });
+  const error404Container = new RepresentationMetadata({
+    [SOLID_ERROR.errorResponse]: NotFoundHttpError.uri,
+    [SOLID_ERROR.target]: 'http://example.com/foo/',
+  });
+  const error404Document = new RepresentationMetadata({
+    [SOLID_ERROR.errorResponse]: NotFoundHttpError.uri,
+    [SOLID_ERROR.target]: 'http://example.com/foo/bar',
+  });
   const error405 = new RepresentationMetadata(
     { [SOLID_ERROR.errorResponse]: MethodNotAllowedHttpError.uri, [SOLID_ERROR.disallowedMethod]: 'PUT' },
   );
@@ -57,33 +65,36 @@ describe('An AllowAcceptHeaderWriter', (): void => {
     expect(headers['accept-post']).toBeUndefined();
   });
 
-  it('returns all methods except PUT for an empty container.', async(): Promise<void> => {
+  it('returns all methods except PUT/PATCH for an empty container.', async(): Promise<void> => {
     await expect(writer.handleSafe({ response, metadata: emptyContainer })).resolves.toBeUndefined();
     const headers = response.getHeaders();
     expect(typeof headers.allow).toBe('string');
     expect(new Set(headers.allow!.split(', ')))
-      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH', 'DELETE' ]));
-    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'DELETE' ]));
+    expect(headers['accept-patch']).toBeUndefined();
+    expect(headers['accept-put']).toBeUndefined();
     expect(headers['accept-post']).toBe('*/*');
   });
 
-  it('returns all methods except PUT/DELETE for a non-empty container.', async(): Promise<void> => {
+  it('returns all methods except PUT/PATCH/DELETE for a non-empty container.', async(): Promise<void> => {
     await expect(writer.handleSafe({ response, metadata: fullContainer })).resolves.toBeUndefined();
     const headers = response.getHeaders();
     expect(typeof headers.allow).toBe('string');
     expect(new Set(headers.allow!.split(', ')))
-      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH' ]));
-    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST' ]));
+    expect(headers['accept-patch']).toBeUndefined();
+    expect(headers['accept-put']).toBeUndefined();
     expect(headers['accept-post']).toBe('*/*');
   });
 
-  it('returns all methods except PUT/DELETE for a storage container.', async(): Promise<void> => {
+  it('returns all methods except PUT/PATCH/DELETE for a storage container.', async(): Promise<void> => {
     await expect(writer.handleSafe({ response, metadata: storageContainer })).resolves.toBeUndefined();
     const headers = response.getHeaders();
     expect(typeof headers.allow).toBe('string');
     expect(new Set(headers.allow!.split(', ')))
-      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST', 'PATCH' ]));
-    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST' ]));
+    expect(headers['accept-patch']).toBeUndefined();
+    expect(headers['accept-put']).toBeUndefined();
     expect(headers['accept-post']).toBe('*/*');
   });
 
@@ -94,6 +105,28 @@ describe('An AllowAcceptHeaderWriter', (): void => {
     expect(new Set(headers.allow!.split(', ')))
       .toEqual(new Set([ 'PUT', 'PATCH' ]));
     expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBeUndefined();
+  });
+
+  it('returns PUT if the target does not exist and is a document.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: error404Document })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set(headers.allow!.split(', ')))
+      .toEqual(new Set([ 'PUT', 'PATCH' ]));
+    expect(headers['accept-patch']).toBe('text/n3, application/sparql-update');
+    expect(headers['accept-put']).toBe('*/*');
+    expect(headers['accept-post']).toBeUndefined();
+  });
+
+  it('returns PUT if the target does not exist and is a container.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: error404Container })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set(headers.allow!.split(', ')))
+      .toEqual(new Set([ 'PUT' ]));
+    expect(headers['accept-patch']).toBeUndefined();
     expect(headers['accept-put']).toBe('*/*');
     expect(headers['accept-post']).toBeUndefined();
   });

--- a/test/unit/http/output/metadata/AuxiliaryLinkMetadataWriter.test.ts
+++ b/test/unit/http/output/metadata/AuxiliaryLinkMetadataWriter.test.ts
@@ -3,6 +3,7 @@ import { AuxiliaryLinkMetadataWriter } from '../../../../../src/http/output/meta
 import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
 import type { HttpResponse } from '../../../../../src/server/HttpResponse';
+import { LDP, RDF, SOLID_ERROR } from '../../../../../src/util/Vocabularies';
 import { SimpleSuffixStrategy } from '../../../../util/SimpleSuffixStrategy';
 
 describe('A LinkRelMetadataWriter', (): void => {
@@ -18,6 +19,7 @@ describe('A LinkRelMetadataWriter', (): void => {
   it('adds the correct link headers.', async(): Promise<void> => {
     const response = createResponse() as HttpResponse;
     const metadata = new RepresentationMetadata(identifier);
+    metadata.add(RDF.terms.type, LDP.terms.Resource);
 
     await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
     expect(response.getHeaders()).toEqual({ link:
@@ -28,12 +30,22 @@ describe('A LinkRelMetadataWriter', (): void => {
     const response = createResponse() as HttpResponse;
     identifier.path += '.dummy';
     const metadata = new RepresentationMetadata(identifier);
+    metadata.add(RDF.terms.type, LDP.terms.Resource);
 
     await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
     expect(response.getHeaders()).toEqual({});
   });
 
-  it('does not add link headers for blank node identifiers.', async(): Promise<void> => {
+  it('adds link headers for errors.', async(): Promise<void> => {
+    const response = createResponse() as HttpResponse;
+    const metadata = new RepresentationMetadata();
+    metadata.add(SOLID_ERROR.terms.target, identifier.path);
+    await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
+    expect(response.getHeaders()).toEqual({ link:
+        `<${identifier.path}.meta>; rel="test"` });
+  });
+
+  it('does not add link headers for errors without a target.', async(): Promise<void> => {
     const response = createResponse() as HttpResponse;
     const metadata = new RepresentationMetadata();
     await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();

--- a/test/unit/util/handlers/StaticThrowHandler.test.ts
+++ b/test/unit/util/handlers/StaticThrowHandler.test.ts
@@ -1,5 +1,6 @@
 import { BadRequestHttpError } from '../../../../src/util/errors/BadRequestHttpError';
 import { StaticThrowHandler } from '../../../../src/util/handlers/StaticThrowHandler';
+import { SOLID_ERROR } from '../../../../src/util/Vocabularies';
 
 describe('A StaticThrowHandler', (): void => {
   const error = new BadRequestHttpError();
@@ -9,7 +10,26 @@ describe('A StaticThrowHandler', (): void => {
     await expect(handler.canHandle({})).resolves.toBeUndefined();
   });
 
-  it('always throws the given error.', async(): Promise<void> => {
+  it('always throws an instance of the given error.', async(): Promise<void> => {
     await expect(handler.handle()).rejects.toThrow(error);
+  });
+
+  it('creates a new instance every time.', async(): Promise<void> => {
+    /* eslint-disable jest/no-conditional-expect */
+    try {
+      await handler.handle();
+    } catch (error: unknown) {
+      expect(BadRequestHttpError.isInstance(error)).toBe(true);
+      // Change the metadata
+      (error as BadRequestHttpError).metadata.add(SOLID_ERROR.terms.target, 'http://example.com/foo');
+    }
+    try {
+      await handler.handle();
+    } catch (error: unknown) {
+      expect(BadRequestHttpError.isInstance(error)).toBe(true);
+      // Metadata should not have the change
+      expect((error as BadRequestHttpError).metadata.has(SOLID_ERROR.terms.target)).toBe(false);
+    }
+    /* eslint-enable jest/no-conditional-expect */
   });
 });

--- a/test/util/FetchUtil.ts
+++ b/test/util/FetchUtil.ts
@@ -19,11 +19,12 @@ export async function getResource(
   expect(response.status).toBe(200);
   expect(response.headers.get('link')).toContain(`<${LDP.Resource}>; rel="type"`);
   expect(response.headers.get('link')).toContain(`<${url}.acl>; rel="acl"`);
-  expect(response.headers.get('accept-patch')).toBe('text/n3, application/sparql-update');
 
   if (isContainer) {
     expect(response.headers.get('link')).toContain(`<${LDP.Container}>; rel="type"`);
     expect(response.headers.get('link')).toContain(`<${LDP.BasicContainer}>; rel="type"`);
+  } else {
+    expect(response.headers.get('accept-patch')).toBe('text/n3, application/sparql-update');
   }
   if (expected?.contentType) {
     expect(response.headers.get('content-type')).toBe(expected.contentType);


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1877

#### ✍️ Description

Adds a new error handler that stores the original target in the error metadata. This way we can close the linked issue and also have more accurate Allow headers.
