### PR TITLE
feat: URL client id for client credentials

### DIFF
--- a/config/identity/handler/base/adapter-factory.json
+++ b/config/identity/handler/base/adapter-factory.json
@@ -4,12 +4,12 @@
     {
       "comment": "An adapter is responsible for storing all interaction metadata.",
       "@id": "urn:solid-server:default:IdpAdapterFactory",
-      "@type": "ClientCredentialsAdapterFactory",
-      "webIdStore": { "@id": "urn:solid-server:default:WebIdStore" },
-      "clientCredentialsStore": { "@id": "urn:solid-server:default:ClientCredentialsStore" },
+      "@type": "ClientIdAdapterFactory",
+      "converter": { "@id": "urn:solid-server:default:RepresentationConverter" },
       "source": {
-        "@type": "ClientIdAdapterFactory",
-        "converter": { "@id": "urn:solid-server:default:RepresentationConverter" },
+        "@type": "ClientCredentialsAdapterFactory",
+        "webIdStore": { "@id": "urn:solid-server:default:WebIdStore" },
+        "clientCredentialsStore": { "@id": "urn:solid-server:default:ClientCredentialsStore" },
         "source": {
           "@type": "ExpiringAdapterFactory",
           "storage": {

--- a/src/identity/interaction/client-credentials/CreateClientCredentialsHandler.ts
+++ b/src/identity/interaction/client-credentials/CreateClientCredentialsHandler.ts
@@ -68,9 +68,7 @@ export class CreateClientCredentialsHandler extends JsonInteractionHandler<OutTy
       throw new ConflictHttpError('Token with this name already exists.');
     }
 
-    // ?? will pass empty string through
-    // eslint-disable-next-line ts/prefer-nullish-coalescing
-    const label = name || v4();
+    const label = name && name.length > 0 ? name : v4();
 
     const { secret, id } = await this.clientCredentialsStore.create(label, webId, accountId);
     const resource = this.clientCredentialsRoute.getPath({ accountId, clientCredentialsId: id });

--- a/templates/identity/account/create-client-credentials.html.ejs
+++ b/templates/identity/account/create-client-credentials.html.ejs
@@ -13,7 +13,9 @@
     <ol id="webIdList">
     </ol>
   </fieldset>
-
+  <div class="hidden" id="response-error">
+    <p class="error"></p>
+  </div>
   <ul class="actions">
     <li><button type="submit" name="submit" disabled>Create token</button></li>
     <li><button type="button" id="account-link">Back</button></li>
@@ -66,11 +68,15 @@
     }
 
     addPostListener(async() => {
-      const { id, secret } = await postJsonForm(controls.account.clientCredentials);
-      updateElement('token-id', id, { innerText: true });
-      updateElement('token-secret', secret, { innerText: true });
-      setVisibility('response', true);
-      setVisibility('mainForm', false);
+      try {
+        const { id, secret } = await postJsonForm(controls.account.clientCredentials);
+        updateElement('token-id', id, { innerText: true });
+        updateElement('token-secret', secret, { innerText: true });
+        setVisibility('response', true);
+        setVisibility('mainForm', false);
+      } catch (err) {
+        setError(err.message, 'response-error')
+      }
     });
   })();
 </script>

--- a/test/deploy/createAccountCredentials.ts
+++ b/test/deploy/createAccountCredentials.ts
@@ -94,7 +94,7 @@ async function createCredentials(webId: string, authorization: string): Promise<
   res = await fetch(controls.account.clientCredentials, {
     method: 'POST',
     headers: { authorization, 'content-type': 'application/json' },
-    body: JSON.stringify({ name: 'token', webId }),
+    body: JSON.stringify({ webId }),
   });
   if (res.status !== 200) {
     throw new Error(`Token generation failed: ${await res.text()}`);


### PR DESCRIPTION
#### 📁 Related issues

<!--
Reference any relevant issues here. Closing keywords only have an effect when targeting the main branch. If there are no related issues, you must first create an issue through https://github.com/CommunitySolidServer/CommunitySolidServer/issues/new/choose
-->

#### ✍️ Description

<!-- Describe the relevant changes in this PR. Also add notes that might be relevant for code reviewers. -->

It allows to use URL as client_id when creating a client credential.
I only uses uuid if no name was provided
If there is an existing credential with provided name it responds with an error - is that a breaking change?
This approach makes sense to me, if one doesn't care about specific name they can just leave it out and get random uuid.
I had to change order of OIDC adapters to try registered client credential before fetching client id
TBH I'm not sure if this is a new feature or a fix or major

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
