### PR TITLE
grant-type:jwt-bearer similar to client credentials but with proper support for URL client_id

### DIFF
--- a/config/identity/handler/base/provider-factory.json
+++ b/config/identity/handler/base/provider-factory.json
@@ -26,6 +26,11 @@
       "showStackTrace": { "@id": "urn:solid-server:default:variable:showStackTrace" },
       "errorHandler": { "@id": "urn:solid-server:default:ErrorHandler" },
       "responseWriter": { "@id": "urn:solid-server:default:ResponseWriter" },
+      "jwtAssertionsGrantHandler": {
+        "@id": "urn:solid-server:default:JwtAssertionsGrantHandler",
+        "@type": "JwtAssertionsGrantHandler",
+        "jwkGenerator": { "@id": "urn:solid-server:default:JwkGenerator" }
+      },
       "interactionRoute": { "@id": "urn:solid-server:default:IndexRoute" },
       "config": {
         "claims": {

--- a/config/identity/handler/default.json
+++ b/config/identity/handler/default.json
@@ -7,6 +7,7 @@
 
     "css:config/identity/handler/enable/account.json",
     "css:config/identity/handler/enable/client-credentials.json",
+    "css:config/identity/handler/enable/jwt-assertions.json",
     "css:config/identity/handler/enable/password.json",
     "css:config/identity/handler/enable/pod.json",
     "css:config/identity/handler/enable/webid.json"

--- a/config/identity/handler/enable/jwt-assertions.json
+++ b/config/identity/handler/enable/jwt-assertions.json
@@ -1,0 +1,43 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Enable JWT assertions creation."
+    },
+    {
+      "@id": "urn:solid-server:default:InteractionRouteHandler",
+      "@type": "WaterfallHandler",
+      "handlers": [{ "@id": "urn:solid-server:default:AccountJwtAssertionsRouter" }]
+    },
+
+    {
+      "@id": "urn:solid-server:default:AccountControlHandler",
+      "@type": "ControlHandler",
+      "controls": [{
+        "ControlHandler:_controls_key": "jwtAssertions",
+        "ControlHandler:_controls_value": { "@id": "urn:solid-server:default:AccountJwtAssertionsRoute" }
+      }]
+    },
+
+    {
+      "@id": "urn:solid-server:default:HtmlViewHandler",
+      "@type": "HtmlViewHandler",
+      "templates": [{
+        "@id": "urn:solid-server:default:CreateJwtAssertionsHtml",
+        "@type": "HtmlViewEntry",
+        "filePath": "@css:templates/identity/account/create-jwt-assertions.html.ejs",
+        "route": { "@id": "urn:solid-server:default:AccountJwtAssertionsRoute" }
+      }]
+    },
+    {
+      "ControlHandler:_controls_value": {
+        "@id": "urn:solid-server:default:AccountHtmlControlHandler",
+        "@type": "ControlHandler",
+        "controls": [{
+          "ControlHandler:_controls_key": "createJwtAssertions",
+          "ControlHandler:_controls_value": { "@id": "urn:solid-server:default:AccountJwtAssertionsRoute" }
+        }]
+      }
+    }
+  ]
+}

--- a/config/identity/handler/routing/default.json
+++ b/config/identity/handler/routing/default.json
@@ -4,6 +4,8 @@
     "css:config/identity/handler/routing/account/main.json",
     "css:config/identity/handler/routing/client-credentials/create.json",
     "css:config/identity/handler/routing/client-credentials/resource.json",
+    "css:config/identity/handler/routing/jwt-assertions/create.json",
+    "css:config/identity/handler/routing/jwt-assertions/resource.json",
     "css:config/identity/handler/routing/core/main.json",
     "css:config/identity/handler/routing/oidc/main.json",
     "css:config/identity/handler/routing/password/main.json",

--- a/config/identity/handler/routing/jwt-assertions/create.json
+++ b/config/identity/handler/routing/jwt-assertions/create.json
@@ -1,0 +1,27 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Handles JWT assertions. These can be used to automate clients. See documentation for more info.",
+      "@id": "urn:solid-server:default:AccountJwtAssertionsRouter",
+      "@type": "AuthorizedRouteHandler",
+      "route": {
+        "@id": "urn:solid-server:default:AccountJwtAssertionsRoute",
+        "@type": "RelativePathInteractionRoute",
+        "base": { "@id": "urn:solid-server:default:AccountIdRoute" },
+        "relativePath": "jwt-assertions/"
+      },
+      "source": {
+        "@type": "ViewInteractionHandler",
+        "source": {
+          "@id": "urn:solid-server:default:CreateJwtAssertionsHandler",
+          "@type": "CreateJwtAssertionsHandler",
+          "webIdStore": { "@id": "urn:solid-server:default:WebIdStore" },
+          "jwtAssertionsStore": { "@id": "urn:solid-server:default:JwtAssertionsStore" },
+          "jwtAssertionsRoute": { "@id": "urn:solid-server:default:AccountJwtAssertionsIdRoute" },
+          "jwkGenerator": { "@id": "urn:solid-server:default:JwkGenerator" }
+        }
+      }
+    }
+  ]
+}

