### PR TITLE
Return children metadata from memory backend

### DIFF
--- a/src/storage/accessors/InMemoryDataAccessor.ts
+++ b/src/storage/accessors/InMemoryDataAccessor.ts
@@ -1,5 +1,6 @@
 import type { Readable } from 'node:stream';
 import arrayifyStream from 'arrayify-stream';
+import { DataFactory } from 'n3';
 import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import type { SingleThreaded } from '../../init/cluster/SingleThreaded';
@@ -53,8 +54,11 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
   public async* getChildren(identifier: ResourceIdentifier): AsyncIterableIterator<RepresentationMetadata> {
     const entry = this.getEntry(identifier);
     if (!this.isDataEntry(entry)) {
-      const childNames = Object.keys(entry.entries);
-      yield* childNames.map((name): RepresentationMetadata => new RepresentationMetadata({ path: name }));
+      yield* Object.entries(entry.entries).map(([ path, child ]): RepresentationMetadata => {
+        const metadata = new RepresentationMetadata(DataFactory.namedNode(path));
+        metadata.addQuads(child.metadata.quads());
+        return metadata;
+      });
     }
   }
 

--- a/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
+++ b/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
@@ -9,7 +9,8 @@ import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError
 import type { Guarded } from '../../../../src/util/GuardedStream';
 import { BaseIdentifierStrategy } from '../../../../src/util/identifiers/BaseIdentifierStrategy';
 import { guardedStreamFrom, readableToString } from '../../../../src/util/StreamUtil';
-import { CONTENT_TYPE, LDP, POSIX, RDF } from '../../../../src/util/Vocabularies';
+import { toLiteral } from '../../../../src/util/TermUtil';
+import { CONTENT_TYPE, DC, LDP, POSIX, RDF, XSD } from '../../../../src/util/Vocabularies';
 
 const { namedNode } = DataFactory;
 
@@ -101,6 +102,29 @@ describe('An InMemoryDataAccessor', (): void => {
       expect(children).toHaveLength(2);
       expect(children[0].identifier.value).toBe(`${base}container/resource`);
       expect(children[1].identifier.value).toBe(`${base}container/container2/`);
+    });
+
+    it('generates metadata for container child resources.', async(): Promise<void> => {
+      const now = new Date();
+      await expect(accessor.writeContainer({ path: `${base}container/` }, metadata)).resolves.toBeUndefined();
+      await expect(accessor.writeDocument({ path: `${base}container/resource` }, data, new RepresentationMetadata(
+        { path: `${base}container/resource` },
+        {
+          [RDF.type]: LDP.terms.Resource,
+          [DC.modified]: toLiteral(now.toISOString(), XSD.terms.dateTime),
+          [CONTENT_TYPE]: 'text/turtle',
+        },
+      ))).resolves.toBeUndefined();
+
+      const children = [];
+      for await (const child of accessor.getChildren({ path: `${base}container/` })) {
+        children.push(child);
+      }
+      expect(children).toHaveLength(1);
+      expect(children[0].identifier.value).toBe(`${base}container/resource`);
+      expect(children[0].get(DC.terms.modified))
+        .toEqualRdfTerm(toLiteral(now.toISOString(), XSD.terms.dateTime));
+      expect(children[0].get(RDF.terms.type)).toEqual(LDP.terms.Resource);
     });
 
     it('adds stored metadata when requesting document metadata.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

- https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2169

#### ✍️ Description

Added code to return metadata from container children in the memory backend, also implemented a new test to cover the functionality.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
