### PR TITLE
perf: Reuse the resolved effective ACL across the passes of a single request

### DIFF
--- a/src/authorization/WebAclReader.ts
+++ b/src/authorization/WebAclReader.ts
@@ -18,7 +18,7 @@ import type { PermissionReaderInput } from './PermissionReader';
 import { PermissionReader } from './PermissionReader';
 import type { AclPermissionSet } from './permissions/AclPermissionSet';
 import { AclMode } from './permissions/AclPermissionSet';
-import type { PermissionMap } from './permissions/Permissions';
+import type { AccessMap, PermissionMap } from './permissions/Permissions';
 import { AccessMode } from './permissions/Permissions';
 
 // Maps WebACL-specific modes to generic access modes.
@@ -45,6 +45,30 @@ export class WebAclReader extends PermissionReader {
   private readonly identifierStrategy: IdentifierStrategy;
   private readonly accessChecker: AccessChecker;
 
+  /**
+   * Memoizes the credential-independent part of ACL resolution (the effective-ACL existence walk
+   * and the read + parse of the relevant authorization statements) for the duration of a single request.
+   *
+   * A single authenticated `GET`/`HEAD` invokes this reader multiple times with the same
+   * `requestedModes` but different `credentials`: once for the authorization decision (and, sharing
+   * the same `(credentials, requestedModes)` object pair, the `WAC-Allow` user-permission pass), and
+   * a separate time for the `WAC-Allow` public-permission pass (with an empty `credentials` literal,
+   * which is a cache miss for the surrounding {@link CachedHandler}). The resulting effective ACL is
+   * identical for all of these, so without memoization it is read and parsed once per distinct
+   * credential set rather than once per request.
+   *
+   * The map is keyed by the `requestedModes` {@link AccessMap} object, which the (cached)
+   * `ModesExtractor` produces exactly once per request and shares across all of the above passes,
+   * so the memoized value is request-scoped by construction: it is reused only within a single
+   * request and becomes eligible for garbage collection once that request's `AccessMap` is
+   * unreachable. As a `WeakMap`, it can therefore never serve a stale ACL to a later request.
+   * This mirrors the request-scoping approach already used by {@link CachedResourceSet}.
+   *
+   * Only the credential-independent resolution is shared; the per-credential evaluation of which
+   * permissions are granted still runs for every call, so the returned permissions are unchanged.
+   */
+  private readonly statementCache: WeakMap<AccessMap, Promise<Map<Store, ResourceIdentifier[]>>>;
+
   public constructor(
     aclStrategy: AuxiliaryIdentifierStrategy,
     resourceSet: ResourceSet,
@@ -58,6 +82,7 @@ export class WebAclReader extends PermissionReader {
     this.aclStore = aclStore;
     this.identifierStrategy = identifierStrategy;
     this.accessChecker = accessChecker;
+    this.statementCache = new WeakMap();
   }
 
   /**
@@ -67,9 +92,39 @@ export class WebAclReader extends PermissionReader {
   public async handle({ credentials, requestedModes }: PermissionReaderInput): Promise<PermissionMap> {
     // Determine the required access modes
     this.logger.debug(`Retrieving permissions of ${credentials.agent?.webId ?? 'an unknown agent'}`);
-    const aclMap = await this.getAclMatches(requestedModes.distinctKeys());
-    const storeMap = await this.findAuthorizationStatements(aclMap);
+    const storeMap = await this.getAuthorizationStatements(requestedModes);
     return this.findPermissions(storeMap, credentials);
+  }
+
+  /**
+   * Finds the relevant authorization statements for the targets in the given access map,
+   * reusing a request-scoped result if one was already computed for this exact `requestedModes` object.
+   *
+   * The resolution (effective-ACL existence walk + read + parse) does not depend on the credentials,
+   * so it is safe to share between the multiple credential-specific calls of a single request.
+   * See {@link statementCache} for the request-scoping and staleness guarantees.
+   *
+   * @param requestedModes - The requested modes whose target resources need authorization statements.
+   */
+  private async getAuthorizationStatements(requestedModes: AccessMap): Promise<Map<Store, ResourceIdentifier[]>> {
+    const cached = this.statementCache.get(requestedModes);
+    if (cached) {
+      return cached;
+    }
+    // Cache the promise (not the resolved value) so concurrent passes within the same request
+    // share a single in-flight resolution instead of racing to read the ACL.
+    const promise = (async(): Promise<Map<Store, ResourceIdentifier[]>> => {
+      const aclMap = await this.getAclMatches(requestedModes.distinctKeys());
+      return this.findAuthorizationStatements(aclMap);
+    })();
+    this.statementCache.set(requestedModes, promise);
+    try {
+      return await promise;
+    } catch (error: unknown) {
+      // Do not memoize failures: a transient read error must not be served to later passes/requests.
+      this.statementCache.delete(requestedModes);
+      throw error;
+    }
   }
 
   /**

--- a/src/authorization/WebAclReader.ts
+++ b/src/authorization/WebAclReader.ts
@@ -46,26 +46,11 @@ export class WebAclReader extends PermissionReader {
   private readonly accessChecker: AccessChecker;
 
   /**
-   * Memoizes the credential-independent part of ACL resolution (the effective-ACL existence walk
-   * and the read + parse of the relevant authorization statements) for the duration of a single request.
-   *
-   * A single authenticated `GET`/`HEAD` invokes this reader multiple times with the same
-   * `requestedModes` but different `credentials`: once for the authorization decision (and, sharing
-   * the same `(credentials, requestedModes)` object pair, the `WAC-Allow` user-permission pass), and
-   * a separate time for the `WAC-Allow` public-permission pass (with an empty `credentials` literal,
-   * which is a cache miss for the surrounding {@link CachedHandler}). The resulting effective ACL is
-   * identical for all of these, so without memoization it is read and parsed once per distinct
-   * credential set rather than once per request.
-   *
-   * The map is keyed by the `requestedModes` {@link AccessMap} object, which the (cached)
-   * `ModesExtractor` produces exactly once per request and shares across all of the above passes,
-   * so the memoized value is request-scoped by construction: it is reused only within a single
-   * request and becomes eligible for garbage collection once that request's `AccessMap` is
-   * unreachable. As a `WeakMap`, it can therefore never serve a stale ACL to a later request.
-   * This mirrors the request-scoping approach already used by {@link CachedResourceSet}.
-   *
-   * Only the credential-independent resolution is shared; the per-credential evaluation of which
-   * permissions are granted still runs for every call, so the returned permissions are unchanged.
+   * Memoizes the credential-independent part of ACL resolution (existence walk + read + parse)
+   * for the duration of a single request, so the multiple credential-specific passes of one request
+   * (authorization decision and the WAC-Allow user/public passes) share a single ACL read.
+   * Keyed by the `requestedModes` object, which the cached `ModesExtractor` produces once per request:
+   * a different request always has a different key, so this `WeakMap` can never serve a stale ACL.
    */
   private readonly statementCache: WeakMap<AccessMap, Promise<Map<Store, ResourceIdentifier[]>>>;
 
@@ -98,11 +83,8 @@ export class WebAclReader extends PermissionReader {
 
   /**
    * Finds the relevant authorization statements for the targets in the given access map,
-   * reusing a request-scoped result if one was already computed for this exact `requestedModes` object.
-   *
-   * The resolution (effective-ACL existence walk + read + parse) does not depend on the credentials,
-   * so it is safe to share between the multiple credential-specific calls of a single request.
-   * See {@link statementCache} for the request-scoping and staleness guarantees.
+   * reusing the result if it was already resolved for this `requestedModes` object.
+   * See {@link statementCache} for the request-scoping guarantee.
    *
    * @param requestedModes - The requested modes whose target resources need authorization statements.
    */
@@ -111,8 +93,7 @@ export class WebAclReader extends PermissionReader {
     if (cached) {
       return cached;
     }
-    // Cache the promise (not the resolved value) so concurrent passes within the same request
-    // share a single in-flight resolution instead of racing to read the ACL.
+    // Caching the promise lets concurrent passes share one in-flight read instead of racing.
     const promise = (async(): Promise<Map<Store, ResourceIdentifier[]>> => {
       const aclMap = await this.getAclMatches(requestedModes.distinctKeys());
       return this.findAuthorizationStatements(aclMap);
@@ -121,7 +102,7 @@ export class WebAclReader extends PermissionReader {
     try {
       return await promise;
     } catch (error: unknown) {
-      // Do not memoize failures: a transient read error must not be served to later passes/requests.
+      // Do not memoize failures so a transient read error is not served to a later pass.
       this.statementCache.delete(requestedModes);
       throw error;
     }

--- a/src/authorization/WebAclReader.ts
+++ b/src/authorization/WebAclReader.ts
@@ -94,10 +94,8 @@ export class WebAclReader extends PermissionReader {
       return cached;
     }
     // Caching the promise lets concurrent passes share one in-flight read instead of racing.
-    const promise = (async(): Promise<Map<Store, ResourceIdentifier[]>> => {
-      const aclMap = await this.getAclMatches(requestedModes.distinctKeys());
-      return this.findAuthorizationStatements(aclMap);
-    })();
+    const promise = this.getAclMatches(requestedModes.distinctKeys()).then(aclMap => 
+      this.findAuthorizationStatements(aclMap));
     this.statementCache.set(requestedModes, promise);
     try {
       return await promise;

--- a/test/unit/authorization/WebAclReader.test.ts
+++ b/test/unit/authorization/WebAclReader.test.ts
@@ -234,7 +234,8 @@ describe('A WebAclReader', (): void => {
           return true;
         }
         const agents = store.getObjects(rule, `${acl}agent`, null).map((term): string => term.value);
-        return Boolean(credentials.agent?.webId) && agents.includes(credentials.agent.webId);
+        const webId = credentials.agent?.webId;
+        return webId !== undefined && agents.includes(webId);
       });
 
       // Authorization decision + WAC-Allow user-permission pass: authenticated agent.
@@ -265,7 +266,7 @@ describe('A WebAclReader', (): void => {
 
       // A separate request always produces a new `requestedModes` `AccessMap` object,
       // so it cannot hit the request-scoped cache of an earlier request.
-      const secondAccessMap = new IdentifierSetMultiMap<ResourceIdentifier>([[ identifier, AccessMode.read ]]);
+      const secondAccessMap = new IdentifierSetMultiMap<AccessMode>([[ identifier, AccessMode.read ]]);
 
       await reader.handle({ credentials, requestedModes: accessMap });
       await reader.handle({ credentials, requestedModes: secondAccessMap });

--- a/test/unit/authorization/WebAclReader.test.ts
+++ b/test/unit/authorization/WebAclReader.test.ts
@@ -208,4 +208,89 @@ describe('A WebAclReader', (): void => {
     // http://example.com/.acl and http://example.com/bar/.acl
     expect(store.getRepresentation).toHaveBeenCalledTimes(2);
   });
+
+  describe('reusing the effective ACL within a single request', (): void => {
+    // The same effective ACL gets resolved several times during a single request:
+    // once for the authorization decision (and the WAC-Allow user-permission pass, which shares the
+    // same `(credentials, requestedModes)` object pair), and a separate time for the WAC-Allow
+    // public-permission pass (empty credentials). All these calls share the same `requestedModes`
+    // `AccessMap` object as it is produced once per request by the (cached) `ModesExtractor`.
+    it('resolves the effective ACL once when reused for different credentials.', async(): Promise<void> => {
+      // Return a fresh representation on each call as the underlying data stream is consumed once.
+      store.getRepresentation.mockImplementation(async(): Promise<Representation> => new BasicRepresentation([
+        quad(nn('auth'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+        quad(nn('auth'), nn(`${acl}agent`), nn('http://test.com/user')),
+        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+        quad(nn('pub'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+        quad(nn('pub'), nn(`${acl}accessTo`), nn(identifier.path)),
+        quad(nn('pub'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+        quad(nn('pub'), nn(`${acl}mode`), nn(`${acl}Read`)),
+      ], INTERNAL_QUADS));
+      // The access checker only grants the rule for the matching agent or for the public class.
+      accessChecker.handleSafe.mockImplementation(async({ acl: store, rule, credentials }): Promise<boolean> => {
+        const classes = store.getObjects(rule, `${acl}agentClass`, null).map((term): string => term.value);
+        if (classes.includes('http://xmlns.com/foaf/0.1/Agent')) {
+          return true;
+        }
+        const agents = store.getObjects(rule, `${acl}agent`, null).map((term): string => term.value);
+        return Boolean(credentials.agent?.webId) && agents.includes(credentials.agent.webId);
+      });
+
+      // Authorization decision + WAC-Allow user-permission pass: authenticated agent.
+      const userInput: PermissionReaderInput = {
+        credentials: { agent: { webId: 'http://test.com/user' }},
+        requestedModes: accessMap,
+      };
+      // WAC-Allow public-permission pass: same `requestedModes`, empty credentials object.
+      const publicInput: PermissionReaderInput = { credentials: {}, requestedModes: accessMap };
+
+      compareMaps(await reader.handle(userInput), new IdentifierMap([[ identifier, { read: true }]]));
+      compareMaps(await reader.handle(publicInput), new IdentifierMap([[ identifier, { read: true }]]));
+
+      // The effective ACL must be read and resolved exactly once for the whole request,
+      // even though the permissions are evaluated separately for each credential set.
+      expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+      expect(resourceSet.hasResource).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-resolves the effective ACL for a different request (no stale cache).', async(): Promise<void> => {
+      // Return a fresh representation on each call as the underlying data stream is consumed once.
+      store.getRepresentation.mockImplementation(async(): Promise<Representation> => new BasicRepresentation([
+        quad(nn('auth'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+        quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+        quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+        quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+      ], INTERNAL_QUADS));
+
+      // A separate request always produces a new `requestedModes` `AccessMap` object,
+      // so it cannot hit the request-scoped cache of an earlier request.
+      const secondAccessMap = new IdentifierSetMultiMap<ResourceIdentifier>([[ identifier, AccessMode.read ]]);
+
+      await reader.handle({ credentials, requestedModes: accessMap });
+      await reader.handle({ credentials, requestedModes: secondAccessMap });
+
+      expect(store.getRepresentation).toHaveBeenCalledTimes(2);
+      expect(resourceSet.hasResource).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not memoize a failed ACL read.', async(): Promise<void> => {
+      store.getRepresentation
+        .mockRejectedValueOnce(new Error('TEST!'))
+        .mockImplementation(async(): Promise<Representation> => new BasicRepresentation([
+          quad(nn('auth'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+          quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+          quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+          quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+        ], INTERNAL_QUADS));
+
+      // First call fails while reading the ACL; the failure must not be cached for the retry.
+      await expect(reader.handle({ credentials, requestedModes: accessMap })).rejects.toThrow(InternalServerError);
+      compareMaps(
+        await reader.handle({ credentials, requestedModes: accessMap }),
+        new IdentifierMap([[ identifier, { read: true }]]),
+      );
+      expect(store.getRepresentation).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
🚧 **DRAFT — for @jeswr to review first** (opened by @jeswr's AI coding agent; please hold off reviewing until marked ready).

#### ✍️ Description

A single authenticated `GET`/`HEAD` resolves and parses the target's effective `.acl` twice. The `WebAclReader` runs once for the authorization decision (shared with the `WAC-Allow` user pass via the same cached `(credentials, requestedModes)` pair) and again for the `WAC-Allow` public pass, which builds a fresh empty-credentials object and so misses the `CachedHandler` — re-walking the container hierarchy and re-reading + re-parsing the same ACL.

This memoizes the credential-independent part of ACL resolution (the existence walk + read + parse) for the duration of a single request, in a `WeakMap` keyed by the per-request `requestedModes` object that `ModesExtractor` produces once per request. Each pass still evaluates its own credentials against the shared parsed ACL, so the granted permissions and the `WAC-Allow` header are byte-identical. The cache is request-scoped by construction (a different request has a different key) and so can never serve a stale ACL; failed reads are not memoized.

Added a regression `describe` block to `WebAclReader.test.ts` covering the within-request reuse (fails on `main`), the no-stale-cache guarantee across requests, and the no-memoize-on-failure path.

#### 📈 Performance

Effective-`.acl` read+parse operations per request (WAC enabled), the load-independent metric asserted by the regression test:

| Request | before | after |
|---|---|---|
| Authenticated GET | 2 | **1** |
| Unauthenticated GET | 1 | 1 |
| PUT | 1 | 1 |

This is the load-independent evidence for a fewer-reads change. The per-request saving is one effective-`.acl` existence-walk + read + parse on authenticated GETs, so the wall-clock effect is modest. A quick back-to-back wall-clock A/B (baseline `main` vs this branch, both WAC-enabled, same file backend, constant-WebID extractor so `oha` could drive authenticated load) did not produce a stable reading on the test box — the build-to-build delta was swamped by background load (1-min load oscillating ~1.6→8.8 mid-run, the faster build flipping run to run). A clean wall-clock confirmation needs a quiet box; the deterministic op-count above is the reproducible evidence.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