--- a/config/identity/handler/routing/jwt-assertions/resource.json
+++ b/config/identity/handler/routing/jwt-assertions/resource.json
@@ -1,0 +1,45 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Handles the JWT assertions link details such as deletion.",
+      "@id": "urn:solid-server:default:AccountJwtAssertionsIdRouter",
+      "@type": "AuthorizedRouteHandler",
+      "route": {
+        "@id": "urn:solid-server:default:AccountJwtAssertionsIdRoute",
+        "@type": "BaseJwtAssertionsIdRoute",
+        "base": { "@id": "urn:solid-server:default:AccountJwtAssertionsRoute" }
+      },
+      "source": {
+        "@id": "urn:solid-server:default:JwtAssertionsResourceHandler",
+        "@type": "WaterfallHandler",
+        "handlers": [
+          {
+            "@type": "MethodFilterHandler",
+            "methods": [ "GET" ],
+            "source": {
+              "@type": "JwtAssertionsDetailsHandler",
+              "jwtAssertionsRoute": { "@id": "urn:solid-server:default:AccountJwtAssertionsIdRoute" },
+              "jwtAssertionsStore": { "@id": "urn:solid-server:default:JwtAssertionsStore" }
+            }
+          },
+          {
+            "@type": "MethodFilterHandler",
+            "methods": [ "DELETE" ],
+            "source": {
+              "@type": "DeleteJwtAssertionsHandler",
+              "jwtAssertionsRoute": { "@id": "urn:solid-server:default:AccountJwtAssertionsIdRoute" },
+              "jwtAssertionsStore": { "@id": "urn:solid-server:default:JwtAssertionsStore" }
+            }
+          }
+        ]
+      }
+    },
+
+    {
+      "@id": "urn:solid-server:default:InteractionRouteHandler",
+      "@type": "WaterfallHandler",
+      "handlers": [{ "@id": "urn:solid-server:default:AccountClientCredentialsIdRouter" }]
+    }
+  ]
+}

--- a/config/identity/handler/storage/default.json
+++ b/config/identity/handler/storage/default.json
@@ -60,12 +60,19 @@
     },
 
     {
+      "@id": "urn:solid-server:default:JwtAssertionsStore",
+      "@type": "BaseJwtAssertionsStore",
+      "storage": { "@id": "urn:solid-server:default:AccountStorage" }
+    },
+
+    {
       "comment": "Initialize all the stores. Also necessary on primary thread for pod seeding.",
       "@id": "urn:solid-server:default:PrimaryParallelInitializer",
       "@type": "ParallelHandler",
       "handlers": [
         { "@id": "urn:solid-server:default:AccountStore" },
         { "@id": "urn:solid-server:default:ClientCredentialsStore" },
+        { "@id": "urn:solid-server:default:JwtAssertionsStore" },
         { "@id": "urn:solid-server:default:PodStore" },
         { "@id": "urn:solid-server:default:WebIdStore" }
       ]
@@ -77,6 +84,7 @@
       "handlers": [
         { "@id": "urn:solid-server:default:AccountStore" },
         { "@id": "urn:solid-server:default:ClientCredentialsStore" },
+        { "@id": "urn:solid-server:default:JwtAssertionsStore" },
         { "@id": "urn:solid-server:default:PodStore" },
         { "@id": "urn:solid-server:default:WebIdStore" }
       ]

--- a/src/identity/IdentityUtil.ts
+++ b/src/identity/IdentityUtil.ts
@@ -16,3 +16,19 @@ export function importOidcProvider(): CanBePromise<typeof import('../../template
   }
   return import('oidc-provider');
 }
+
+export function importDpopValidate(): CanBePromise<any> {
+  if (process.env.JEST_WORKER_ID ?? process.env.NODE_ENV === 'test') {
+    return jest.requireActual('oidc-provider/lib/helpers/validate_dpop.js');
+  }
+  // @ts-expect-error
+  return import('oidc-provider/lib/helpers/validate_dpop.js');
+}
+
+export function importCheckResource(): CanBePromise<any> {
+  if (process.env.JEST_WORKER_ID ?? process.env.NODE_ENV === 'test') {
+    return jest.requireActual('oidc-provider/lib/shared/check_resource.js');
+  }
+  // @ts-expect-error
+  return import('oidc-provider/lib/shared/check_resource.js');
+}

