### PR TITLE
refactor: Add generics to AccountStore so it can be more easily extended

### DIFF
--- a/.componentsignore
+++ b/.componentsignore
@@ -15,6 +15,7 @@
   "Error",
   "EventEmitter",
   "FetchDocumentLoader",
+  "GenericAccountSettings",
   "GenericEventEmitter",
   "HashMap",
   "HttpErrorOptions",

--- a/src/identity/interaction/account/util/AccountStore.ts
+++ b/src/identity/interaction/account/util/AccountStore.ts
@@ -1,14 +1,32 @@
+import type {
+  IndexObject,
+  StringKey,
+  TypeObject,
+  ValueTypeDescription,
+} from '../../../../storage/keyvalue/IndexedStorage';
+import type { ACCOUNT_TYPE } from './LoginStorage';
+
 /**
  * Settings parameter used to determine if the user wants the login to be remembered.
  */
 export const ACCOUNT_SETTINGS_REMEMBER_LOGIN = 'rememberLogin';
 
-export type AccountSettings = { [ACCOUNT_SETTINGS_REMEMBER_LOGIN]?: boolean };
+export type GenericAccountSettings = Record<string, ValueTypeDescription<typeof ACCOUNT_TYPE> & `${string}?`>;
+
+/**
+ * The index type description of the minimal account settings.
+ */
+export type MinimalAccountSettings = { [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: 'boolean?' };
+
+/**
+ * The JS object representation of the minimal account settings.
+ */
+export type AccountSettings = IndexObject<MinimalAccountSettings>;
 
 /**
  * Used to store account data.
  */
-export interface AccountStore {
+export interface AccountStore<TSettings extends GenericAccountSettings = MinimalAccountSettings> {
   /**
    * Creates a new and empty account.
    * Since this account will not yet have a login method,
@@ -19,11 +37,13 @@ export interface AccountStore {
 
   /**
    * Finds the setting of the account with the given identifier.
+   * Returns undefined if there is no matching account.
    *
    * @param id - The account identifier.
    * @param setting - The setting to find the value of.
    */
-  getSetting: <T extends keyof AccountSettings>(id: string, setting: T) => Promise<AccountSettings[T]>;
+  getSetting: <TKey extends keyof TSettings>(id: string, setting: TKey)
+  => Promise<TypeObject<TSettings>[TKey] | undefined>;
 
   /**
    * Updates the settings for the account with the given identifier to the new values.
@@ -32,5 +52,6 @@ export interface AccountStore {
    * @param setting - The setting to update.
    * @param value - The new value for the setting.
    */
-  updateSetting: <T extends keyof AccountSettings>(id: string, setting: T, value: AccountSettings[T]) => Promise<void>;
+  updateSetting: <TKey extends StringKey<TSettings>>(id: string, setting: TKey, value: TypeObject<TSettings>[TKey])
+  => Promise<void>;
 }

--- a/src/identity/interaction/account/util/BaseAccountStore.ts
+++ b/src/identity/interaction/account/util/BaseAccountStore.ts
@@ -1,64 +1,19 @@
-import { Initializer } from '../../../../init/Initializer';
-import { getLoggerFor } from '../../../../logging/LogUtil';
-import type { ValueType } from '../../../../storage/keyvalue/IndexedStorage';
-import { createErrorMessage } from '../../../../util/errors/ErrorUtil';
-import { InternalServerError } from '../../../../util/errors/InternalServerError';
-import type { AccountSettings, AccountStore } from './AccountStore';
+import type { MinimalAccountSettings } from './AccountStore';
 import { ACCOUNT_SETTINGS_REMEMBER_LOGIN } from './AccountStore';
+import { GenericAccountStore } from './GenericAccountStore';
 import type { AccountLoginStorage } from './LoginStorage';
-import { ACCOUNT_TYPE } from './LoginStorage';
 
 export const ACCOUNT_STORAGE_DESCRIPTION = {
   [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: 'boolean?',
 } as const;
 
 /**
- * A {@link AccountStore} that uses an {@link AccountLoginStorage} to keep track of the accounts.
+ * A {@link GenericAccountStore} that supports the minimal account settings.
  * Needs to be initialized before it can be used.
  */
-export class BaseAccountStore extends Initializer implements AccountStore {
-  private readonly logger = getLoggerFor(this);
-
-  private readonly storage: AccountLoginStorage<{ [ACCOUNT_TYPE]: typeof ACCOUNT_STORAGE_DESCRIPTION }>;
-  private initialized = false;
-
+export class BaseAccountStore extends GenericAccountStore<MinimalAccountSettings> {
   // Wrong typings to prevent Components.js typing issues
   public constructor(storage: AccountLoginStorage<Record<string, never>>) {
-    super();
-    this.storage = storage as unknown as typeof this.storage;
-  }
-
-  // Initialize the type definitions
-  public async handle(): Promise<void> {
-    if (this.initialized) {
-      return;
-    }
-    try {
-      await this.storage.defineType(ACCOUNT_TYPE, ACCOUNT_STORAGE_DESCRIPTION, false);
-      this.initialized = true;
-    } catch (cause: unknown) {
-      throw new InternalServerError(`Error defining account in storage: ${createErrorMessage(cause)}`, { cause });
-    }
-  }
-
-  public async create(): Promise<string> {
-    const { id } = await this.storage.create(ACCOUNT_TYPE, {});
-    this.logger.debug(`Created new account ${id}`);
-
-    return id;
-  }
-
-  public async getSetting<T extends keyof AccountSettings>(id: string, setting: T): Promise<AccountSettings[T]> {
-    const account = await this.storage.get(ACCOUNT_TYPE, id);
-    if (!account) {
-      return;
-    }
-    const { id: unused, ...settings } = account;
-    return settings[setting];
-  }
-
-  public async updateSetting<T extends keyof AccountSettings>(id: string, setting: T, value: AccountSettings[T]):
-  Promise<void> {
-    await this.storage.setField(ACCOUNT_TYPE, id, setting, value as ValueType<typeof ACCOUNT_STORAGE_DESCRIPTION[T]>);
+    super(storage, ACCOUNT_STORAGE_DESCRIPTION);
   }
 }

--- a/src/identity/interaction/account/util/GenericAccountStore.ts
+++ b/src/identity/interaction/account/util/GenericAccountStore.ts
@@ -1,0 +1,67 @@
+import { Initializer } from '../../../../init/Initializer';
+import { getLoggerFor } from '../../../../logging/LogUtil';
+import type {
+  CreateTypeObject,
+  StringKey,
+  TypeObject,
+} from '../../../../storage/keyvalue/IndexedStorage';
+import { createErrorMessage } from '../../../../util/errors/ErrorUtil';
+import { InternalServerError } from '../../../../util/errors/InternalServerError';
+import type { AccountStore, MinimalAccountSettings } from './AccountStore';
+import type { AccountLoginStorage } from './LoginStorage';
+import { ACCOUNT_TYPE } from './LoginStorage';
+
+/**
+ * A {@link AccountStore} that uses an {@link AccountLoginStorage} to keep track of the accounts.
+ * Needs to be initialized before it can be used.
+ */
+export class GenericAccountStore<TDesc extends MinimalAccountSettings>
+  extends Initializer implements AccountStore<TDesc> {
+  protected readonly logger = getLoggerFor(this);
+
+  protected readonly description: TDesc;
+  protected readonly storage: AccountLoginStorage<{ [ACCOUNT_TYPE]: TDesc }>;
+  protected initialized = false;
+
+  // Wrong typings to prevent Components.js typing issues
+  public constructor(storage: AccountLoginStorage<Record<string, never>>, description: TDesc) {
+    super();
+    this.description = description;
+    this.storage = storage as unknown as typeof this.storage;
+  }
+
+  // Initialize the type definitions
+  public async handle(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    try {
+      await this.storage.defineType(ACCOUNT_TYPE, this.description, false);
+      this.initialized = true;
+    } catch (cause: unknown) {
+      throw new InternalServerError(`Error defining account in storage: ${createErrorMessage(cause)}`, { cause });
+    }
+  }
+
+  public async create(): Promise<string> {
+    // {} is valid as only optional fields are allowed in the description
+    const { id } = await this.storage.create(ACCOUNT_TYPE, {} as CreateTypeObject<TDesc>);
+    this.logger.debug(`Created new account ${id}`);
+
+    return id;
+  }
+
+  public async getSetting<TKey extends keyof TDesc>(id: string, setting: TKey):
+  Promise<TypeObject<TDesc>[TKey] | undefined> {
+    const account = await this.storage.get(ACCOUNT_TYPE, id);
+    if (!account) {
+      return;
+    }
+    return account[setting];
+  }
+
+  public async updateSetting<TKey extends StringKey<TDesc>>(id: string, setting: TKey, value: TypeObject<TDesc>[TKey]):
+  Promise<void> {
+    await this.storage.setField(ACCOUNT_TYPE, id, setting, value);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ export * from './identity/interaction/account/util/BaseAccountStore';
 export * from './identity/interaction/account/util/BaseCookieStore';
 export * from './identity/interaction/account/util/BaseLoginAccountStorage';
 export * from './identity/interaction/account/util/CookieStore';
+export * from './identity/interaction/account/util/GenericAccountStore';
 export * from './identity/interaction/account/util/LoginStorage';
 
 // Identity/Interaction/Account

--- a/src/storage/keyvalue/IndexedStorage.ts
+++ b/src/storage/keyvalue/IndexedStorage.ts
@@ -27,14 +27,23 @@ export type ValueType<T extends ValueTypeDescription> =
 export type OptionalKey<T> = {[K in keyof T ]: T[K] extends `${string}?` ? K : never }[keyof T];
 
 /**
- * Converts a {@link IndexedStorage} definition of a specific type
- * to the typing an object would have that is returned as an output on function calls.
+ * Converts a key/value object type description with {@link ValueTypeDescription} values
+ * to the corresponding JS type.
+ * E.g., { key: 'boolean?' } becomes { key?: boolean }.
  */
-export type TypeObject<TDesc extends Record<string, ValueTypeDescription>> = {
+export type IndexObject<TDesc extends Record<string, ValueTypeDescription>> = {
   -readonly [K in Exclude<keyof TDesc, OptionalKey<TDesc>>]: ValueType<TDesc[K]>;
 } & {
   -readonly [K in keyof TDesc]?: ValueType<TDesc[K]>;
-} & { [INDEX_ID_KEY]: string };
+};
+
+/**
+ * Converts a {@link IndexedStorage} definition of a specific type
+ * to the typing an object would have that is returned as an output on function calls.
+ * Makes sure the required `id` parameter is always present.
+ */
+export type TypeObject<TDesc extends Record<string, ValueTypeDescription>> =
+  IndexObject<TDesc> & { [INDEX_ID_KEY]: string };
 
 /**
  * Input expected for `create()` call in {@link IndexedStorage}.

--- a/test/unit/identity/interaction/account/util/BaseAccountStore.test.ts
+++ b/test/unit/identity/interaction/account/util/BaseAccountStore.test.ts
@@ -6,21 +6,14 @@ import type {
 import {
   ACCOUNT_TYPE,
 } from '../../../../../../src/identity/interaction/account/util/LoginStorage';
-import { InternalServerError } from '../../../../../../src/util/errors/InternalServerError';
-
-jest.mock('uuid', (): any => ({ v4: (): string => '4c9b88c1-7502-4107-bb79-2a3a590c7aa3' }));
 
 describe('A BaseAccountStore', (): void => {
-  const id = 'id';
   let storage: jest.Mocked<AccountLoginStorage<any>>;
   let store: BaseAccountStore;
 
   beforeEach(async(): Promise<void> => {
     storage = {
       defineType: jest.fn().mockResolvedValue({}),
-      create: jest.fn().mockResolvedValue({ id }),
-      get: jest.fn().mockResolvedValue({ id, [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: true }),
-      setField: jest.fn(),
     } satisfies Partial<AccountLoginStorage<any>> as any;
 
     store = new BaseAccountStore(storage);
@@ -32,41 +25,5 @@ describe('A BaseAccountStore', (): void => {
     expect(storage.defineType).toHaveBeenLastCalledWith(ACCOUNT_TYPE, {
       [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: 'boolean?',
     }, false);
-  });
-
-  it('can only initialize once.', async(): Promise<void> => {
-    await expect(store.handle()).resolves.toBeUndefined();
-    await expect(store.handle()).resolves.toBeUndefined();
-    expect(storage.defineType).toHaveBeenCalledTimes(1);
-  });
-
-  it('throws an error if defining the type goes wrong.', async(): Promise<void> => {
-    storage.defineType.mockRejectedValueOnce(new Error('bad data'));
-    await expect(store.handle()).rejects.toThrow(InternalServerError);
-  });
-
-  it('creates an empty account.', async(): Promise<void> => {
-    await expect(store.create()).resolves.toEqual(id);
-    expect(storage.create).toHaveBeenCalledTimes(1);
-    expect(storage.create).toHaveBeenLastCalledWith(ACCOUNT_TYPE, {});
-  });
-
-  it('can return a setting.', async(): Promise<void> => {
-    await expect(store.getSetting(id, ACCOUNT_SETTINGS_REMEMBER_LOGIN)).resolves.toBe(true);
-    expect(storage.get).toHaveBeenCalledTimes(1);
-    expect(storage.get).toHaveBeenLastCalledWith(ACCOUNT_TYPE, id);
-  });
-
-  it('returns undefined if the accountId is invalid.', async(): Promise<void> => {
-    storage.get.mockResolvedValueOnce(undefined);
-    await expect(store.getSetting(id, ACCOUNT_SETTINGS_REMEMBER_LOGIN)).resolves.toBeUndefined();
-    expect(storage.get).toHaveBeenCalledTimes(1);
-    expect(storage.get).toHaveBeenLastCalledWith(ACCOUNT_TYPE, id);
-  });
-
-  it('can set the settings.', async(): Promise<void> => {
-    await expect(store.updateSetting(id, ACCOUNT_SETTINGS_REMEMBER_LOGIN, true)).resolves.toBeUndefined();
-    expect(storage.setField).toHaveBeenCalledTimes(1);
-    expect(storage.setField).toHaveBeenLastCalledWith(ACCOUNT_TYPE, id, ACCOUNT_SETTINGS_REMEMBER_LOGIN, true);
   });
 });

--- a/test/unit/identity/interaction/account/util/GenericAccountStore.test.ts
+++ b/test/unit/identity/interaction/account/util/GenericAccountStore.test.ts
@@ -1,0 +1,75 @@
+import {
+  ACCOUNT_SETTINGS_REMEMBER_LOGIN,
+  type MinimalAccountSettings,
+} from '../../../../../../src/identity/interaction/account/util/AccountStore';
+import { GenericAccountStore } from '../../../../../../src/identity/interaction/account/util/GenericAccountStore';
+import type {
+  AccountLoginStorage,
+} from '../../../../../../src/identity/interaction/account/util/LoginStorage';
+import {
+  ACCOUNT_TYPE,
+} from '../../../../../../src/identity/interaction/account/util/LoginStorage';
+import { InternalServerError } from '../../../../../../src/util/errors/InternalServerError';
+
+jest.mock('uuid', (): any => ({ v4: (): string => '4c9b88c1-7502-4107-bb79-2a3a590c7aa3' }));
+
+describe('A GenericAccountStore', (): void => {
+  const id = 'id';
+  let storage: jest.Mocked<AccountLoginStorage<any>>;
+  let store: GenericAccountStore<MinimalAccountSettings>;
+
+  beforeEach(async(): Promise<void> => {
+    storage = {
+      defineType: jest.fn().mockResolvedValue({}),
+      create: jest.fn().mockResolvedValue({ id }),
+      get: jest.fn().mockResolvedValue({ id, [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: true }),
+      setField: jest.fn(),
+    } satisfies Partial<AccountLoginStorage<any>> as any;
+
+    store = new GenericAccountStore(storage, { [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: 'boolean?' });
+  });
+
+  it('defines the account type in the storage.', async(): Promise<void> => {
+    await expect(store.handle()).resolves.toBeUndefined();
+    expect(storage.defineType).toHaveBeenCalledTimes(1);
+    expect(storage.defineType).toHaveBeenLastCalledWith(ACCOUNT_TYPE, {
+      [ACCOUNT_SETTINGS_REMEMBER_LOGIN]: 'boolean?',
+    }, false);
+  });
+
+  it('can only initialize once.', async(): Promise<void> => {
+    await expect(store.handle()).resolves.toBeUndefined();
+    await expect(store.handle()).resolves.toBeUndefined();
+    expect(storage.defineType).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws an error if defining the type goes wrong.', async(): Promise<void> => {
+    storage.defineType.mockRejectedValueOnce(new Error('bad data'));
+    await expect(store.handle()).rejects.toThrow(InternalServerError);
+  });
+
+  it('creates an empty account.', async(): Promise<void> => {
+    await expect(store.create()).resolves.toEqual(id);
+    expect(storage.create).toHaveBeenCalledTimes(1);
+    expect(storage.create).toHaveBeenLastCalledWith(ACCOUNT_TYPE, {});
+  });
+
+  it('can return a setting.', async(): Promise<void> => {
+    await expect(store.getSetting(id, ACCOUNT_SETTINGS_REMEMBER_LOGIN)).resolves.toBe(true);
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.get).toHaveBeenLastCalledWith(ACCOUNT_TYPE, id);
+  });
+
+  it('returns undefined if the accountId is invalid.', async(): Promise<void> => {
+    storage.get.mockResolvedValueOnce(undefined);
+    await expect(store.getSetting(id, ACCOUNT_SETTINGS_REMEMBER_LOGIN)).resolves.toBeUndefined();
+    expect(storage.get).toHaveBeenCalledTimes(1);
+    expect(storage.get).toHaveBeenLastCalledWith(ACCOUNT_TYPE, id);
+  });
+
+  it('can set the settings.', async(): Promise<void> => {
+    await expect(store.updateSetting(id, ACCOUNT_SETTINGS_REMEMBER_LOGIN, true)).resolves.toBeUndefined();
+    expect(storage.setField).toHaveBeenCalledTimes(1);
+    expect(storage.setField).toHaveBeenLastCalledWith(ACCOUNT_TYPE, id, ACCOUNT_SETTINGS_REMEMBER_LOGIN, true);
+  });
+});


### PR DESCRIPTION
#### ✍️ Description

Does not change any functionality, but makes it easier for extensions to update the account setting types when necessary.
