### PR TITLE
chore: Update Components.js to v5.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "arrayify-stream": "^2.0.1",
         "async-lock": "^1.4.0",
         "bcryptjs": "^2.4.3",
-        "componentsjs": "^5.4.2",
+        "componentsjs": "^5.5.1",
         "cookie": "^0.7.0",
         "cors": "^2.8.5",
         "cross-fetch": "^4.0.0",
@@ -8029,9 +8029,10 @@
       "dev": true
     },
     "node_modules/componentsjs": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.4.2.tgz",
-      "integrity": "sha512-qIeXLozDkvubl6qtiovWsIBRqUP80w1ImTbilB6QE3OQgaEExI8pYZ9MkZ10QDFtdoKUryztlqp0AWs49t4puA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.5.1.tgz",
+      "integrity": "sha512-hmqq+ZUa98t9CoeWPGwE14I18aXQFAt66HRd8DaZCNggcSr82vhlyrjeXX0JAUMgr2MyQzwKstkv4INRAREguA==",
+      "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",
@@ -8050,9 +8051,6 @@
       },
       "bin": {
         "componentsjs-compile-config": "bin/compile-config.js"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/componentsjs-generator": {
@@ -23489,9 +23487,9 @@
       "dev": true
     },
     "componentsjs": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.4.2.tgz",
-      "integrity": "sha512-qIeXLozDkvubl6qtiovWsIBRqUP80w1ImTbilB6QE3OQgaEExI8pYZ9MkZ10QDFtdoKUryztlqp0AWs49t4puA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/componentsjs/-/componentsjs-5.5.1.tgz",
+      "integrity": "sha512-hmqq+ZUa98t9CoeWPGwE14I18aXQFAt66HRd8DaZCNggcSr82vhlyrjeXX0JAUMgr2MyQzwKstkv4INRAREguA==",
       "requires": {
         "@rdfjs/types": "*",
         "@types/minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "arrayify-stream": "^2.0.1",
     "async-lock": "^1.4.0",
     "bcryptjs": "^2.4.3",
-    "componentsjs": "^5.4.2",
+    "componentsjs": "^5.5.1",
     "cookie": "^0.7.0",
     "cors": "^2.8.5",
     "cross-fetch": "^4.0.0",


### PR DESCRIPTION
#### ✍️ Description

Not immediately necessary, but users were running into issues where they used the CSS components.js dependency and tried using features that were only added in v5.5.0. This prevents those issues.