--- a/src/identity/configuration/JwtAssertionsGrantHandler.ts
+++ b/src/identity/configuration/JwtAssertionsGrantHandler.ts
@@ -1,0 +1,73 @@
+import { importJWK, jwtVerify } from 'jose';
+import type {
+  KoaContextWithOIDC,
+} from '../../../templates/types/oidc-provider';
+import { importCheckResource, importDpopValidate } from '../IdentityUtil';
+import type { JwkGenerator } from './JwkGenerator';
+
+const epochTime = (date = Date.now()) => Math.floor(date / 1000);
+
+export class JwtAssertionsGrantHandler {
+  public constructor(
+    private readonly jwkGenerator: JwkGenerator,
+  ) {}
+
+  public parameters = [
+    'client_id',
+    'scope',
+    'assertion',
+  ];
+
+  public grantType = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+
+  public async handler(ctx: KoaContextWithOIDC) {
+    const { ClientCredentials, ReplayDetection } = ctx.oidc.provider;
+    const { client } = ctx.oidc;
+
+    // Validate DPoP
+    const dpopValidate = await importDpopValidate().default;
+    const dPoP = await dpopValidate(ctx);
+    // TODO
+    // const unique = await ReplayDetection.unique(client!.clientId, dPoP.jti, epochTime() + 300);
+    // ctx.assert(unique, new InvalidGrant('DPoP proof JWT Replay detected'));
+    //
+    const checkResource = await importCheckResource().default;
+    await checkResource(ctx, () => {});
+
+    // Validate assertion
+    const assertion = ctx.oidc.params?.assertion;
+    if (!assertion) {
+      // TODO: set correct error resonse
+      return;
+    }
+    const publicKey = await this.jwkGenerator.getPublicKey();
+    const publicKeyObject = await importJWK(publicKey);
+
+    // TODO: better handling of failure
+    const assertedData = await jwtVerify(assertion as string, publicKeyObject);
+
+    // Issue access_token
+    const claims = {
+      client: client!,
+      scope: 'webid',
+      extra: {
+        webid: assertedData.payload.agent,
+      },
+    };
+    const token = new ClientCredentials(claims);
+
+    // @ts-expect-error
+    token.setThumbprint('jkt', dPoP.thumbprint);
+    token.resourceServer = Object.values(ctx.oidc.resourceServers!)[0];
+
+    ctx.oidc.entity('ClientCredentials', token);
+    const value = await token.save();
+
+    ctx.body = {
+      access_token: value,
+      expires_in: token.expiration,
+      token_type: token.tokenType,
+      scope: token.scope || undefined,
+    };
+  }
+}

