### PR TITLE
fix: Include pim:storage in WebID profile by default

### DIFF
--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -242,6 +242,7 @@ export const OIDC = createVocabulary(
 export const PIM = createVocabulary(
   'http://www.w3.org/ns/pim/space#',
   'Storage',
+  'storage',
 );
 
 export const POSIX = createVocabulary(

--- a/templates/pod/base/profile/card$.ttl.hbs
+++ b/templates/pod/base/profile/card$.ttl.hbs
@@ -1,5 +1,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix pim: <http://www.w3.org/ns/pim/space#>.
 
 <>
     a foaf:PersonalProfileDocument;
@@ -9,4 +10,5 @@
 <{{webId}}>
     {{#if name}}foaf:name "{{name}}";{{/if}}
     {{#if oidcIssuer}}solid:oidcIssuer <{{oidcIssuer}}>;{{/if}}
+    pim:storage <{{base.path}}>;
     a foaf:Person.

--- a/test/integration/Accounts.test.ts
+++ b/test/integration/Accounts.test.ts
@@ -1,10 +1,12 @@
 import fetch from 'cross-fetch';
+import { Parser } from 'n3';
 import { parse, splitCookiesString } from 'set-cookie-parser';
 import { BasicRepresentation } from '../../src/http/representation/BasicRepresentation';
 import type { App } from '../../src/init/App';
 import type { ResourceStore } from '../../src/storage/ResourceStore';
 import { APPLICATION_X_WWW_FORM_URLENCODED } from '../../src/util/ContentTypes';
 import { joinUrl } from '../../src/util/PathUtil';
+import { PIM } from '../../src/util/Vocabularies';
 import { getPort } from '../util/Util';
 import { getDefaultVariables, getTestConfigPath, getTestFolder, instantiateFromConfig, removeFolder } from './Config';
 
@@ -270,6 +272,22 @@ describe.each(stores)('A server with account management using %s', (name, { conf
     res = await fetch(controls.account.webId, { headers: { cookie }});
     expect(res.status).toBe(200);
     expect((await res.json()).webIdLinks[webId]).toBeDefined();
+  });
+
+  it('includes pim:storage triple in the WebID profile.', async(): Promise<void> => {
+    // Fetch the WebID profile document
+    const profileUrl = webId.split('#')[0];
+    const res = await fetch(profileUrl, { headers: { accept: 'text/turtle' }});
+    expect(res.status).toBe(200);
+
+    // Parse and verify the pim:storage triple points to the pod root
+    const parser = new Parser({ baseIRI: profileUrl });
+    const quads = parser.parse(await res.text());
+    const storageQuads = quads.filter((q): boolean =>
+      q.subject.value === webId &&
+      q.predicate.value === PIM.storage &&
+      q.object.value === pod);
+    expect(storageQuads).toHaveLength(1);
   });
 
   it('can not remove the last owner of a pod.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/910

#### ✍️ Description

Adds a default `pim:storage` statement to newly generated WebID profile documents so Solid clients can discover the pod’s root storage container directly from the profile.

As noted in https://github.com/CommunitySolidServer/CommunitySolidServer/issues/910 - unless there is a reason to omit the `pim:storage` declaration on the basis of user privacy - the entity managing a WebID SHOULD include declare the `pim:storage` for any storages owned by the user.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.

@joachimvh - please let me know if you consider this a feature rather than a patch, in which case I can target against `versions/next-major` and add a release note.

<!-- Try to check these to the best of your abilities before opening the PR -->
