### PR TITLE
update CI node versions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
       - run: npm ci --ignore-scripts
       - run: npm run lint
 
@@ -27,7 +27,7 @@ jobs:
           - 18.x
           - '20.0'
           - 20.x
-          - 21.x
+          - 22.x
     timeout-minutes: 15
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
@@ -59,7 +59,7 @@ jobs:
         node-version:
           - 18.x
           - 20.x
-          - 21.x
+          - 22.x
     env:
       TEST_DOCKER: true
     services:
@@ -94,7 +94,7 @@ jobs:
         node-version:
           - 18.x
           - 20.x
-          - 21.x
+          - 22.x
     timeout-minutes: 20
     steps:
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Node 21 became inactive over a month ago, while 22 became current two weeks ago.
https://endoflife.date/nodejs

The issue discussed in https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1878#pullrequestreview-1999330254 and the related workaround is only needed for node 21. Since it is already inactive, I don't expect that it will get an updated version of `undici`.