--- a/src/identity/interaction/jwt-assertions/CreateJwtAssertionsHandler.ts
+++ b/src/identity/interaction/jwt-assertions/CreateJwtAssertionsHandler.ts
@@ -1,0 +1,96 @@
+import { v4 } from 'uuid';
+import { object, string } from 'yup';
+import { importJWK, SignJWT } from 'jose';
+import { getLoggerFor } from '../../../logging/LogUtil';
+import { BadRequestHttpError } from '../../../util/errors/BadRequestHttpError';
+import { sanitizeUrlPart } from '../../../util/StringUtil';
+import { assertAccountId } from '../account/util/AccountUtil';
+import type { JsonRepresentation } from '../InteractionUtil';
+import { JsonInteractionHandler } from '../JsonInteractionHandler';
+import type { JsonInteractionHandlerInput } from '../JsonInteractionHandler';
+import type { JsonView } from '../JsonView';
+import type { WebIdStore } from '../webid/util/WebIdStore';
+import { parseSchema, validateWithError } from '../YupUtil';
+import type { JwtAssertionsIdRoute } from './util/JwtAssertionsIdRoute';
+import type { JwtAssertionsStore } from './util/JwtAssertionsStore';
+import type { JwkGenerator } from '../../../identity/configuration/JwkGenerator';
+
+const inSchema = object({
+  clientId: string().trim().required(),
+  webId: string().trim().required(),
+});
+
+type OutType = {
+  assertion: string;
+};
+
+/**
+ * Handles the creation of JWT assertions.
+ */
+export class CreateJwtAssertionsHandler extends JsonInteractionHandler<OutType> implements JsonView {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly webIdStore: WebIdStore;
+  private readonly jwtAssertionsStore: JwtAssertionsStore;
+  private readonly jwtAssertionsRoute: JwtAssertionsIdRoute;
+  private readonly jwkGenerator: JwkGenerator;
+
+  public constructor(
+    webIdStore: WebIdStore,
+    jwtAssertionsStore: JwtAssertionsStore,
+    jwtAssertionsRoute: JwtAssertionsIdRoute,
+    jwkGenerator: JwkGenerator,
+  ) {
+    super();
+    this.webIdStore = webIdStore;
+    this.jwtAssertionsStore = jwtAssertionsStore;
+    this.jwtAssertionsRoute = jwtAssertionsRoute;
+    this.jwkGenerator = jwkGenerator;
+  }
+
+  public async getView({ accountId }: JsonInteractionHandlerInput): Promise<JsonRepresentation> {
+    assertAccountId(accountId);
+    const jwtAssertions: Record<string, string> = {};
+    for (const { id, client: label } of await this.jwtAssertionsStore.findByAccount(accountId)) {
+      jwtAssertions[label] = this.jwtAssertionsRoute.getPath({ accountId, jwtAssertionsId: id });
+    }
+    return { json: { ...parseSchema(inSchema), jwtAssertions }};
+  }
+
+  public async handle({ accountId, json }: JsonInteractionHandlerInput): Promise<JsonRepresentation<OutType>> {
+    assertAccountId(accountId);
+
+    const { clientId, webId } = await validateWithError(inSchema, json);
+
+    if (!await this.webIdStore.isLinked(webId, accountId)) {
+      this.logger.warn(`Trying to create assertion for ${webId} which does not belong to account ${accountId}`);
+      throw new BadRequestHttpError('WebID does not belong to this account.');
+    }
+
+    const privateKey = await this.jwkGenerator.getPrivateKey();
+
+    const privateKeyObject = await importJWK(privateKey);
+
+    // Make sure both header and proof have the same timestamp
+    const time = Date.now();
+
+    // Currently the spec does not define how the notification sender should identify.
+    // The format used here has been chosen to be similar
+    // to how ID tokens are described in the Solid-OIDC specification for consistency.
+    const assertion = await new SignJWT({
+      client: clientId,
+      agent: webId,
+    }).setProtectedHeader({ alg: privateKey.alg })
+      .setIssuedAt(time)
+      //.setExpirationTime(time + duration)
+      //.setAudience('token endpoint')
+      .setJti(v4())
+      .sign(privateKeyObject);
+
+    const { id } = await this.jwtAssertionsStore.create(clientId!, webId, accountId);
+
+    // Exposing the field as `id` as that is how we originally defined the client credentials API
+    // and is more consistent with how the field names are explained in other places
+    return { json: { assertion }};
+  }
+}

--- a/src/identity/interaction/jwt-assertions/CreateJwtAssertionsHandler.ts
+++ b/src/identity/interaction/jwt-assertions/CreateJwtAssertionsHandler.ts
@@ -3,7 +3,6 @@ import { object, string } from 'yup';
 import { importJWK, SignJWT } from 'jose';
 import { getLoggerFor } from '../../../logging/LogUtil';
 import { BadRequestHttpError } from '../../../util/errors/BadRequestHttpError';
-import { sanitizeUrlPart } from '../../../util/StringUtil';
 import { assertAccountId } from '../account/util/AccountUtil';
 import type { JsonRepresentation } from '../InteractionUtil';
 import { JsonInteractionHandler } from '../JsonInteractionHandler';
@@ -11,9 +10,9 @@ import type { JsonInteractionHandlerInput } from '../JsonInteractionHandler';
 import type { JsonView } from '../JsonView';
 import type { WebIdStore } from '../webid/util/WebIdStore';
 import { parseSchema, validateWithError } from '../YupUtil';
+import type { JwkGenerator } from '../../../identity/configuration/JwkGenerator';
 import type { JwtAssertionsIdRoute } from './util/JwtAssertionsIdRoute';
 import type { JwtAssertionsStore } from './util/JwtAssertionsStore';
-import type { JwkGenerator } from '../../../identity/configuration/JwkGenerator';
 
 const inSchema = object({
   clientId: string().trim().required(),
@@ -82,12 +81,12 @@ export class CreateJwtAssertionsHandler extends JsonInteractionHandler<OutType> 
       agent: webId,
     }).setProtectedHeader({ alg: privateKey.alg })
       .setIssuedAt(time)
-      //.setExpirationTime(time + duration)
-      //.setAudience('token endpoint')
+      // .setExpirationTime(time + duration)
+      // .setAudience('token endpoint')
       .setJti(v4())
       .sign(privateKeyObject);
 
-    const { id } = await this.jwtAssertionsStore.create(clientId!, webId, accountId);
+    const { id } = await this.jwtAssertionsStore.create(clientId, webId, accountId);
 
     // Exposing the field as `id` as that is how we originally defined the client credentials API
     // and is more consistent with how the field names are explained in other places

