### PR TITLE
fix: use full encoded topic iri in streaming http receiveFrom url template

### DIFF
--- a/config/http/notifications/streaming-http.json
+++ b/config/http/notifications/streaming-http.json
@@ -1,6 +1,7 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "import": [
+    "css:config/http/notifications/base/description.json",
     "css:config/http/notifications/base/handler.json",
     "css:config/http/notifications/base/http.json",
     "css:config/http/notifications/base/storage.json",

--- a/config/http/notifications/streaming-http/http.json
+++ b/config/http/notifications/streaming-http/http.json
@@ -32,6 +32,7 @@
         "@id": "urn:solid-server:default:StreamingHttp2023RequestHandler",
         "@type": "StreamingHttpRequestHandler",
         "streamMap": { "@id": "urn:solid-server:default:StreamingHttpMap" },
+        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
         "pathPrefix": { "@id": "urn:solid-server:default:variable:streamingHTTPReceiveFromPrefix" },
         "generator": { "@id": "urn:solid-server:default:BaseNotificationGenerator" },
         "serializer": { "@id": "urn:solid-server:default:BaseNotificationSerializer" },

--- a/config/http/notifications/streaming-http/http.json
+++ b/config/http/notifications/streaming-http/http.json
@@ -2,16 +2,16 @@
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
   "@graph": [
     {
-      "comment": "Path prefix used by streaming HTTP receiveFrom endpoints",
-      "@id": "urn:solid-server:default:variable:streamingHTTPReceiveFromPrefix",
-      "valueRaw": ".notifications/StreamingHTTPChannel2023/"
+      "@id": "urn:solid-server:default:StreamingHTTP2023Route",
+      "@type": "RelativePathInteractionRoute",
+      "base": { "@id": "urn:solid-server:default:NotificationRoute" },
+      "relativePath": "/StreamingHTTPChannel2023/"
     },
     {
       "comment": "Creates updatesViaStreamingHttp2023 Link relations",
       "@id": "urn:solid-server:default:StreamingHttpMetadataWriter",
       "@type": "StreamingHttpMetadataWriter",
-      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-      "pathPrefix": { "@id": "urn:solid-server:default:variable:streamingHTTPReceiveFromPrefix" }
+      "route": { "@id": "urn:solid-server:default:StreamingHTTP2023Route" }
     },
     {
       "comment": "Allows discovery of the corresponding streaming HTTP channel",
@@ -32,8 +32,7 @@
         "@id": "urn:solid-server:default:StreamingHttp2023RequestHandler",
         "@type": "StreamingHttpRequestHandler",
         "streamMap": { "@id": "urn:solid-server:default:StreamingHttpMap" },
-        "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
-        "pathPrefix": { "@id": "urn:solid-server:default:variable:streamingHTTPReceiveFromPrefix" },
+        "route": { "@id": "urn:solid-server:default:StreamingHTTP2023Route" },
         "generator": { "@id": "urn:solid-server:default:BaseNotificationGenerator" },
         "serializer": { "@id": "urn:solid-server:default:BaseNotificationSerializer" },
         "credentialsExtractor": { "@id": "urn:solid-server:default:CredentialsExtractor" },

--- a/src/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.ts
+++ b/src/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.ts
@@ -19,8 +19,8 @@ export class StreamingHttpMetadataWriter extends MetadataWriter {
   }
 
   public async handle(input: { response: HttpResponse; metadata: RepresentationMetadata }): Promise<void> {
-    const resourcePath = input.metadata.identifier.value.replace(this.baseUrl, '');
-    const receiveFrom = `${this.baseUrl}${this.pathPrefix}${resourcePath}`;
+    const encodedUrl = encodeURIComponent(input.metadata.identifier.value);
+    const receiveFrom = `${this.baseUrl}${this.pathPrefix}${encodedUrl}`;
     const link = `<${receiveFrom}>; rel="http://www.w3.org/ns/solid/terms#updatesViaStreamingHttp2023"`;
     this.logger.debug('Adding updatesViaStreamingHttp2023  to the Link header');
     addHeader(input.response, 'Link', link);

--- a/src/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.ts
+++ b/src/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.ts
@@ -1,6 +1,8 @@
 import { getLoggerFor } from '../../../logging/LogUtil';
 import type { HttpResponse } from '../../HttpResponse';
 import { addHeader } from '../../../util/HeaderUtil';
+import { joinUrl } from '../../../util/PathUtil';
+import type { InteractionRoute } from '../../../identity/interaction/routing/InteractionRoute';
 import type { RepresentationMetadata } from '../../../http/representation/RepresentationMetadata';
 import { MetadataWriter } from '../../../http/output/metadata/MetadataWriter';
 
@@ -12,15 +14,14 @@ export class StreamingHttpMetadataWriter extends MetadataWriter {
   protected readonly logger = getLoggerFor(this);
 
   public constructor(
-    private readonly baseUrl: string,
-    private readonly pathPrefix: string,
+    private readonly route: InteractionRoute,
   ) {
     super();
   }
 
   public async handle(input: { response: HttpResponse; metadata: RepresentationMetadata }): Promise<void> {
     const encodedUrl = encodeURIComponent(input.metadata.identifier.value);
-    const receiveFrom = `${this.baseUrl}${this.pathPrefix}${encodedUrl}`;
+    const receiveFrom = joinUrl(this.route.getPath(), encodedUrl);
     const link = `<${receiveFrom}>; rel="http://www.w3.org/ns/solid/terms#updatesViaStreamingHttp2023"`;
     this.logger.debug('Adding updatesViaStreamingHttp2023  to the Link header');
     addHeader(input.response, 'Link', link);

--- a/src/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.ts
+++ b/src/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.ts
@@ -7,6 +7,7 @@ import { AccessMode } from '../../../authorization/permissions/Permissions';
 import { OkResponseDescription } from '../../../http/output/response/OkResponseDescription';
 import type { ResponseDescription } from '../../../http/output/response/ResponseDescription';
 import { BasicRepresentation } from '../../../http/representation/BasicRepresentation';
+import type { InteractionRoute } from '../../../identity/interaction/routing/InteractionRoute';
 import { getLoggerFor } from '../../../logging/LogUtil';
 import type { OperationHttpHandlerInput } from '../../OperationHttpHandler';
 import { OperationHttpHandler } from '../../OperationHttpHandler';
@@ -28,8 +29,7 @@ export class StreamingHttpRequestHandler extends OperationHttpHandler {
 
   public constructor(
     private readonly streamMap: StreamingHttpMap,
-    private readonly baseUrl: string,
-    private readonly pathPrefix: string,
+    private readonly route: InteractionRoute,
     private readonly generator: NotificationGenerator,
     private readonly serializer: NotificationSerializer,
     private readonly credentialsExtractor: CredentialsExtractor,
@@ -40,7 +40,8 @@ export class StreamingHttpRequestHandler extends OperationHttpHandler {
   }
 
   public async handle({ operation, request }: OperationHttpHandlerInput): Promise<ResponseDescription> {
-    const topic = decodeURIComponent(operation.target.path.replace(this.baseUrl + this.pathPrefix, ''));
+    const encodedUrl = operation.target.path.replace(this.route.getPath(), '');
+    const topic = decodeURIComponent(encodedUrl);
 
     // Verify if the client is allowed to connect
     const credentials = await this.credentialsExtractor.handleSafe(request);

--- a/src/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.ts
+++ b/src/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.ts
@@ -28,6 +28,7 @@ export class StreamingHttpRequestHandler extends OperationHttpHandler {
 
   public constructor(
     private readonly streamMap: StreamingHttpMap,
+    private readonly baseUrl: string,
     private readonly pathPrefix: string,
     private readonly generator: NotificationGenerator,
     private readonly serializer: NotificationSerializer,
@@ -39,7 +40,7 @@ export class StreamingHttpRequestHandler extends OperationHttpHandler {
   }
 
   public async handle({ operation, request }: OperationHttpHandlerInput): Promise<ResponseDescription> {
-    const topic = operation.target.path.replace(this.pathPrefix, '');
+    const topic = decodeURIComponent(operation.target.path.replace(this.baseUrl + this.pathPrefix, ''));
 
     // Verify if the client is allowed to connect
     const credentials = await this.credentialsExtractor.handleSafe(request);

--- a/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.test.ts
+++ b/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.test.ts
@@ -4,6 +4,7 @@ import {
 } from '../../../../../src/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter';
 import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
 import type { HttpResponse } from '../../../../../src/server/HttpResponse';
+import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
 
 describe('A StreamingHttpMetadataWriter', (): void => {
   const baseUrl = 'http://example.org/';
@@ -12,9 +13,10 @@ describe('A StreamingHttpMetadataWriter', (): void => {
   const rel = 'http://www.w3.org/ns/solid/terms#updatesViaStreamingHttp2023';
 
   it('adds the correct link header.', async(): Promise<void> => {
+    const topic: ResourceIdentifier = { path: 'http://example.com/foo' };
     const response = createResponse() as HttpResponse;
-    const metadata = new RepresentationMetadata({ path: 'http://example.org/foo/bar/baz' });
+    const metadata = new RepresentationMetadata(topic);
     await expect(writer.handle({ response, metadata })).resolves.toBeUndefined();
-    expect(response.getHeaders()).toEqual({ link: `<http://example.org/.notifications/StreamingHTTPChannel2023/foo/bar/baz>; rel="${rel}"` });
+    expect(response.getHeaders()).toEqual({ link: `<http://example.org/.notifications/StreamingHTTPChannel2023/${encodeURIComponent(topic.path)}>; rel="${rel}"` });
   });
 });

--- a/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.test.ts
+++ b/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter.test.ts
@@ -2,14 +2,17 @@ import { createResponse } from 'node-mocks-http';
 import {
   StreamingHttpMetadataWriter,
 } from '../../../../../src/server/notifications/StreamingHttpChannel2023/StreamingHttpMetadataWriter';
+import {
+  AbsolutePathInteractionRoute,
+} from '../../../../../src/identity/interaction/routing/AbsolutePathInteractionRoute';
 import { RepresentationMetadata } from '../../../../../src/http/representation/RepresentationMetadata';
 import type { HttpResponse } from '../../../../../src/server/HttpResponse';
 import type { ResourceIdentifier } from '../../../../../src/http/representation/ResourceIdentifier';
 
 describe('A StreamingHttpMetadataWriter', (): void => {
-  const baseUrl = 'http://example.org/';
-  const pathPrefix = '.notifications/StreamingHTTPChannel2023/';
-  const writer = new StreamingHttpMetadataWriter(baseUrl, pathPrefix);
+  const path = 'http://example.org/.notifications/StreamingHTTPChannel2023/';
+  const route = new AbsolutePathInteractionRoute(path);
+  const writer = new StreamingHttpMetadataWriter(route);
   const rel = 'http://www.w3.org/ns/solid/terms#updatesViaStreamingHttp2023';
 
   it('adds the correct link header.', async(): Promise<void> => {

--- a/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.test.ts
+++ b/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.test.ts
@@ -31,6 +31,7 @@ jest.mock('../../../../../src/logging/LogUtil', (): any => {
 describe('A StreamingHttpRequestHandler', (): void => {
   const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   const topic: ResourceIdentifier = { path: 'http://example.com/foo' };
+  const baseUrl = 'http://example.com/';
   const pathPrefix = '.notifications/StreamingHTTPChannel2023/';
   const channel: NotificationChannel = {
     id: 'id',
@@ -64,7 +65,7 @@ describe('A StreamingHttpRequestHandler', (): void => {
   beforeEach(async(): Promise<void> => {
     operation = {
       method: 'GET',
-      target: { path: 'http://example.com/.notifications/StreamingHTTPChannel2023/foo' },
+      target: { path: `http://example.com/.notifications/StreamingHTTPChannel2023/${encodeURIComponent(topic.path)}` },
       body: new BasicRepresentation(),
       preferences: {},
     };
@@ -95,6 +96,7 @@ describe('A StreamingHttpRequestHandler', (): void => {
 
     handler = new StreamingHttpRequestHandler(
       streamMap,
+      baseUrl,
       pathPrefix,
       generator,
       serializer,
@@ -151,6 +153,7 @@ describe('A StreamingHttpRequestHandler', (): void => {
     } as any;
     handler = new StreamingHttpRequestHandler(
       streamMap,
+      baseUrl,
       pathPrefix,
       generator,
       serializer,

--- a/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.test.ts
+++ b/test/unit/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler.test.ts
@@ -16,8 +16,8 @@ import { getLoggerFor } from '../../../../../src/logging/LogUtil';
 import {
   StreamingHttpRequestHandler,
 } from '../../../../../src/server/notifications/StreamingHttpChannel2023/StreamingHttpRequestHandler';
+import { AbsolutePathInteractionRoute, StreamingHttpMap } from '../../../../../src';
 import type { NotificationGenerator, NotificationSerializer } from '../../../../../src';
-import { StreamingHttpMap } from '../../../../../src';
 import type { Notification } from '../../../../../src/server/notifications/Notification';
 import { flushPromises } from '../../../../util/Util';
 
@@ -31,8 +31,7 @@ jest.mock('../../../../../src/logging/LogUtil', (): any => {
 describe('A StreamingHttpRequestHandler', (): void => {
   const logger: jest.Mocked<Logger> = getLoggerFor('mock') as any;
   const topic: ResourceIdentifier = { path: 'http://example.com/foo' };
-  const baseUrl = 'http://example.com/';
-  const pathPrefix = '.notifications/StreamingHTTPChannel2023/';
+  const path = 'http://example.com/.notifications/StreamingHTTPChannel2023/';
   const channel: NotificationChannel = {
     id: 'id',
     topic: topic.path,
@@ -53,6 +52,7 @@ describe('A StreamingHttpRequestHandler', (): void => {
   const request: HttpRequest = {} as any;
   const response: HttpResponse = {} as any;
   let representation: BasicRepresentation;
+  let route: AbsolutePathInteractionRoute;
   let streamMap: StreamingHttpMap;
   let operation: Operation;
   let generator: jest.Mocked<NotificationGenerator>;
@@ -65,11 +65,13 @@ describe('A StreamingHttpRequestHandler', (): void => {
   beforeEach(async(): Promise<void> => {
     operation = {
       method: 'GET',
-      target: { path: `http://example.com/.notifications/StreamingHTTPChannel2023/${encodeURIComponent(topic.path)}` },
+      target: { path: `${path}${encodeURIComponent(topic.path)}` },
       body: new BasicRepresentation(),
       preferences: {},
     };
     representation = new BasicRepresentation(chunk, 'text/plain');
+
+    route = new AbsolutePathInteractionRoute(path);
 
     streamMap = new StreamingHttpMap();
 
@@ -96,8 +98,7 @@ describe('A StreamingHttpRequestHandler', (): void => {
 
     handler = new StreamingHttpRequestHandler(
       streamMap,
-      baseUrl,
-      pathPrefix,
+      route,
       generator,
       serializer,
       credentialsExtractor,
@@ -153,8 +154,7 @@ describe('A StreamingHttpRequestHandler', (): void => {
     } as any;
     handler = new StreamingHttpRequestHandler(
       streamMap,
-      baseUrl,
-      pathPrefix,
+      route,
       generator,
       serializer,
       credentialsExtractor,


### PR DESCRIPTION
#### 📁 Related issues

<!--
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose
-->

#### ✍️ Description

I tried streaming HTTP notifications with the *subdomain* identifier strategy, which, of course, didn't work.
By using the topic's fully encoded IRI now, it should not assume any specific identifier strategy.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
