### PR TITLE
Correctly delete data in validate-configs.sh

### DIFF
--- a/test/deploy/validate-configs.sh
+++ b/test/deploy/validate-configs.sh
@@ -82,7 +82,7 @@ run_server_with_config () {
     timeout 30s tail --pid=$PID -f /dev/null
   fi
 
-  rm -rf test/tmp/data/*
+  rm -rf test/tmp/data/
   return $FAILURE
 }
 


### PR DESCRIPTION
#### 📁 Related issues

Accidentally discovered through https://github.com/CommunitySolidServer/CommunitySolidServer/pull/1943

#### ✍️ Description

The `*` should not be there and actually caused the files not to be deleted.