--- a/src/identity/interaction/jwt-assertions/DeleteJwtAssertionsHandler.ts
+++ b/src/identity/interaction/jwt-assertions/DeleteJwtAssertionsHandler.ts
@@ -1,0 +1,32 @@
+import type { EmptyObject } from '../../../util/map/MapUtil';
+import { parsePath, verifyAccountId } from '../account/util/AccountUtil';
+import type { JsonRepresentation } from '../InteractionUtil';
+import type { JsonInteractionHandlerInput } from '../JsonInteractionHandler';
+import { JsonInteractionHandler } from '../JsonInteractionHandler';
+import type { JwtAssertionsIdRoute } from './util/JwtAssertionsIdRoute';
+import type { JwtAssertionsStore } from './util/JwtAssertionsStore';
+
+/**
+ * Handles the deletion of JWT assertions.
+ */
+export class DeleteJwtAssertionsHandler extends JsonInteractionHandler<EmptyObject> {
+  private readonly jwtAssertionsStore: JwtAssertionsStore;
+  private readonly jwtAssertionsRoute: JwtAssertionsIdRoute;
+
+  public constructor(jwtAssertionsStore: JwtAssertionsStore, jwtAssertionsRoute: JwtAssertionsIdRoute) {
+    super();
+    this.jwtAssertionsStore = jwtAssertionsStore;
+    this.jwtAssertionsRoute = jwtAssertionsRoute;
+  }
+
+  public async handle({ target, accountId }: JsonInteractionHandlerInput): Promise<JsonRepresentation<EmptyObject>> {
+    const match = parsePath(this.jwtAssertionsRoute, target.path);
+
+    const credentials = await this.jwtAssertionsStore.get(match.jwtAssertionsId);
+    verifyAccountId(accountId, credentials?.accountId);
+
+    await this.jwtAssertionsStore.delete(match.jwtAssertionsId);
+
+    return { json: {}};
+  }
+}

--- a/src/identity/interaction/jwt-assertions/JwtAssertionsDetailsHandler.ts
+++ b/src/identity/interaction/jwt-assertions/JwtAssertionsDetailsHandler.ts
@@ -1,0 +1,40 @@
+import { getLoggerFor } from '../../../logging/LogUtil';
+import { parsePath, verifyAccountId } from '../account/util/AccountUtil';
+import type { JsonRepresentation } from '../InteractionUtil';
+import type { JsonInteractionHandlerInput } from '../JsonInteractionHandler';
+import { JsonInteractionHandler } from '../JsonInteractionHandler';
+import type { JwtAssertionsIdRoute } from './util/JwtAssertionsIdRoute';
+import type { JwtAssertionsStore } from './util/JwtAssertionsStore';
+
+type OutType = {
+  id: string;
+  webId: string;
+};
+
+/**
+ * Provides a view on a client credentials token, indicating the token identifier and its associated WebID.
+ */
+export class JwtAssertionsDetailsHandler extends JsonInteractionHandler<OutType> {
+  protected readonly logger = getLoggerFor(this);
+
+  private readonly jwtAssertionsStore: JwtAssertionsStore;
+  private readonly jwtAssertionsRoute: JwtAssertionsIdRoute;
+
+  public constructor(jwtAssertionsStore: JwtAssertionsStore, jwtAssertionsRoute: JwtAssertionsIdRoute) {
+    super();
+    this.jwtAssertionsStore = jwtAssertionsStore;
+    this.jwtAssertionsRoute = jwtAssertionsRoute;
+  }
+
+  public async handle({ target, accountId }: JsonInteractionHandlerInput): Promise<JsonRepresentation<OutType>> {
+    const match = parsePath(this.jwtAssertionsRoute, target.path);
+
+    const credentials = await this.jwtAssertionsStore.get(match.jwtAssertionsId);
+    verifyAccountId(accountId, credentials?.accountId);
+
+    return { json: {
+      id: credentials.client,
+      webId: credentials.agent,
+    }};
+  }
+}

