### PR TITLE
fix: streaming video by adding a limit to streaming chunks

### DIFF
--- a/config/http/middleware/handlers/constant-headers.json
+++ b/config/http/middleware/handlers/constant-headers.json
@@ -13,6 +13,10 @@
         {
           "HeaderHandler:_headers_key": "X-Powered-By",
           "HeaderHandler:_headers_value": "Community Solid Server"
+        },
+        {
+          "HeaderHandler:_headers_key": "Accept-Ranges",
+          "HeaderHandler:_headers_value": "bytes"
         }
       ]
     }

--- a/config/storage/middleware/default.json
+++ b/config/storage/middleware/default.json
@@ -22,7 +22,8 @@
       "comment": "Slices part of binary streams based on the range preferences.",
       "@id": "urn:solid-server:default:ResourceStore_BinarySlice",
       "@type": "BinarySliceResourceStore",
-      "source": { "@id": "urn:solid-server:default:ResourceStore_Index" }
+      "source": { "@id": "urn:solid-server:default:ResourceStore_Index" },
+      "defaultSliceSize": 10000000
     },
     {
       "comment": "When a container with an index.html document is accessed, serve that HTML document instead of the container.",


### PR DESCRIPTION
#### 📁 Related issues

Fixes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1948

#### ✍️ Description

Firefox and Chrome both use range headers with ambiguous endings to stream video (for example `range: 0-` rather than `range: 0-5000000`). As built, CSS was trying to deliver an entire video in a single request because of this. This lead to long load times for large videos.

I followed the solution posed by Zeng Xu (https://www.zeng.dev/post/2023-http-range-and-play-mp4-in-browser/) and arbitrarily added a default number of bytes to deliver if the byte range end wasn't provided. This works on Firefox, Chrome, and Safari.

Unfortunately, this does break RFC 7233 (https://www.rfc-editor.org/rfc/rfc7233#section-2.1), but as of this moment, it is the only way I found to get streaming video to work on Firefox and Chrome.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [?] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [X] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [X] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
