### PR TITLE
fix: Force pod names to be lower case

### DIFF
--- a/src/pods/generate/SubdomainIdentifierGenerator.ts
+++ b/src/pods/generate/SubdomainIdentifierGenerator.ts
@@ -19,7 +19,7 @@ export class SubdomainIdentifierGenerator implements IdentifierGenerator {
 
   public generate(name: string): ResourceIdentifier {
     // Using the punycode converter is a risk as it doesn't convert slashes for example
-    const cleanName = sanitizeUrlPart(name);
+    const cleanName = sanitizeUrlPart(name).toLowerCase();
     return { path: `${this.baseParts.scheme}${cleanName}.${this.baseParts.rest}` };
   }
 

--- a/src/pods/generate/SuffixIdentifierGenerator.ts
+++ b/src/pods/generate/SuffixIdentifierGenerator.ts
@@ -16,7 +16,7 @@ export class SuffixIdentifierGenerator implements IdentifierGenerator {
   }
 
   public generate(name: string): ResourceIdentifier {
-    const cleanName = sanitizeUrlPart(name);
+    const cleanName = sanitizeUrlPart(name).toLowerCase();
     return { path: ensureTrailingSlash(new URL(cleanName, this.base).href) };
   }
 

--- a/templates/identity/account/create-pod.html.ejs
+++ b/templates/identity/account/create-pod.html.ejs
@@ -3,14 +3,14 @@
   <p class="error" id="error"></p>
 
   <fieldset>
-    <p>Choose a name for your pod</p>
+    <p>Choose a name for your pod. It will be converted to lower case.</p>
     <ol>
       <li>
         <label for="name">Name</label>
         <input id="name" type="text" name="name" autofocus>
       </li>
     </ol>
-    <p>Choose which WebID will have initial write permissions on the pod</p>
+    <p>Choose which WebID will have initial write permissions on the pod.</p>
     <ol>
       <li class="radio">
         <label>

--- a/test/unit/pods/generate/SubdomainIdentifierGenerator.test.ts
+++ b/test/unit/pods/generate/SubdomainIdentifierGenerator.test.ts
@@ -13,6 +13,10 @@ describe('A SubdomainIdentifierGenerator', (): void => {
     expect(generator.generate('sàl/u㋡g')).toEqual({ path: 'http://s-l-u-g.example.com/' });
   });
 
+  it('converts the name to lowercase.', async(): Promise<void> => {
+    expect(generator.generate('Sàl/u㋡G')).toEqual({ path: 'http://s-l-u-g.example.com/' });
+  });
+
   it('can extract the pod from an identifier.', async(): Promise<void> => {
     const identifier = { path: 'http://foo.example.com/bar/baz' };
     expect(generator.extractPod(identifier)).toEqual({ path: 'http://foo.example.com/' });

--- a/test/unit/pods/generate/SuffixIdentifierGenerator.test.ts
+++ b/test/unit/pods/generate/SuffixIdentifierGenerator.test.ts
@@ -13,6 +13,10 @@ describe('A SuffixIdentifierGenerator', (): void => {
     expect(generator.generate('sàl/u㋡g')).toEqual({ path: `${base}s-l-u-g/` });
   });
 
+  it('converts the name to lowercase.', async(): Promise<void> => {
+    expect(generator.generate('Sàl/u㋡G')).toEqual({ path: `${base}s-l-u-g/` });
+  });
+
   it('can extract the pod from an identifier.', async(): Promise<void> => {
     const identifier = { path: 'http://example.com/foo/bar/baz' };
     expect(generator.extractPod(identifier)).toEqual({ path: 'http://example.com/foo/' });


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/1894

#### ✍️ Description

Only relevant for subdomain pods as domains are case-insensitive. But for consistency, suffix pods are also changed.
