### PR TITLE
fix: Correctly match IdInteractionRoutes without trailing slash

### DIFF
--- a/src/identity/interaction/routing/IdInteractionRoute.ts
+++ b/src/identity/interaction/routing/IdInteractionRoute.ts
@@ -9,11 +9,13 @@ export class IdInteractionRoute<TBase extends string, TId extends string> implem
   private readonly base: InteractionRoute<TBase>;
   private readonly idName: TId;
   private readonly ensureSlash: boolean;
+  private readonly matchRegex: RegExp;
 
   public constructor(base: InteractionRoute<TBase>, idName: TId, ensureSlash = true) {
     this.base = base;
     this.idName = idName;
     this.ensureSlash = ensureSlash;
+    this.matchRegex = ensureSlash ? /(.*\/)([^/]+)\/$/u : /(.*\/)([^/]+)$/u;
   }
 
   public getPath(parameters?: Record<TBase | TId, string>): string {
@@ -27,7 +29,7 @@ export class IdInteractionRoute<TBase extends string, TId extends string> implem
   }
 
   public matchPath(path: string): Record<TBase | TId, string> | undefined {
-    const match = /(.*\/)([^/]+)\/$/u.exec(path);
+    const match = this.matchRegex.exec(path);
 
     if (!match) {
       return;

--- a/test/unit/identity/interaction/routing/IdInteractionRoute.test.ts
+++ b/test/unit/identity/interaction/routing/IdInteractionRoute.test.ts
@@ -36,6 +36,11 @@ describe('An IdInteractionRoute', (): void => {
       expect(route.matchPath('http://example.com/1234/')).toEqual({ base: 'base', id: '1234' });
     });
 
+    it('can match paths without trailing slash if ensureSlash is false.', async(): Promise<void> => {
+      route = new IdInteractionRoute<'base', 'id'>(base, idName, false);
+      expect(route.matchPath('http://example.com/1234')).toEqual({ base: 'base', id: '1234' });
+    });
+
     it('returns undefined if there is no match.', async(): Promise<void> => {
       expect(route.matchPath('http://example.com/1234')).toBeUndefined();
     });


### PR DESCRIPTION
#### ✍️ Description

`IdInteractionRoute` could not match URLs if `ensureSlash` was set to false.