--- a/src/identity/interaction/jwt-assertions/util/BaseJwtAssertionsStore.ts
+++ b/src/identity/interaction/jwt-assertions/util/BaseJwtAssertionsStore.ts
@@ -1,0 +1,84 @@
+import { randomBytes } from 'node:crypto';
+import { Initializer } from '../../../../init/Initializer';
+import { getLoggerFor } from '../../../../logging/LogUtil';
+import { createErrorMessage } from '../../../../util/errors/ErrorUtil';
+import { InternalServerError } from '../../../../util/errors/InternalServerError';
+import { ACCOUNT_TYPE } from '../../account/util/LoginStorage';
+import type { AccountLoginStorage } from '../../account/util/LoginStorage';
+import type { JwtAssertion, JwtAssertionsStore } from './JwtAssertionsStore';
+
+export const JWT_ASSERTIONS_STORAGE_TYPE = 'jwtAssertions';
+export const JWT_ASSERTIONS_STORAGE_DESCRIPTION = {
+  client: 'string',
+  agent: 'string',
+  accountId: `id:${ACCOUNT_TYPE}`,
+} as const;
+
+/**
+ * A {@link JwtAssertionsStore} that uses a {@link AccountLoginStorage} for storing the tokens.
+ * Needs to be initialized before it can be used.
+ */
+export class BaseJwtAssertionsStore extends Initializer implements JwtAssertionsStore {
+  private readonly logger = getLoggerFor(this);
+
+  private readonly storage: AccountLoginStorage<{ [JWT_ASSERTIONS_STORAGE_TYPE]:
+      typeof JWT_ASSERTIONS_STORAGE_DESCRIPTION; }>;
+
+  private initialized = false;
+
+  // Wrong typings to prevent Components.js typing issues
+  public constructor(storage: AccountLoginStorage<Record<string, never>>) {
+    super();
+    this.storage = storage as unknown as typeof this.storage;
+  }
+
+  // Initialize the type definitions
+  public async handle(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+    try {
+      await this.storage.defineType(JWT_ASSERTIONS_STORAGE_TYPE, JWT_ASSERTIONS_STORAGE_DESCRIPTION, false);
+      await this.storage.createIndex(JWT_ASSERTIONS_STORAGE_TYPE, 'client');
+      await this.storage.createIndex(JWT_ASSERTIONS_STORAGE_TYPE, 'agent');
+      await this.storage.createIndex(JWT_ASSERTIONS_STORAGE_TYPE, 'accountId');
+      this.initialized = true;
+    } catch (cause: unknown) {
+      throw new InternalServerError(
+        `Error defining client credentials in storage: ${createErrorMessage(cause)}`,
+        { cause },
+      );
+    }
+  }
+
+  public async get(id: string): Promise<JwtAssertion | undefined> {
+    return this.storage.get(JWT_ASSERTIONS_STORAGE_TYPE, id);
+  }
+
+  public async findByLabel(label: string): Promise<JwtAssertion | undefined> {
+    const result = await this.storage.find(JWT_ASSERTIONS_STORAGE_TYPE, { client: label });
+    if (result.length === 0) {
+      return;
+    }
+    return result[0];
+  }
+
+  public async findByAccount(accountId: string): Promise<JwtAssertion[]> {
+    return this.storage.find(JWT_ASSERTIONS_STORAGE_TYPE, { accountId });
+  }
+
+  public async create(label: string, webId: string, accountId: string): Promise<JwtAssertion> {
+    const secret = randomBytes(64).toString('hex');
+
+    this.logger.debug(
+      `Creating client credentials token with label ${label} for WebID ${webId} and account ${accountId}`,
+    );
+
+    return this.storage.create(JWT_ASSERTIONS_STORAGE_TYPE, { accountId, client: label, agent: webId });
+  }
+
+  public async delete(id: string): Promise<void> {
+    this.logger.debug(`Deleting client credentials token with ID ${id}`);
+    return this.storage.delete(JWT_ASSERTIONS_STORAGE_TYPE, id);
+  }
+}

--- a/src/identity/interaction/jwt-assertions/util/JwtAssertionsIdRoute.ts
+++ b/src/identity/interaction/jwt-assertions/util/JwtAssertionsIdRoute.ts
@@ -1,0 +1,20 @@
+import type { AccountIdKey, AccountIdRoute } from '../../account/AccountIdRoute';
+import { IdInteractionRoute } from '../../routing/IdInteractionRoute';
+import type { ExtendedRoute } from '../../routing/InteractionRoute';
+
+export type AssertionsIdKey = 'jwtAssertionsId';
+
+/**
+ * An {@link AccountIdRoute} that also includes a credentials identifier.
+ */
+export type JwtAssertionsIdRoute = ExtendedRoute<AccountIdRoute, AssertionsIdKey>;
+
+/**
+ * Implementation of an {@link JwtAssertionsIdRoute}
+ * that adds the identifier relative to a base {@link AccountIdRoute}.
+ */
+export class BaseJwtAssertionsIdRoute extends IdInteractionRoute<AccountIdKey, AssertionsIdKey> {
+  public constructor(base: AccountIdRoute) {
+    super(base, 'jwtAssertionsId');
+  }
+}

