### PR TITLE
Changing metadata updates a resource's modified time

### DIFF
--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -442,6 +442,9 @@ export class DataAccessorBasedStore implements ResourceStore {
     const quads: Quad[] = await arrayifyStream(representation.data);
     metadata.addQuads(quads);
 
+    // Add date modified metadata
+    updateModifiedDate(metadata);
+
     // Remove the response metadata as this must not be stored
     this.removeResponseMetadata(metadata);
     await this.accessor.writeMetadata(subjectIdentifier, metadata);

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -3,7 +3,7 @@ import type { Readable } from 'node:stream';
 import arrayifyStream from 'arrayify-stream';
 import { DataFactory, Store } from 'n3';
 import type { Conditions } from '../../../src';
-import { CONTENT_TYPE_TERM } from '../../../src';
+import { CONTENT_TYPE_TERM, XSD } from '../../../src';
 import type { AuxiliaryStrategy } from '../../../src/http/auxiliary/AuxiliaryStrategy';
 import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../src/http/representation/Representation';
@@ -589,6 +589,11 @@ describe('A DataAccessorBasedStore', (): void => {
           namedNode(DC.description),
           literal('something'),
         ),
+        quad(
+          namedNode(resourceID.path),
+          DC.terms.modified,
+          literal(now.toISOString(), XSD.terms.dateTime),
+        ),
       ]);
     });
 
@@ -606,7 +611,14 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.setRepresentation(metaResourceID, metaRepresentation);
       expect(result.get(resourceID)?.get(SOLID_AS.terms.activity)).toEqual(AS.terms.Update);
-      expect(accessor.data[resourceID.path].metadata.quads()).toBeRdfIsomorphic(quads);
+      expect(accessor.data[resourceID.path].metadata.quads()).toBeRdfIsomorphic([
+        ...quads,
+        quad(
+          namedNode(resourceID.path),
+          DC.terms.modified,
+          literal(now.toISOString(), XSD.terms.dateTime),
+        ),
+      ]);
     });
 
     it('can not write metadata when the corresponding resource does not exist.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Discussed in matrix. Problem was that updating metadata did not change the last modified time of a resource, causing the ETag to not update. This was especially a problem for contains whose representation is partially generated by their metadata.

#### ✍️ Description

This now updates the last modified time of a resource when the metadata is modified. Since the `FileDataAccessor` uses `mtime` from disk, there we have to take the max of the `mtime` for both the resource itself and its metadata.