### PR TITLE
chore(deps-dev): bump @inrupt/solid-client-authn-js from 2.0.0 to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,8 +87,8 @@
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
-        "@inrupt/solid-client-authn-core": "^2.0.0",
-        "@inrupt/solid-client-authn-node": "^2.0.0",
+        "@inrupt/solid-client-authn-core": "^3.1.0",
+        "@inrupt/solid-client-authn-node": "^3.1.0",
         "@swc/jest": "^0.2.39",
         "@tsconfig/node20": "^20.1.6",
         "@types/jest": "^30.0.0",
@@ -12249,32 +12249,62 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.0.0.tgz",
-      "integrity": "sha512-qM+E9I5u2DFlsfyoXossx8w0vKv8p+rXH98K9RUauJImpygQ3I3Ra6hSB2bwA1PdPQd5ttNg236oKe1sTT6Hqw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-3.1.0.tgz",
+      "integrity": "sha512-aoG8RvPBmYXTSqy2uJogpoVGPKsydC4mXNdm63BWCEMZ2QyaSRBjx4R4N6n5N2uy/aoib678Y7U3UtDCLDoFsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
         "jose": "^5.1.3",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.0"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0"
+        "node": "^20.0.0 || ^22.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-core/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-2.0.0.tgz",
-      "integrity": "sha512-S1vGRodX0MSAKR3B6tm4qUvMhGv0sMcFjYyhVil7isoRI/7ei5QTpm+081RTWe6/cv4WI6UiHER3YIG15uwhhg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-3.1.0.tgz",
+      "integrity": "sha512-kbjNkb3V85aamnPqKzUnu6DZxLovbwtAtekoeqYGIReASHLxdKq/TS+f+T2LUyMZ2G3m1a3rnB1TZtCYSF5mmw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^2.0.0",
+        "@inrupt/solid-client-authn-core": "^3.1.0",
         "jose": "^5.1.3",
-        "openid-client": "~5.6.1",
-        "uuid": "^9.0.1"
+        "openid-client": "^5.7.1",
+        "uuid": "^11.1.0"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0"
+        "node": "^20.0.0 || ^22.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client-authn-node/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -23717,6 +23747,7 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
@@ -23776,10 +23807,11 @@
       }
     },
     "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -23838,12 +23870,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
-      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jose": "^4.15.4",
+        "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
@@ -37165,26 +37198,42 @@
       "dev": true
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.0.0.tgz",
-      "integrity": "sha512-qM+E9I5u2DFlsfyoXossx8w0vKv8p+rXH98K9RUauJImpygQ3I3Ra6hSB2bwA1PdPQd5ttNg236oKe1sTT6Hqw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-3.1.0.tgz",
+      "integrity": "sha512-aoG8RvPBmYXTSqy2uJogpoVGPKsydC4mXNdm63BWCEMZ2QyaSRBjx4R4N6n5N2uy/aoib678Y7U3UtDCLDoFsQ==",
       "dev": true,
       "requires": {
         "events": "^3.3.0",
         "jose": "^5.1.3",
-        "uuid": "^9.0.1"
+        "uuid": "^11.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+          "dev": true
+        }
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-2.0.0.tgz",
-      "integrity": "sha512-S1vGRodX0MSAKR3B6tm4qUvMhGv0sMcFjYyhVil7isoRI/7ei5QTpm+081RTWe6/cv4WI6UiHER3YIG15uwhhg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-3.1.0.tgz",
+      "integrity": "sha512-kbjNkb3V85aamnPqKzUnu6DZxLovbwtAtekoeqYGIReASHLxdKq/TS+f+T2LUyMZ2G3m1a3rnB1TZtCYSF5mmw==",
       "dev": true,
       "requires": {
-        "@inrupt/solid-client-authn-core": "^2.0.0",
+        "@inrupt/solid-client-authn-core": "^3.1.0",
         "jose": "^5.1.3",
-        "openid-client": "~5.6.1",
-        "uuid": "^9.0.1"
+        "openid-client": "^5.7.1",
+        "uuid": "^11.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+          "dev": true
+        }
       }
     },
     "@ioredis/commands": {
@@ -45490,9 +45539,9 @@
       }
     },
     "oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
       "dev": true
     },
     "on-finished": {
@@ -45535,12 +45584,12 @@
       "dev": true
     },
     "openid-client": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
-      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "dev": true,
       "requires": {
-        "jose": "^4.15.4",
+        "jose": "^4.15.9",
         "lru-cache": "^6.0.0",
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -147,8 +147,8 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
-    "@inrupt/solid-client-authn-core": "^2.0.0",
-    "@inrupt/solid-client-authn-node": "^2.0.0",
+    "@inrupt/solid-client-authn-core": "^3.1.0",
+    "@inrupt/solid-client-authn-node": "^3.1.0",
     "@swc/jest": "^0.2.39",
     "@tsconfig/node20": "^20.1.6",
     "@types/jest": "^30.0.0",

--- a/test/integration/Identity.test.ts
+++ b/test/integration/Identity.test.ts
@@ -392,7 +392,7 @@ describe.each(stores)('A Solid server with IDP using %s', (name, { config, teard
     });
 
     it('can use the generated access token to do an authenticated call.', async(): Promise<void> => {
-      const authFetch = await buildAuthenticatedFetch(accessToken!, { dpopKey });
+      const authFetch = buildAuthenticatedFetch(accessToken!, { dpopKey });
       let res = await fetch(container);
       expect(res.status).toBe(401);
       res = await authFetch(container);


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/pull/2070 and https://github.com/CommunitySolidServer/CommunitySolidServer/pull/2068