### PR TITLE
fix: Make `getParentContainer` work with query parameters

### DIFF
--- a/src/util/identifiers/BaseIdentifierStrategy.ts
+++ b/src/util/identifiers/BaseIdentifierStrategy.ts
@@ -1,8 +1,18 @@
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { errorTermsToMetadata } from '../errors/HttpErrorUtil';
 import { InternalServerError } from '../errors/InternalServerError';
-import { ensureTrailingSlash, isContainerIdentifier } from '../PathUtil';
+import { isContainerIdentifier } from '../PathUtil';
 import type { IdentifierStrategy } from './IdentifierStrategy';
+
+/**
+ * Regular expression used to determine the parent container of a resource.
+ */
+const parentRegex = /^(.+\/)[^/]+\/*$/u;
+
+/**
+ * Used during containment check to determine if an identifier is a direct child or not.
+ */
+const tailRegex = /\/./u;
 
 /**
  * Provides a default implementation for `getParentContainer`
@@ -26,10 +36,9 @@ export abstract class BaseIdentifierStrategy implements IdentifierStrategy {
       throw new InternalServerError(`Cannot obtain the parent of ${identifier.path} because it is a root container.`);
     }
 
-    // Trailing slash is necessary for URL library
-    const parentPath = new URL('..', ensureTrailingSlash(identifier.path)).href;
-
-    return { path: parentPath };
+    // Due to the checks above we know this will always succeed
+    const match = parentRegex.exec(identifier.path);
+    return { path: match![1] };
   }
 
   public abstract isRootContainer(identifier: ResourceIdentifier): boolean;
@@ -49,6 +58,6 @@ export abstract class BaseIdentifierStrategy implements IdentifierStrategy {
 
     const tail = identifier.path.slice(container.path.length);
     // If there is at least one `/` followed by a char this is not a direct parent container
-    return !/\/./u.test(tail);
+    return !tailRegex.test(tail);
   }
 }

--- a/test/unit/util/identifiers/BaseIdentifierStrategy.test.ts
+++ b/test/unit/util/identifiers/BaseIdentifierStrategy.test.ts
@@ -19,7 +19,9 @@ describe('A BaseIdentifierStrategy', (): void => {
   describe('getParentContainer', (): void => {
     it('returns the parent identifier.', async(): Promise<void> => {
       expect(strategy.getParentContainer({ path: 'http://example.com/foo/bar' })).toEqual({ path: 'http://example.com/foo/' });
+      expect(strategy.getParentContainer({ path: 'http://example.com/foo//' })).toEqual({ path: 'http://example.com/' });
       expect(strategy.getParentContainer({ path: 'http://example.com/foo/bar/' })).toEqual({ path: 'http://example.com/foo/' });
+      expect(strategy.getParentContainer({ path: 'http://example.com/foo/bar?q=5' })).toEqual({ path: 'http://example.com/foo/' });
     });
 
     it('errors when attempting to get the parent of an unsupported identifier.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1889

#### ✍️ Description

Replace URL constructor logic with regex to have consistent results. The test with double slashes was added to keep behaviour there consistent with how it was before this.
