### PR TITLE
Cache JSON-LD contexts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@comunica/context-entries": "^2.8.2",
         "@comunica/query-sparql": "^2.9.0",
+        "@isaacs/ttlcache": "^1.4.1",
         "@rdfjs/types": "^1.1.0",
         "@solid/access-control-policy": "^0.1.3",
         "@solid/access-token-verifier": "^2.1.0",
@@ -4950,6 +4951,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
       "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+    },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -21097,6 +21107,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
       "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+    },
+    "@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@comunica/context-entries": "^2.8.2",
     "@comunica/query-sparql": "^2.9.0",
+    "@isaacs/ttlcache": "^1.4.1",
     "@rdfjs/types": "^1.1.0",
     "@solid/access-control-policy": "^0.1.3",
     "@solid/access-token-verifier": "^2.1.0",


### PR DESCRIPTION
#### ✍️ Description

Caches JSON-LD contexts fetched during RDF conversion for a short time to prevent spamming external servers in case there are a lot of requests.
