### PR TITLE
fix: Prevent server from crashing when a lock is compromised

### DIFF
--- a/test/unit/util/locking/FileSystemResourceLocker.test.ts
+++ b/test/unit/util/locking/FileSystemResourceLocker.test.ts
@@ -123,9 +123,21 @@ describe('A FileSystemResourceLocker', (): void => {
   });
 
   it('stops proper-lock from throwing errors after finalize was called.', async(): Promise<void> => {
-    // Tests should never access private fields so we need to change this after splitting the test as mentioned above.
+    locker = new FileSystemResourceLocker({
+      rootFilePath,
+      attemptSettings: { retryCount: 19, retryDelay: 100 },
+      throwOnCompromise: true,
+    });
+    // Tests should never access private fields, so we need to change this after splitting the test as mentioned above.
     // Once we have a mock we can check which parameters `unlock` was called with and extract the function from there.
     expect((): void => (locker as any).customOnCompromised(new Error('test'))).toThrow('test');
+    await locker.finalize();
+    expect((locker as any).customOnCompromised(new Error('test'))).toBeUndefined();
+  });
+
+  it('by default does not throw an error if the lock is compromised.', async(): Promise<void> => {
+    // See comments above
+    expect((locker as any).customOnCompromised(new Error('test'))).toBeUndefined();
     await locker.finalize();
     expect((locker as any).customOnCompromised(new Error('test'))).toBeUndefined();
   });


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/Recipes/issues/44#issuecomment-2602605410

#### ✍️ Description

Prevents the server from crashing, unless required, when a lock is compromised.