--- a/src/identity/interaction/jwt-assertions/util/JwtAssertionsStore.ts
+++ b/src/identity/interaction/jwt-assertions/util/JwtAssertionsStore.ts
@@ -1,0 +1,48 @@
+export interface JwtAssertion {
+  id: string;
+  client: string;
+  agent: string;
+  accountId: string;
+}
+
+/**
+ * Stores and creates {@link JwtAssertion}.
+ */
+export interface JwtAssertionsStore {
+  /**
+   * Find the {@link JwtAssertions} with the given ID.
+   *
+   * @param id - ID of the token.
+   */
+  get: (id: string) => Promise<JwtAssertion | undefined>;
+
+  /**
+   * Find the {@link JwtAssertions} with the given label.
+   *
+   * @param label - Label of the token.
+   */
+  findByLabel: (label: string) => Promise<JwtAssertion | undefined>;
+
+  /**
+   * Find all tokens created by the given account.
+   *
+   * @param accountId - ID of the account.
+   */
+  findByAccount: (accountId: string) => Promise<JwtAssertion[]>;
+
+  /**
+   * Creates new token.
+   *
+   * @param label - Identifier to use for the new token.
+   * @param webId - WebID to identify as when using this token.
+   * @param account - Account that is associated with this token.
+   */
+  create: (label: string, webId: string, accountId: string) => Promise<JwtAssertion>;
+
+  /**
+   * Deletes the token with the given ID.
+   *
+   * @param id - ID of the token.
+   */
+  delete: (id: string) => Promise<void>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,17 @@ export * from './identity/interaction/client-credentials/ClientCredentialsDetail
 export * from './identity/interaction/client-credentials/CreateClientCredentialsHandler';
 export * from './identity/interaction/client-credentials/DeleteClientCredentialsHandler';
 
+// Identity/Interaction/JWT-Assertions/Util
+export * from './identity/interaction/jwt-assertions/util/BaseJwtAssertionsStore';
+export * from './identity/interaction/jwt-assertions/util/JwtAssertionsIdRoute';
+export * from './identity/interaction/jwt-assertions/util/JwtAssertionsStore';
+
+// Identity/Interaction/JWT-Assertions
+// export * from './identity/interaction/jwt-assertions/JwtAssertionsAdapterFactory';
+export * from './identity/interaction/jwt-assertions/JwtAssertionsDetailsHandler';
+export * from './identity/interaction/jwt-assertions/CreateJwtAssertionsHandler';
+export * from './identity/interaction/jwt-assertions/DeleteJwtAssertionsHandler';
+
 // Identity/Interaction/Login
 export * from './identity/interaction/login/LogoutHandler';
 export * from './identity/interaction/login/ResolveLoginHandler';

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,10 +180,12 @@ export * from './identity/interaction/jwt-assertions/util/JwtAssertionsIdRoute';
 export * from './identity/interaction/jwt-assertions/util/JwtAssertionsStore';
 
 // Identity/Interaction/JWT-Assertions
-// export * from './identity/interaction/jwt-assertions/JwtAssertionsAdapterFactory';
 export * from './identity/interaction/jwt-assertions/JwtAssertionsDetailsHandler';
 export * from './identity/interaction/jwt-assertions/CreateJwtAssertionsHandler';
 export * from './identity/interaction/jwt-assertions/DeleteJwtAssertionsHandler';
+
+// Identity/Configuration/JWT-Assertions
+export * from './identity/configuration/JwtAssertionsGrantHandler';
 
 // Identity/Interaction/Login
 export * from './identity/interaction/login/LogoutHandler';

--- a/templates/identity/account/create-jwt-assertions.html.ejs
+++ b/templates/identity/account/create-jwt-assertions.html.ejs
@@ -1,0 +1,76 @@
+<h1>Create client credentials token</h1>
+<form method="post" id="mainForm">
+  <p class="error" id="error"></p>
+
+  <fieldset>
+    <p>Choose a name and which WebID to associate with the token</p>
+    <ol>
+      <li>
+        <label for="name">Name</label>
+        <input id="name" type="text" name="name" autofocus>
+      </li>
+    </ol>
+    <ol id="webIdList">
+    </ol>
+  </fieldset>
+
+  <ul class="actions">
+    <li><button type="submit" name="submit" disabled>Create token</button></li>
+    <li><button type="button" id="account-link">Back</button></li>
+  </ul>
+</form>
+<div class="hidden" id="no-webId">
+  <p class="error">There are no WebIDs linked to this account.</p>
+  <p class="actions"><button type="button" id="error-account-link">Back</button></p>
+</div>
+<div class="hidden" id="response">
+  <p>
+    Make sure to store the secret somewhere as there is no way to retrieve it afterwards!
+  </p>
+  <p>
+    Token identifier: <strong id="token-id"></strong>
+  </p>
+  <p>
+    Token secret: <strong style="word-wrap:break-word;" id="token-secret"></strong>
+  </p>
+
+  <p class="actions"><button type="button" id="response-account-link">Back</button></p>
+</div>
+
+
+<script>
+  (async() => {
+    const controls = await fetchControls('<%= idpIndex %>');
+    const { webIdLinks } = await fetchJson(controls.account.webId, '<%= idpIndex %>');
+
+    setRedirectClick('account-link', controls.html.account.account);
+    setRedirectClick('error-account-link', controls.html.account.account);
+    setRedirectClick('response-account-link', controls.html.account.account);
+
+    const webIds = Object.keys(webIdLinks);
+    if (webIds.length === 0) {
+      setVisibility('no-webId', true);
+      setVisibility('mainForm', false);
+      return;
+    }
+
+    const { webIdList } = getElements('webIdList');
+    for (const webId of webIds) {
+      webIdList.insertAdjacentHTML('beforeend', `
+        <li class="radio">
+          <label for="${webId}">
+            <input id="${webId}" type="radio" name="webId" value="${webId}" ${webIds.length === 1 ? 'checked' : ''}>
+            ${webId}
+          </label>
+        </li>`);
+    }
+
+    addPostListener(async() => {
+      const { id, secret } = await postJsonForm(controls.account.clientCredentials);
+      updateElement('token-id', id, { innerText: true });
+      updateElement('token-secret', secret, { innerText: true });
+      setVisibility('response', true);
+      setVisibility('mainForm', false);
+    });
+  })();
+</script>


### PR DESCRIPTION
> [!WARNING]
> very early and rough draft, practically proof of concept

supersedes #2041 

## TODO
* [ ] JwtAssertionsStore currently isn't used so assertions can't be revoked

# CSS JWT assertions authn

[CSS supports client credentials](https://communitysolidserver.github.io/CommunitySolidServer/latest/usage/client-credentials/) which use a combintation of:
```
client_id
client_secret
```
and internally has those credentials associated with `webid` of the user which created them.
Current implementation doesn't support use of URL as `client_id`, I made a [PR with a naive quick fix](https://github.com/CommunitySolidServer/CommunitySolidServer/pull/2041). It would be very limited since with multiple tenants only one could register a client with any given URL.

[RFC7523: JSON Web Token (JWT) Profile for OAuth 2.0 Client Authentication and Authorization Grants](https://www.rfc-editor.org/rfc/rfc7523) defines `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` which can be used together with an `assertion` encoded as JWT.

This allows any user to issue a distinct assertion for the client with a given URL. And when `token` is requested based on that assertion OP will know which WebID to use as `webid` claim in a `token`.

## assertion

The `assertion` is issued by the OP as signed JWT
An example from `Identity.test.ts`

```ts
const grantType = 'urn:ietf:params:oauth:grant-type:jwt-bearer';

const res = await fetch(tokenUrl, {
  method: 'POST',
  headers: {
    'content-type': APPLICATION_X_WWW_FORM_URLENCODED,
    dpop: dpopHeader,
  },
  body: `grant_type=${grantType}&assertion=${assertion}&client_id=${clientId}&scope=webid`,
});
```

The assertion already includes `client_id` in `client` claim. It is used due to how `oidc-provider` package work. It might be possible to remove it in the future.

### current draft

When verified only the signature is checked so it doesn't need to be stored by the OP except for revocations (currently not checked)
An example logged from integration test in `Identity.test.ts`

```
eyJhbGciOiJFUzI1NiJ9.eyJjbGllbnQiOiJodHRwOi8vbG9jYWxob3N0OjYwMDkvY2xpZW50LWlkIiwiYWdlbnQiOiJodHRwOi8vbG9jYWxob3N0OjYwMDkvdGVzdC9wcm9maWxlL2NhcmQjbWUiLCJpYXQiOjE3NTUzODIzNzQ5MDAsImp0aSI6IjdiNjU5ODhlLTIzNDQtNDM2OC1hN2FiLTI1MDNjNGFiOGEzNCJ9.pB1oBT0YLnHbD_qu4VlpGy1WSgjgPs1fXOYIruu9YMH4bSdlJIFkrjOH7oz8grOAajXxhNiU0g_K3BREh4orQg
```

```json
{
  "client": "http://localhost:6009/client-id",
  "agent": "http://localhost:6009/test/profile/card#me",
  "iat": 1755382374900,
  "jti": "7b65988e-2344-4368-a7ab-2503c4ab8a34"
}
```

### planned

Sender constrained using client's public key 👇

## client authentication

### current draft

```
token_endpoint_auth_method: 'none'
```

Effectivelly the assertion acts as client secret (bearer)

### planned

```
token_endpoint_auth_method: 'private_key_jwt'
```

RFC7523 also defines `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` which has a separate JWT `client_assertion` which is created and signed by the client.

It would discover keys based on Client ID document.

> [!Note]
> This would be in lines of authenticating client based on `redirect_uris` in ClientID Document