### PR TITLE
Use the correct field when adding a pod owner

### DIFF
--- a/templates/identity/account/pod-settings.html.ejs
+++ b/templates/identity/account/pod-settings.html.ejs
@@ -16,8 +16,8 @@
     <p>Add the WebID to add to the list of owners</p>
     <ol>
       <li>
-        <label for="owner">WebID:</label>
-        <input id="owner" type="text" name="owner" autofocus>
+        <label for="webId">WebID:</label>
+        <input id="webId" type="text" name="webId" autofocus>
       </li>
     </ol>
   </fieldset>


### PR DESCRIPTION
#### 📁 Related issues

Fixes https://github.com/CommunitySolidServer/Recipes/issues/46

#### ✍️ Description

The HTML page was using the wrong field to add an owner to a pod
