### PR TITLE
refactor: Resolve the effective ACL once per request (cache-free alternative to #2182)

### DIFF
--- a/src/authorization/AuthAuxiliaryReader.ts
+++ b/src/authorization/AuthAuxiliaryReader.ts
@@ -8,6 +8,8 @@ import type { PermissionReaderInput } from './PermissionReader';
 import { PermissionReader } from './PermissionReader';
 import { AclMode } from './permissions/AclPermissionSet';
 import type { AclPermissionSet } from './permissions/AclPermissionSet';
+import type { PermissionSetWithComparisons } from './permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS } from './permissions/ComparisonPermissions';
 import type { AccessMap, AccessMode, PermissionMap, PermissionSet } from './permissions/Permissions';
 
 /**
@@ -30,7 +32,8 @@ export class AuthAuxiliaryReader extends PermissionReader {
     this.authStrategy = authStrategy;
   }
 
-  public async handle({ requestedModes, credentials }: PermissionReaderInput): Promise<PermissionMap> {
+  public async handle({ requestedModes, credentials, credentialsToCompare }: PermissionReaderInput):
+  Promise<PermissionMap> {
     // Finds all the ACL identifiers
     const authMap = new Map(this.findAuth(requestedModes));
 
@@ -39,12 +42,21 @@ export class AuthAuxiliaryReader extends PermissionReader {
       new IdentifierSetMultiMap(requestedModes),
       { add: authMap.values(), remove: authMap.keys() },
     );
-    const result = await this.reader.handleSafe({ requestedModes: updatedMap, credentials });
+    const result = await this.reader.handleSafe({ requestedModes: updatedMap, credentials, credentialsToCompare });
 
     // Extracts the permissions based on the subject control permissions
     for (const [ identifier, [ subject ]] of authMap) {
       this.logger.debug(`Mapping ${subject.path} control permission to all permissions for ${identifier.path}`);
-      result.set(identifier, this.interpretControl(identifier, result.get(subject)));
+      const subjectSet = result.get(subject);
+      const authSet = this.interpretControl(identifier, subjectSet);
+      // Apply the same control->read/write interpretation to each comparison credential set,
+      // using that comparison's own subject permissions, so the comparison result matches a full pass.
+      const subjectComparisons = (subjectSet as PermissionSetWithComparisons | undefined)?.[COMPARISON_PERMISSIONS];
+      if (subjectComparisons) {
+        (authSet as PermissionSetWithComparisons)[COMPARISON_PERMISSIONS] = subjectComparisons
+          .map((set): PermissionSet => this.interpretControl(identifier, set));
+      }
+      result.set(identifier, authSet);
     }
     return result;
   }

--- a/src/authorization/AuxiliaryReader.ts
+++ b/src/authorization/AuxiliaryReader.ts
@@ -23,7 +23,8 @@ export class AuxiliaryReader extends PermissionReader {
     this.auxiliaryStrategy = auxiliaryStrategy;
   }
 
-  public async handle({ requestedModes, credentials }: PermissionReaderInput): Promise<PermissionMap> {
+  public async handle({ requestedModes, credentials, credentialsToCompare }: PermissionReaderInput):
+  Promise<PermissionMap> {
     // Finds all the dependent auxiliary identifiers
     const auxiliaries = this.findAuxiliaries(requestedModes);
 
@@ -32,9 +33,11 @@ export class AuxiliaryReader extends PermissionReader {
       new IdentifierSetMultiMap(requestedModes),
       { add: auxiliaries.values(), remove: auxiliaries.keys() },
     );
-    const result = await this.reader.handleSafe({ requestedModes: updatedMap, credentials });
+    const result = await this.reader.handleSafe({ requestedModes: updatedMap, credentials, credentialsToCompare });
 
-    // Extracts the auxiliary permissions based on the subject permissions
+    // Extracts the auxiliary permissions based on the subject permissions.
+    // The subject permission set is copied by reference, so any comparison permissions attached to it
+    // (under the COMPARISON_PERMISSIONS symbol) are carried over to the auxiliary identifier unchanged.
     for (const [ identifier, [ subject ]] of auxiliaries) {
       this.logger.debug(`Mapping ${subject.path} permissions to ${identifier.path}`);
       result.set(identifier, result.get(subject) ?? {});

--- a/src/authorization/OwnerPermissionReader.ts
+++ b/src/authorization/OwnerPermissionReader.ts
@@ -5,9 +5,12 @@ import { getLoggerFor } from '../logging/LogUtil';
 import type { StorageLocationStrategy } from '../server/description/StorageLocationStrategy';
 import { filter } from '../util/IterableUtil';
 import { IdentifierMap } from '../util/map/IdentifierMap';
+import type { Credentials } from '../authentication/Credentials';
 import type { PermissionReaderInput } from './PermissionReader';
 import { PermissionReader } from './PermissionReader';
 import type { AclPermissionSet } from './permissions/AclPermissionSet';
+import type { PermissionSetWithComparisons } from './permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS } from './permissions/ComparisonPermissions';
 import type { PermissionMap } from './permissions/Permissions';
 
 /**
@@ -40,12 +43,17 @@ export class OwnerPermissionReader extends PermissionReader {
       return result;
     }
 
-    const webId = input.credentials.agent?.webId;
-    if (!webId) {
+    const { credentials, credentialsToCompare } = input;
+    // If neither the primary credentials nor any comparison credentials have a WebID,
+    // no ownership grant is possible for anyone, so there is nothing to do.
+    const anyWebId = credentials.agent?.webId ??
+      credentialsToCompare?.find((cred): boolean => Boolean(cred.agent?.webId))?.agent?.webId;
+    if (!anyWebId) {
       this.logger.debug(`No WebId found for an ownership check on the pod.`);
       return result;
     }
 
+    // The pod owners are resolved ONCE per pod and reused for every credential set being evaluated.
     const pods = await this.findPods(auths);
     const owners = await this.findOwners(Object.values(pods));
 
@@ -54,19 +62,46 @@ export class OwnerPermissionReader extends PermissionReader {
       if (!webIds) {
         continue;
       }
-      if (webIds.includes(webId)) {
-        this.logger.debug(`Granting Control permissions to owner on ${auth.path}`);
-        result.set(auth, {
-          read: true,
-          write: true,
-          append: true,
-          create: true,
-          delete: true,
-          control: true,
-        } as AclPermissionSet);
+      const primarySet = this.grantIfOwner(auth, webIds, credentials);
+      const comparisonSets = credentialsToCompare
+        ?.map((cred): AclPermissionSet => this.grantIfOwner(auth, webIds, cred) ?? {});
+      // An entry is created when the primary credentials are an owner (matching the original behaviour
+      // exactly), OR when a comparison credential set is an owner (so its owner grant is not silently
+      // dropped). When only a comparison is an owner, the primary set is an empty `{}`, which the
+      // UnionPermissionReader treats as no contribution for the primary - identical to the original.
+      const comparisonOwner = comparisonSets?.some((set): boolean => Boolean(set.control));
+      if (primarySet ?? comparisonOwner) {
+        const entry: AclPermissionSet = primarySet ?? {};
+        if (comparisonSets) {
+          (entry as PermissionSetWithComparisons)[COMPARISON_PERMISSIONS] = comparisonSets;
+        }
+        result.set(auth, entry);
       }
     }
     return result;
+  }
+
+  /**
+   * Returns the full owner permission set if the given credentials belong to an owner of the resource,
+   * or `undefined` otherwise.
+   */
+  private grantIfOwner(
+    auth: { path: string },
+    ownerWebIds: string[],
+    credentials: Credentials,
+  ): AclPermissionSet | undefined {
+    const webId = credentials.agent?.webId;
+    if (webId && ownerWebIds.includes(webId)) {
+      this.logger.debug(`Granting Control permissions to owner on ${auth.path}`);
+      return {
+        read: true,
+        write: true,
+        append: true,
+        create: true,
+        delete: true,
+        control: true,
+      };
+    }
   }
 
   /**

--- a/src/authorization/ParentContainerReader.ts
+++ b/src/authorization/ParentContainerReader.ts
@@ -6,6 +6,8 @@ import type { MapEntry } from '../util/map/MapUtil';
 import { modify } from '../util/map/MapUtil';
 import type { PermissionReaderInput } from './PermissionReader';
 import { PermissionReader } from './PermissionReader';
+import type { PermissionSetWithComparisons } from './permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS } from './permissions/ComparisonPermissions';
 import type { AccessMap, PermissionMap, PermissionSet } from './permissions/Permissions';
 import { AccessMode } from './permissions/Permissions';
 
@@ -28,20 +30,49 @@ export class ParentContainerReader extends PermissionReader {
     this.identifierStrategy = identifierStrategy;
   }
 
-  public async handle({ requestedModes, credentials }: PermissionReaderInput): Promise<PermissionMap> {
+  public async handle({ requestedModes, credentials, credentialsToCompare }: PermissionReaderInput):
+  Promise<PermissionMap> {
     // Finds the entries for which we require parent container permissions
     const containerMap = this.findParents(requestedModes);
 
     // Merges the necessary parent container modes with the already requested modes
     const combinedModes = modify(new IdentifierSetMultiMap(requestedModes), { add: containerMap.values() });
-    const result = await this.reader.handleSafe({ requestedModes: combinedModes, credentials });
+    const result = await this.reader.handleSafe({ requestedModes: combinedModes, credentials, credentialsToCompare });
 
     // Updates the create/delete permissions based on the parent container permissions
     for (const [ identifier, [ container ]] of containerMap) {
       this.logger.debug(`Determining ${identifier.path} create and delete permissions based on ${container.path}`);
-      result.set(identifier, this.addContainerPermissions(result.get(identifier), result.get(container)));
+      const resourceSet = result.get(identifier);
+      const containerSet = result.get(container);
+      const merged = this.addContainerPermissions(resourceSet, containerSet);
+      // Apply the same create/delete derivation to each comparison credential set, using that comparison's
+      // own resource + container permissions, so the comparison result matches a full separate pass.
+      this.addComparisonContainerPermissions(merged, resourceSet, containerSet);
+      result.set(identifier, merged);
     }
     return result;
+  }
+
+  /**
+   * Derives the comparison create/delete permissions (those carried for `credentialsToCompare`)
+   * from the comparison resource and container permission sets, mirroring the primary derivation.
+   */
+  private addComparisonContainerPermissions(
+    merged: PermissionSet,
+    resourceSet?: PermissionSet,
+    containerSet?: PermissionSet,
+  ): void {
+    const resourceComparisons = (resourceSet as PermissionSetWithComparisons | undefined)?.[COMPARISON_PERMISSIONS];
+    const containerComparisons = (containerSet as PermissionSetWithComparisons | undefined)?.[COMPARISON_PERMISSIONS];
+    if (!resourceComparisons && !containerComparisons) {
+      return;
+    }
+    const length = Math.max(resourceComparisons?.length ?? 0, containerComparisons?.length ?? 0);
+    const mergedComparisons: PermissionSet[] = [];
+    for (let i = 0; i < length; i++) {
+      mergedComparisons.push(this.addContainerPermissions(resourceComparisons?.[i], containerComparisons?.[i]));
+    }
+    (merged as PermissionSetWithComparisons)[COMPARISON_PERMISSIONS] = mergedComparisons;
   }
 
   /**

--- a/src/authorization/PathBasedReader.ts
+++ b/src/authorization/PathBasedReader.ts
@@ -32,7 +32,14 @@ export class PathBasedReader extends PermissionReader {
   public async handle(input: PermissionReaderInput): Promise<PermissionMap> {
     const results: PermissionMap[] = [];
     for (const [ reader, readerModes ] of this.matchReaders(input.requestedModes)) {
-      results.push(await reader.handleSafe({ credentials: input.credentials, requestedModes: readerModes }));
+      // Forwarding `credentialsToCompare` is sufficient here: this reader only routes by identifier
+      // and never transforms permission sets, so any comparison sets attached by the sub-reader pass
+      // through unchanged.
+      results.push(await reader.handleSafe({
+        credentials: input.credentials,
+        requestedModes: readerModes,
+        credentialsToCompare: input.credentialsToCompare,
+      }));
     }
     return new IdentifierMap(concat(results));
   }

--- a/src/authorization/PermissionReader.ts
+++ b/src/authorization/PermissionReader.ts
@@ -12,6 +12,30 @@ export interface PermissionReaderInput {
    * However, non-exhaustive information about other access modes and resources can still be returned.
    */
   requestedModes: AccessMap;
+  /**
+   * Optional list of *additional* credential sets whose permissions should ALSO be evaluated,
+   * against the exact same authorization data that is resolved for the primary {@link credentials}.
+   *
+   * This exists purely as an optimisation to avoid resolving the same effective ACL/ACR more than once
+   * when permissions for several credential sets are needed for one resource in a single request
+   * (the canonical example being the {@link WacAllowHttpHandler}, which needs both the requesting agent's
+   * permissions and the public (`{}`) permissions to build the `WAC-Allow` header).
+   *
+   * The field is OPTIONAL and the change is fully non-breaking:
+   *  - The PRIMARY result returned by a reader is the {@link PermissionMap} for {@link credentials} ONLY,
+   *    with semantics identical to a call that omits this field. Authorization decisions are unaffected.
+   *  - A reader that does not understand this field MUST keep behaving identically; it simply ignores it
+   *    and returns the primary map. The comparison results are then unavailable, which callers must tolerate
+   *    (they fall back to evaluating the comparison credentials in a separate call).
+   *
+   * A reader that DOES support it (currently {@link WebAclReader}) attaches, for each identifier in the
+   * primary {@link PermissionMap}, the permission set computed for every entry of this array under the
+   * {@link COMPARISON_PERMISSIONS} symbol on that identifier's primary {@link PermissionSet}
+   * (index-aligned with this array). See {@link getComparisonPermissions} to read them back out.
+   * The attachment is on a non-enumerable {@link Symbol} key, so it is invisible to the authorizer and to
+   * the `WAC-Allow` header generation, keeping both byte-identical.
+   */
+  credentialsToCompare?: Credentials[];
 }
 
 /**

--- a/src/authorization/UnionPermissionReader.ts
+++ b/src/authorization/UnionPermissionReader.ts
@@ -2,6 +2,8 @@ import { UnionHandler } from '../util/handlers/UnionHandler';
 import { IdentifierMap } from '../util/map/IdentifierMap';
 import { getDefault } from '../util/map/MapUtil';
 import type { PermissionReader } from './PermissionReader';
+import type { PermissionSetWithComparisons } from './permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS } from './permissions/ComparisonPermissions';
 import type { PermissionMap, PermissionSet } from './permissions/Permissions';
 
 /**
@@ -40,6 +42,33 @@ export class UnionPermissionReader extends UnionHandler<PermissionReader> {
         result[key] = value;
       }
     }
+    // Symbol-keyed comparison permissions (from `credentialsToCompare`) are not enumerated by `Object.entries`,
+    // so they must be merged explicitly to survive the union. Each entry is merged using the same rules,
+    // index-aligned, so the comparison result is identical to a full separate pass for those credentials.
+    this.mergeComparisons(permissions, result);
     return result;
+  }
+
+  /**
+   * Merges the {@link COMPARISON_PERMISSIONS} arrays of two permission sets, index by index,
+   * using the same `false` \> `true` \> `undefined` rule as the primary permissions.
+   * Ensures the comparison permissions carried for `credentialsToCompare` compose across readers
+   * exactly as a separate full pass for those credentials would.
+   */
+  private mergeComparisons(permissions: PermissionSet, result: PermissionSet): void {
+    const incoming = (permissions as PermissionSetWithComparisons)[COMPARISON_PERMISSIONS];
+    if (!incoming) {
+      return;
+    }
+    const target = result as PermissionSetWithComparisons;
+    const existing = target[COMPARISON_PERMISSIONS];
+    if (!existing) {
+      // Copy each comparison set so later in-place merges never mutate a source reader's objects.
+      target[COMPARISON_PERMISSIONS] = incoming.map((set): PermissionSet => ({ ...set }));
+      return;
+    }
+    for (const [ index, set ] of incoming.entries()) {
+      existing[index] = this.mergePermissions(set, existing[index] ?? {});
+    }
   }
 }

--- a/src/authorization/WebAclReader.ts
+++ b/src/authorization/WebAclReader.ts
@@ -18,6 +18,8 @@ import type { PermissionReaderInput } from './PermissionReader';
 import { PermissionReader } from './PermissionReader';
 import type { AclPermissionSet } from './permissions/AclPermissionSet';
 import { AclMode } from './permissions/AclPermissionSet';
+import type { PermissionSetWithComparisons } from './permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS } from './permissions/ComparisonPermissions';
 import type { PermissionMap } from './permissions/Permissions';
 import { AccessMode } from './permissions/Permissions';
 
@@ -64,12 +66,15 @@ export class WebAclReader extends PermissionReader {
    * Checks if an agent is allowed to execute the requested actions.
    * Will throw an error if this is not the case.
    */
-  public async handle({ credentials, requestedModes }: PermissionReaderInput): Promise<PermissionMap> {
+  public async handle({ credentials, requestedModes, credentialsToCompare }: PermissionReaderInput):
+  Promise<PermissionMap> {
     // Determine the required access modes
     this.logger.debug(`Retrieving permissions of ${credentials.agent?.webId ?? 'an unknown agent'}`);
+    // The effective ACL document(s) are resolved (walked + read + parsed) exactly ONCE here,
+    // regardless of how many credential sets need to be evaluated against them.
     const aclMap = await this.getAclMatches(requestedModes.distinctKeys());
     const storeMap = await this.findAuthorizationStatements(aclMap);
-    return this.findPermissions(storeMap, credentials);
+    return this.findPermissions(storeMap, credentials, credentialsToCompare);
   }
 
   /**
@@ -80,12 +85,32 @@ export class WebAclReader extends PermissionReader {
    *
    * @param aclMap - A map containing stores of ACL data linked to their relevant identifiers.
    * @param credentials - Credentials to check permissions for.
+   * @param credentialsToCompare - Optional additional credential sets to ALSO evaluate against the same
+   *                               resolved ACL data. Their resulting permission sets are attached to the
+   *                               primary permission set of each identifier under the
+   *                               {@link COMPARISON_PERMISSIONS} symbol (index-aligned with this array),
+   *                               where they are invisible to the authorizer and WAC-Allow header logic.
    */
-  private async findPermissions(aclMap: Map<Store, ResourceIdentifier[]>, credentials: Credentials):
-  Promise<PermissionMap> {
+  private async findPermissions(
+    aclMap: Map<Store, ResourceIdentifier[]>,
+    credentials: Credentials,
+    credentialsToCompare?: Credentials[],
+  ): Promise<PermissionMap> {
     const result: PermissionMap = new IdentifierMap();
     for (const [ store, aclIdentifiers ] of aclMap) {
+      // Evaluate the primary credentials against this (already resolved + parsed) store.
       const permissionSet = await this.determinePermissions(store, credentials);
+
+      // Evaluate any comparison credential sets against the SAME store, reusing the single resolution.
+      if (credentialsToCompare && credentialsToCompare.length > 0) {
+        const comparisons: AclPermissionSet[] = [];
+        for (const compareCredentials of credentialsToCompare) {
+          comparisons.push(await this.determinePermissions(store, compareCredentials));
+        }
+        // Attach on the non-enumerable Symbol key so the primary set's enumerable shape is unchanged.
+        (permissionSet as PermissionSetWithComparisons)[COMPARISON_PERMISSIONS] = comparisons;
+      }
+
       for (const identifier of aclIdentifiers) {
         result.set(identifier, permissionSet);
       }

--- a/src/authorization/permissions/ComparisonPermissions.ts
+++ b/src/authorization/permissions/ComparisonPermissions.ts
@@ -1,0 +1,49 @@
+import type { Credentials } from '../../authentication/Credentials';
+import type { PermissionSet } from './Permissions';
+
+/**
+ * The single "public" (unauthenticated, empty) credential set used as the comparison credentials
+ * for the `WAC-Allow` header's `public="..."` value.
+ *
+ * It is wrapped in a one-element array because {@link PermissionReaderInput.credentialsToCompare}
+ * is a list. The {@link AuthorizingHttpHandler} attaches this on its (authenticated) reader call so that
+ * the cached permission result already carries the public permissions, allowing the
+ * {@link WacAllowHttpHandler} to read them without resolving the effective ACL a second time.
+ */
+export const PUBLIC_COMPARISON: readonly Credentials[] = Object.freeze([ Object.freeze({}) ]);
+
+/**
+ * Symbol key under which a {@link PermissionSet} can carry the permissions that were
+ * computed for one or more *comparison* credential sets against the SAME resolved ACL,
+ * as requested through {@link PermissionReaderInput.credentialsToCompare}.
+ *
+ * A `Symbol` (rather than a string) property is used deliberately:
+ *  - It is never returned by `Object.keys` / `Object.entries` / `for..in`, so it is invisible
+ *    to {@link PermissionBasedAuthorizer} (which reads explicit {@link AccessMode} keys) and to
+ *    {@link WacAllowHttpHandler.addWacAllowMetadata} (which iterates `Object.keys` and filters on
+ *    the valid ACL modes). The primary permission semantics are therefore completely unchanged.
+ *  - It cannot collide with any current or future {@link AccessMode} string key.
+ *
+ * The value is an array, index-aligned with the `credentialsToCompare` array that produced it,
+ * of the {@link PermissionSet} computed for each comparison credential set on that identifier.
+ */
+export const COMPARISON_PERMISSIONS = Symbol('comparisonPermissions');
+
+/**
+ * A {@link PermissionSet} that may additionally carry comparison permission sets
+ * under the {@link COMPARISON_PERMISSIONS} symbol.
+ */
+export interface PermissionSetWithComparisons extends PermissionSet {
+  [COMPARISON_PERMISSIONS]?: PermissionSet[];
+}
+
+/**
+ * Reads the comparison permission sets attached to a {@link PermissionSet}, if any.
+ *
+ * @param permissionSet - The permission set to read from (may be `undefined`).
+ *
+ * @returns The array of comparison permission sets, or `undefined` if none were attached.
+ */
+export function getComparisonPermissions(permissionSet?: PermissionSet): PermissionSet[] | undefined {
+  return (permissionSet as PermissionSetWithComparisons | undefined)?.[COMPARISON_PERMISSIONS];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export * from './authorization/access/AgentGroupAccessChecker';
 
 // Authorization/Permissions
 export * from './authorization/permissions/AclPermissionSet';
+export * from './authorization/permissions/ComparisonPermissions';
 export * from './authorization/permissions/CreateModesExtractor';
 export * from './authorization/permissions/DeleteParentExtractor';
 export * from './authorization/permissions/IntermediateCreateExtractor';

--- a/src/server/AuthorizingHttpHandler.ts
+++ b/src/server/AuthorizingHttpHandler.ts
@@ -3,6 +3,7 @@ import type { Credentials } from '../authentication/Credentials';
 import type { CredentialsExtractor } from '../authentication/CredentialsExtractor';
 import type { Authorizer } from '../authorization/Authorizer';
 import type { PermissionReader } from '../authorization/PermissionReader';
+import { PUBLIC_COMPARISON } from '../authorization/permissions/ComparisonPermissions';
 import type { ModesExtractor } from '../authorization/permissions/ModesExtractor';
 import type { AccessMap } from '../authorization/permissions/Permissions';
 import type { ResponseDescription } from '../http/output/response/ResponseDescription';
@@ -76,7 +77,18 @@ export class AuthorizingHttpHandler extends OperationHttpHandler {
         .map(([ id, set ]): string => `{ ${id.path}: ${[ ...set ].join(',')} }`).join(',')
     }`);
 
-    const availablePermissions = await this.permissionReader.handleSafe({ credentials, requestedModes });
+    // When the request is authenticated, also resolve the public (`{}`) permissions in this single call
+    // (via `credentialsToCompare`), so the nested WacAllowHttpHandler can build the `WAC-Allow` `public`
+    // value from the cached result without resolving the effective ACL a second time.
+    // The comparison permissions are attached on a non-enumerable symbol key, so the `availablePermissions`
+    // passed to the authorizer below are byte-for-byte identical to a call without `credentialsToCompare`
+    // and the authorization decision is unaffected.
+    const credentialsToCompare = credentials.agent?.webId ? PUBLIC_COMPARISON as Credentials[] : undefined;
+    const availablePermissions = await this.permissionReader.handleSafe({
+      credentials,
+      requestedModes,
+      credentialsToCompare,
+    });
     this.logger.verbose(`Available permissions are ${
       [ ...availablePermissions.entries() ]
         .map(([ id, map ]): string => `{ ${id.path}: ${JSON.stringify(map)} }`).join(',')

--- a/src/server/WacAllowHttpHandler.ts
+++ b/src/server/WacAllowHttpHandler.ts
@@ -3,8 +3,11 @@ import type { CredentialsExtractor } from '../authentication/CredentialsExtracto
 import type { PermissionReader } from '../authorization/PermissionReader';
 import type { AclPermissionSet } from '../authorization/permissions/AclPermissionSet';
 import { AclMode } from '../authorization/permissions/AclPermissionSet';
+import { getComparisonPermissions } from '../authorization/permissions/ComparisonPermissions';
 import type { ModesExtractor } from '../authorization/permissions/ModesExtractor';
+import type { AccessMap } from '../authorization/permissions/Permissions';
 import { AccessMode } from '../authorization/permissions/Permissions';
+import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
 import type { ResponseDescription } from '../http/output/response/ResponseDescription';
 import type { RepresentationMetadata } from '../http/representation/RepresentationMetadata';
 import { getLoggerFor } from '../logging/LogUtil';
@@ -15,6 +18,12 @@ import { OperationHttpHandler } from './OperationHttpHandler';
 
 const VALID_METHODS = new Set([ 'HEAD', 'GET' ]);
 const VALID_ACL_MODES = new Set([ AccessMode.read, AccessMode.write, AccessMode.append, AclMode.control ]);
+
+/**
+ * Index in the `credentialsToCompare`/comparison-permissions array of the public (`{}`) credential set.
+ * Single-sourced with the `PUBLIC_COMPARISON` array attached by the {@link AuthorizingHttpHandler}.
+ */
+const PUBLIC_COMPARISON_INDEX = 0;
 
 export interface WacAllowHttpHandlerArgs {
   credentialsExtractor: CredentialsExtractor;
@@ -75,19 +84,12 @@ export class WacAllowHttpHandler extends OperationHttpHandler {
     const permissionSet = availablePermissions.get(operation.target);
     if (permissionSet) {
       const user: AclPermissionSet = permissionSet;
-      let everyone: AclPermissionSet;
-      if (credentials.agent?.webId) {
-        // Need to determine public permissions
-        this.logger.debug('Determining public permissions');
-        // Note that this call can potentially create a new lock on a resource that is already locked,
-        // so a locker that allows multiple read locks on the same resource is required.
-        const permissionMap = await this.permissionReader.handleSafe({ credentials: {}, requestedModes });
-        everyone = permissionMap.get(operation.target) ?? {};
-      } else {
-        // User is not authenticated so public permissions are the same as agent permissions
-        this.logger.debug('User is not authenticated so has public permissions');
-        everyone = user;
-      }
+      const everyone = await this.determinePublicPermissions(
+        operation.target,
+        permissionSet,
+        credentials,
+        requestedModes,
+      );
 
       this.logger.debug('Adding WAC-Allow metadata');
       this.addWacAllowMetadata(metadata, everyone, user);
@@ -98,6 +100,51 @@ export class WacAllowHttpHandler extends OperationHttpHandler {
     }
 
     return response;
+  }
+
+  /**
+   * Determines the public (unauthenticated) permissions needed for the `WAC-Allow` `public="..."` value.
+   *
+   * For an unauthenticated request, the public permissions are identical to the agent's permissions,
+   * so no extra work is needed.
+   *
+   * For an authenticated request, the public permissions are those of the empty credential set `{}`.
+   * These are normally already available on the user permission set as a comparison result attached by
+   * the {@link AuthorizingHttpHandler} (which requests them via `credentialsToCompare`), so the effective
+   * ACL does not have to be resolved a second time. If they are not present (for instance because the
+   * configured permission reader does not support `credentialsToCompare`), this falls back to the original
+   * behaviour of making a separate reader call with empty credentials.
+   *
+   * @param target - The resource the `WAC-Allow` header is being generated for.
+   * @param userPermissions - The permission set found for the requesting agent on the target.
+   * @param credentials - The requesting agent's credentials.
+   * @param requestedModes - The modes that were requested.
+   */
+  private async determinePublicPermissions(
+    target: ResourceIdentifier,
+    userPermissions: AclPermissionSet,
+    credentials: Credentials,
+    requestedModes: AccessMap,
+  ): Promise<AclPermissionSet> {
+    if (!credentials.agent?.webId) {
+      // User is not authenticated so public permissions are the same as agent permissions
+      this.logger.debug('User is not authenticated so has public permissions');
+      return userPermissions;
+    }
+
+    // Reuse the public permissions computed against the already-resolved ACL during the user pass, if present.
+    const comparisons = getComparisonPermissions(userPermissions);
+    if (comparisons) {
+      this.logger.debug('Reusing public permissions resolved alongside the user permissions');
+      return comparisons[PUBLIC_COMPARISON_INDEX] ?? {};
+    }
+
+    // Fallback: the reader did not provide comparison permissions, so determine them separately.
+    // Note that this call can potentially create a new lock on a resource that is already locked,
+    // so a locker that allows multiple read locks on the same resource is required.
+    this.logger.debug('Determining public permissions separately');
+    const permissionMap = await this.permissionReader.handleSafe({ credentials: {}, requestedModes });
+    return permissionMap.get(target) ?? {};
   }
 
   /**

--- a/test/unit/authorization/OwnerPermissionReader.test.ts
+++ b/test/unit/authorization/OwnerPermissionReader.test.ts
@@ -1,6 +1,7 @@
 import type { Credentials } from '../../../src/authentication/Credentials';
 import { OwnerPermissionReader } from '../../../src/authorization/OwnerPermissionReader';
 import { AclMode } from '../../../src/authorization/permissions/AclPermissionSet';
+import { getComparisonPermissions } from '../../../src/authorization/permissions/ComparisonPermissions';
 import type { AccessMap } from '../../../src/authorization/permissions/Permissions';
 import type { AuxiliaryIdentifierStrategy } from '../../../src/http/auxiliary/AuxiliaryIdentifierStrategy';
 import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
@@ -86,5 +87,25 @@ describe('An OwnerPermissionReader', (): void => {
         control: true,
       },
     ]]));
+  });
+
+  it('attaches an empty comparison set for a non-owner comparison credential.', async(): Promise<void> => {
+    // Owner is the primary; the public ({}) comparison is not an owner so its set is empty.
+    const result = await reader.handle({ credentials, requestedModes, credentialsToCompare: [{}]});
+    const set = result.get(identifier);
+    expect(set).toMatchObject({ control: true });
+    expect(getComparisonPermissions(set)).toEqual([{}]);
+  });
+
+  it('grants a comparison credential owner permissions when the primary is not an owner.', async(): Promise<void> => {
+    credentials = { agent: { webId: 'http://example.com/otherWebId' }};
+    const ownerCompare = [{ agent: { webId: owner }}];
+    const result = await reader.handle({ credentials, requestedModes, credentialsToCompare: ownerCompare });
+    const set = result.get(identifier);
+    // Primary (non-owner) gets an empty primary set, but the comparison (the owner) gets full control.
+    expect(set).toBeDefined();
+    // No enumerable (string-keyed) primary permissions were granted to the non-owner.
+    expect(Object.keys(set!)).toHaveLength(0);
+    expect(getComparisonPermissions(set)![0]).toMatchObject({ control: true });
   });
 });

--- a/test/unit/authorization/UnionPermissionReader.test.ts
+++ b/test/unit/authorization/UnionPermissionReader.test.ts
@@ -1,4 +1,7 @@
 import type { PermissionReader, PermissionReaderInput } from '../../../src/authorization/PermissionReader';
+import type { PermissionSetWithComparisons } from '../../../src/authorization/permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS, getComparisonPermissions } from
+  '../../../src/authorization/permissions/ComparisonPermissions';
 import type { PermissionSet } from '../../../src/authorization/permissions/Permissions';
 import { AccessMode } from '../../../src/authorization/permissions/Permissions';
 import { UnionPermissionReader } from '../../../src/authorization/UnionPermissionReader';
@@ -68,5 +71,35 @@ describe('A UnionPermissionReader', (): void => {
     compareMaps(await unionReader.handle(input), new IdentifierMap(
       [[ identifier, { read: false, write: false, append: true, create: true }]],
     ));
+  });
+
+  it('merges comparison permissions (the COMPARISON_PERMISSIONS symbol) across readers.', async(): Promise<void> => {
+    const set0: PermissionSetWithComparisons = { read: true };
+    set0[COMPARISON_PERMISSIONS] = [{ read: true, write: false }];
+    const set1: PermissionSetWithComparisons = { write: true };
+    set1[COMPARISON_PERMISSIONS] = [{ read: false, write: true, append: true }];
+    readers[0].handle.mockResolvedValue(new IdentifierMap([[ identifier, set0 ]]));
+    readers[1].handle.mockResolvedValue(new IdentifierMap([[ identifier, set1 ]]));
+
+    const result = await unionReader.handle(input);
+    // Primary merges as usual.
+    expect(result.get(identifier)).toMatchObject({ read: true, write: true });
+    // Comparison entry merges position 0 with the same false > true > undefined rule.
+    const comparisons = getComparisonPermissions(result.get(identifier));
+    expect(comparisons).toHaveLength(1);
+    expect(comparisons![0]).toEqual({ read: false, write: false, append: true });
+  });
+
+  it('does not mutate a source reader comparison set while merging.', async(): Promise<void> => {
+    const set0: PermissionSetWithComparisons = { read: true };
+    const source0 = { read: true };
+    set0[COMPARISON_PERMISSIONS] = [ source0 ];
+    readers[0].handle.mockResolvedValue(new IdentifierMap([[ identifier, set0 ]]));
+    readers[1].handle.mockResolvedValue(new IdentifierMap());
+
+    const result = await unionReader.handle(input);
+    getComparisonPermissions(result.get(identifier))![0].write = true;
+    // The original reader's comparison object must be untouched.
+    expect(source0).toEqual({ read: true });
   });
 });

--- a/test/unit/authorization/WebAclReader.test.ts
+++ b/test/unit/authorization/WebAclReader.test.ts
@@ -16,6 +16,7 @@ import { INTERNAL_QUADS } from '../../../src/util/ContentTypes';
 import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError';
 import { InternalServerError } from '../../../src/util/errors/InternalServerError';
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
+import { getComparisonPermissions } from '../../../src/authorization/permissions/ComparisonPermissions';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
 import { IdentifierMap, IdentifierSetMultiMap } from '../../../src/util/map/IdentifierMap';
 import { compareMaps } from '../../util/Util';
@@ -207,5 +208,53 @@ describe('A WebAclReader', (): void => {
     ]));
     // http://example.com/.acl and http://example.com/bar/.acl
     expect(store.getRepresentation).toHaveBeenCalledTimes(2);
+  });
+
+  it('evaluates credentialsToCompare against the same ACL without re-resolving it.', async(): Promise<void> => {
+    // The ACL grants Read to a specific agent and Append to everyone (foaf:Agent).
+    store.getRepresentation.mockResolvedValue(new BasicRepresentation([
+      quad(nn('user'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+      quad(nn('user'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('user'), nn(`${acl}mode`), nn(`${acl}Read`)),
+      quad(nn('public'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+      quad(nn('public'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('public'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+      quad(nn('public'), nn(`${acl}mode`), nn(`${acl}Append`)),
+    ], INTERNAL_QUADS));
+    // Authenticated agent matches the `user` rule; the empty comparison only matches the `public` rule.
+    accessChecker.handleSafe.mockImplementation(async({ rule, credentials: creds }): Promise<boolean> => {
+      if (rule.value === 'public') {
+        return true;
+      }
+      return Boolean(creds.agent?.webId);
+    });
+
+    input.credentialsToCompare = [{}];
+    const result = await reader.handle(input);
+
+    // Primary result is the authenticated agent's permissions: Read (+ Append from the public rule).
+    const userSet = result.get(identifier)!;
+    expect(userSet.read).toBe(true);
+    expect(userSet.append).toBe(true);
+
+    // The public comparison is attached and contains ONLY the public (Append) permission, no Read.
+    const comparisons = getComparisonPermissions(userSet);
+    expect(comparisons).toBeDefined();
+    expect(comparisons).toHaveLength(1);
+    expect(comparisons![0]).toEqual({ append: true });
+
+    // The effective ACL was read exactly once even though two credential sets were evaluated.
+    expect(store.getRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attach comparison data when credentialsToCompare is absent.', async(): Promise<void> => {
+    credentials.agent = { webId: 'http://test.com/user' };
+    store.getRepresentation.mockResolvedValue(new BasicRepresentation([
+      quad(nn('auth'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+      quad(nn('auth'), nn(`${acl}accessTo`), nn(identifier.path)),
+      quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+    ], INTERNAL_QUADS));
+    const result = await reader.handle(input);
+    expect(getComparisonPermissions(result.get(identifier))).toBeUndefined();
   });
 });

--- a/test/unit/server/AuthorizingHttpHandler.test.ts
+++ b/test/unit/server/AuthorizingHttpHandler.test.ts
@@ -71,11 +71,29 @@ describe('An AuthorizingHttpHandler', (): void => {
     expect(modesExtractor.handleSafe).toHaveBeenCalledTimes(1);
     expect(modesExtractor.handleSafe).toHaveBeenLastCalledWith(operation);
     expect(permissionReader.handleSafe).toHaveBeenCalledTimes(1);
+    // Unauthenticated request (default credentials `{}`): no comparison credentials are requested.
     expect(permissionReader.handleSafe).toHaveBeenLastCalledWith({ credentials, requestedModes });
+    expect(permissionReader.handleSafe.mock.calls[0][0].credentialsToCompare).toBeUndefined();
     expect(authorizer.handleSafe).toHaveBeenCalledTimes(1);
     expect(authorizer.handleSafe).toHaveBeenLastCalledWith({ credentials, requestedModes, availablePermissions });
     expect(source.handleSafe).toHaveBeenCalledTimes(1);
     expect(source.handleSafe).toHaveBeenLastCalledWith({ request, response, operation });
+  });
+
+  it('requests the public permissions as a comparison for authenticated requests.', async(): Promise<void> => {
+    credentialsExtractor.handleSafe.mockResolvedValue({ agent: { webId: 'http://example.com/#me' }});
+    await expect(handler.handle({ request, response, operation })).resolves.toBeUndefined();
+    expect(permissionReader.handleSafe).toHaveBeenCalledTimes(1);
+    const readerInput = permissionReader.handleSafe.mock.calls[0][0];
+    // The public ({}) credentials are passed via `credentialsToCompare` so the nested WacAllowHttpHandler
+    // can build the `public` part of the WAC-Allow header without re-resolving the effective ACL.
+    expect(readerInput.credentialsToCompare).toEqual([{}]);
+    // The authorization decision still uses the same `availablePermissions` (the symbol carrier is invisible).
+    expect(authorizer.handleSafe).toHaveBeenLastCalledWith({
+      credentials: { agent: { webId: 'http://example.com/#me' }},
+      requestedModes,
+      availablePermissions,
+    });
   });
 
   it('errors with added access modes if authorization fails.', async(): Promise<void> => {

--- a/test/unit/server/WacAllowHttpHandler.test.ts
+++ b/test/unit/server/WacAllowHttpHandler.test.ts
@@ -1,6 +1,8 @@
 import 'jest-rdf';
 import type { CredentialsExtractor } from '../../../src/authentication/CredentialsExtractor';
 import type { PermissionReader } from '../../../src/authorization/PermissionReader';
+import type { PermissionSetWithComparisons } from '../../../src/authorization/permissions/ComparisonPermissions';
+import { COMPARISON_PERMISSIONS } from '../../../src/authorization/permissions/ComparisonPermissions';
 import type { ModesExtractor } from '../../../src/authorization/permissions/ModesExtractor';
 import type { Operation } from '../../../src/http/Operation';
 import { OkResponseDescription } from '../../../src/http/output/response/OkResponseDescription';
@@ -115,7 +117,7 @@ describe('A WacAllowHttpHandler', (): void => {
     await expect(handler.handle({ operation, request, response })).rejects.toThrow(error);
   });
 
-  it('determines public permissions separately in case of an authenticated request.', async(): Promise<void> => {
+  it('makes a separate reader call for public permissions when none are attached.', async(): Promise<void> => {
     credentialsExtractor.handleSafe.mockResolvedValue({ agent: { webId: 'http://example.com/#me' }});
     permissionReader.handleSafe.mockResolvedValueOnce(new IdentifierMap(
       [[ target, { read: true, write: true, append: false }]],
@@ -144,6 +146,37 @@ describe('A WacAllowHttpHandler', (): void => {
       credentials: {},
       requestedModes: await modesExtractor.handleSafe.mock.results[0].value,
     });
+  });
+
+  it('reuses public permissions attached to the user result without a second reader call.', async(): Promise<void> => {
+    credentialsExtractor.handleSafe.mockResolvedValue({ agent: { webId: 'http://example.com/#me' }});
+    // The reader (driven by `credentialsToCompare` from the AuthorizingHttpHandler) attaches the public
+    // permissions to the user permission set under the COMPARISON_PERMISSIONS symbol. WacAllow must read
+    // them from there and NOT make a second reader call.
+    const userSet: PermissionSetWithComparisons = { read: true, write: true, append: false };
+    userSet[COMPARISON_PERMISSIONS] = [{ read: true, write: false, append: true }];
+    permissionReader.handleSafe.mockResolvedValueOnce(new IdentifierMap([[ target, userSet ]]));
+
+    await expect(handler.handle({ operation, request, response })).resolves.toEqual(output);
+    expect(output.metadata!.quads()).toHaveLength(4);
+    expect(output.metadata!.getAll(AUTH.terms.userMode)).toEqualRdfTermArray([ ACL.terms.Read, ACL.terms.Write ]);
+    expect(output.metadata!.getAll(AUTH.terms.publicMode)).toEqualRdfTermArray([ ACL.terms.Read, ACL.terms.Append ]);
+
+    // Crucially: only ONE reader call (no separate public pass) because the comparison was reused.
+    expect(permissionReader.handleSafe).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses an empty public set if the attached comparison has no entry for the target.', async(): Promise<void> => {
+    credentialsExtractor.handleSafe.mockResolvedValue({ agent: { webId: 'http://example.com/#me' }});
+    const userSet: PermissionSetWithComparisons = { read: true, write: true };
+    // Empty comparison array entry -> public gets nothing.
+    userSet[COMPARISON_PERMISSIONS] = [{}];
+    permissionReader.handleSafe.mockResolvedValueOnce(new IdentifierMap([[ target, userSet ]]));
+
+    await expect(handler.handle({ operation, request, response })).resolves.toEqual(output);
+    expect(output.metadata!.getAll(AUTH.terms.userMode)).toEqualRdfTermArray([ ACL.terms.Read, ACL.terms.Write ]);
+    expect(output.metadata!.getAll(AUTH.terms.publicMode)).toEqualRdfTermArray([]);
+    expect(permissionReader.handleSafe).toHaveBeenCalledTimes(1);
   });
 
   it('adds no permissions if none of them are on the target.', async(): Promise<void> => {

--- a/test/unit/server/WacResolveOncePath.test.ts
+++ b/test/unit/server/WacResolveOncePath.test.ts
@@ -1,0 +1,191 @@
+import 'jest-rdf';
+import { DataFactory } from 'n3';
+import type { Credentials } from '../../../src/authentication/Credentials';
+import type { CredentialsExtractor } from '../../../src/authentication/CredentialsExtractor';
+import type { AccessChecker } from '../../../src/authorization/access/AccessChecker';
+import { AuxiliaryReader } from '../../../src/authorization/AuxiliaryReader';
+import type { Authorizer } from '../../../src/authorization/Authorizer';
+import { PermissionBasedAuthorizer } from '../../../src/authorization/PermissionBasedAuthorizer';
+import { UnionPermissionReader } from '../../../src/authorization/UnionPermissionReader';
+import { WebAclReader } from '../../../src/authorization/WebAclReader';
+import { AclMode } from '../../../src/authorization/permissions/AclPermissionSet';
+import type { ModesExtractor } from '../../../src/authorization/permissions/ModesExtractor';
+import type { AccessMap } from '../../../src/authorization/permissions/Permissions';
+import { AccessMode } from '../../../src/authorization/permissions/Permissions';
+import type { AuxiliaryIdentifierStrategy } from '../../../src/http/auxiliary/AuxiliaryIdentifierStrategy';
+import type { AuxiliaryStrategy } from '../../../src/http/auxiliary/AuxiliaryStrategy';
+import type { Operation } from '../../../src/http/Operation';
+import { OkResponseDescription } from '../../../src/http/output/response/OkResponseDescription';
+import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
+import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import { AuthorizingHttpHandler } from '../../../src/server/AuthorizingHttpHandler';
+import type { HttpRequest } from '../../../src/server/HttpRequest';
+import type { HttpResponse } from '../../../src/server/HttpResponse';
+import type { OperationHttpHandler } from '../../../src/server/OperationHttpHandler';
+import { WacAllowHttpHandler } from '../../../src/server/WacAllowHttpHandler';
+import type { ResourceSet } from '../../../src/storage/ResourceSet';
+import type { ResourceStore } from '../../../src/storage/ResourceStore';
+import { INTERNAL_QUADS } from '../../../src/util/ContentTypes';
+import { CachedHandler } from '../../../src/util/handlers/CachedHandler';
+import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
+import { IdentifierSetMultiMap } from '../../../src/util/map/IdentifierMap';
+import { ACL, AUTH } from '../../../src/util/Vocabularies';
+
+const { namedNode: nn, quad } = DataFactory;
+const acl = 'http://www.w3.org/ns/auth/acl#';
+const rdf = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+
+/**
+ * Drives the REAL AuthorizingHttpHandler -> WacAllowHttpHandler -> OperationHandler chain
+ * over the REAL cached reader stack (CachedHandler -> AuxiliaryReader -> UnionPermissionReader -> WebAclReader)
+ * and counts how many times the effective `.acl` is resolved (read) for a single request,
+ * just as production does. CredentialsExtractor/ModesExtractor are cached on (request)/(operation)
+ * exactly like production, so the WAC-Allow user pass HITs the reader cache.
+ */
+describe('Full auth + WAC-Allow request path: effective .acl resolution count', (): void => {
+  const target: ResourceIdentifier = { path: 'http://example.com/foo' };
+  const aclStrategy: AuxiliaryIdentifierStrategy = {
+    getAuxiliaryIdentifier: (id: ResourceIdentifier): ResourceIdentifier => ({ path: `${id.path}.acl` }),
+    isAuxiliaryIdentifier: (id: ResourceIdentifier): boolean => id.path.endsWith('.acl'),
+    getSubjectIdentifier: (id: ResourceIdentifier): ResourceIdentifier => ({ path: id.path.slice(0, -4) }),
+  } as any;
+  const identifierStrategy = new SingleRootIdentifierStrategy('http://example.com/');
+
+  let aclReads: string[];
+  let store: jest.Mocked<ResourceStore>;
+  let resourceSet: jest.Mocked<ResourceSet>;
+  let accessChecker: jest.Mocked<AccessChecker>;
+  let auxiliaryStrategy: jest.Mocked<AuxiliaryStrategy>;
+  let permissionReader: CachedHandler<any, any>;
+
+  const request: HttpRequest = {} as any;
+  const response: HttpResponse = {} as any;
+
+  // Build a cached credentials extractor keyed on the request object (production behaviour).
+  function cachedCredentials(creds: Credentials): jest.Mocked<CredentialsExtractor> {
+    const cache = new WeakMap<object, Credentials>();
+    return {
+      handleSafe: jest.fn().mockImplementation(async(req: object): Promise<Credentials> => {
+        let value = cache.get(req);
+        if (!value) {
+          value = creds;
+          cache.set(req, value);
+        }
+        return value;
+      }),
+    } as any;
+  }
+
+  function cachedModes(modes: AccessMap): jest.Mocked<ModesExtractor> {
+    const cache = new WeakMap<object, AccessMap>();
+    return {
+      handleSafe: jest.fn().mockImplementation(async(op: object): Promise<AccessMap> => {
+        let value = cache.get(op);
+        if (!value) {
+          value = modes;
+          cache.set(op, value);
+        }
+        return value;
+      }),
+    } as any;
+  }
+
+  beforeEach((): void => {
+    aclReads = [];
+    resourceSet = { hasResource: jest.fn().mockResolvedValue(true) } as any;
+    store = {
+      getRepresentation: jest.fn().mockImplementation(async(id: ResourceIdentifier): Promise<BasicRepresentation> => {
+        aclReads.push(id.path);
+        return new BasicRepresentation([
+          quad(nn('auth'), nn(`${rdf}type`), nn(`${acl}Authorization`)),
+          quad(nn('auth'), nn(`${acl}accessTo`), nn(target.path)),
+          quad(nn('auth'), nn(`${acl}agentClass`), nn('http://xmlns.com/foaf/0.1/Agent')),
+          quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Read`)),
+          quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Write`)),
+          quad(nn('auth'), nn(`${acl}mode`), nn(`${acl}Control`)),
+        ], INTERNAL_QUADS);
+      }),
+    } as any;
+    accessChecker = { handleSafe: jest.fn().mockResolvedValue(true) } as any;
+    auxiliaryStrategy = {
+      isAuxiliaryIdentifier: jest.fn().mockReturnValue(false),
+      usesOwnAuthorization: jest.fn().mockReturnValue(false),
+      getSubjectIdentifier: jest.fn(),
+    } as any;
+
+    const webAcl = new WebAclReader(aclStrategy, resourceSet, store, identifierStrategy, accessChecker);
+    const union = new UnionPermissionReader([ webAcl ]);
+    const aux = new AuxiliaryReader(union, auxiliaryStrategy);
+    permissionReader = new CachedHandler(aux as any, [ 'credentials', 'requestedModes' ]);
+  });
+
+  function buildOperation(): Operation {
+    return { target, method: 'GET', preferences: {}, body: new BasicRepresentation() };
+  }
+
+  function buildModes(): AccessMap {
+    return new IdentifierSetMultiMap<any>([
+      [ target, AccessMode.read ],
+      [ target, AclMode.control ],
+    ]);
+  }
+
+  function buildChain(creds: Credentials, modes: AccessMap): {
+    handler: AuthorizingHttpHandler;
+    authorizer: Authorizer;
+  } {
+    const credentialsExtractor = cachedCredentials(creds);
+    const modesExtractor = cachedModes(modes);
+    const authorizer = new PermissionBasedAuthorizer(resourceSet);
+    const okOutput = new OkResponseDescription(new RepresentationMetadata());
+    const finalHandler: OperationHttpHandler = { handleSafe: jest.fn().mockResolvedValue(okOutput) } as any;
+    const wacAllow = new WacAllowHttpHandler({
+      credentialsExtractor,
+      modesExtractor,
+      permissionReader: permissionReader as any,
+      operationHandler: finalHandler,
+    });
+    const handler = new AuthorizingHttpHandler({
+      credentialsExtractor,
+      modesExtractor,
+      permissionReader: permissionReader as any,
+      authorizer,
+      operationHandler: wacAllow,
+    });
+    return { handler, authorizer };
+  }
+
+  it('AUTHENTICATED GET resolves the effective .acl exactly ONCE across auth + WAC-Allow.', async(): Promise<void> => {
+    const { handler } = buildChain({ agent: { webId: 'http://example.com/#me' }}, buildModes());
+    const result = await handler.handle({ operation: buildOperation(), request, response });
+
+    // The redundant second resolution (the WAC-Allow public pass) is gone: 2 -> 1.
+    expect(aclReads).toEqual([ 'http://example.com/foo.acl' ]);
+
+    // WAC-Allow header is byte-identical: the ACL grants foaf:Agent Read/Write/Control, and
+    // acl:Write maps to both append+write, so user and public both list Read/Append/Write/Control.
+    const expected = [ ACL.terms.Read, ACL.terms.Append, ACL.terms.Write, ACL.terms.Control ];
+    expect(result.metadata!.getAll(AUTH.terms.userMode)).toEqualRdfTermArray(expected);
+    expect(result.metadata!.getAll(AUTH.terms.publicMode)).toEqualRdfTermArray(expected);
+  });
+
+  it('UNAUTHENTICATED GET resolves the effective .acl exactly once.', async(): Promise<void> => {
+    const { handler } = buildChain({}, buildModes());
+    const result = await handler.handle({ operation: buildOperation(), request, response });
+    expect(aclReads).toEqual([ 'http://example.com/foo.acl' ]);
+    // Public == user for an unauthenticated request.
+    const expected = [ ACL.terms.Read, ACL.terms.Append, ACL.terms.Write, ACL.terms.Control ];
+    expect(result.metadata!.getAll(AUTH.terms.userMode)).toEqualRdfTermArray(expected);
+    expect(result.metadata!.getAll(AUTH.terms.publicMode)).toEqualRdfTermArray(expected);
+  });
+
+  it('PUT resolves the effective .acl exactly once (no WAC-Allow).', async(): Promise<void> => {
+    const modes = new IdentifierSetMultiMap<any>([[ target, AccessMode.write ]]);
+    const { handler } = buildChain({ agent: { webId: 'http://example.com/#me' }}, modes);
+    const op = buildOperation();
+    op.method = 'PUT';
+    await handler.handle({ operation: op, request, response });
+    expect(aclReads).toEqual([ 'http://example.com/foo.acl' ]);
+  });
+});


### PR DESCRIPTION
🚧 **DRAFT — not ready for review.** Opened by @jeswr's AI coding agent, intentionally in **draft** for **@jeswr to review first**, before maintainer review. Please hold off reviewing until it's marked ready.

---

**Alternative to #2182.** This is the **cache-free, structural ("resolve-once, evaluate-many")** counterpart to the request-scoped WeakMap memoization in #2182, opened so the two can be compared side by side. Same base commit (`upstream/main` `fb31e5775`) so the diffs are directly comparable. The maintainer picks whichever fits the project better; this PR exists to make that an informed choice, and (per the honest-tradeoff section below) it is the **more invasive** of the two.

## The problem (measured)

A single **authenticated** `GET`/`HEAD` resolves the target's effective `.acl` **twice**.

The permission-reader composite is wrapped by a `CachedHandler` keyed on `[credentials, requestedModes]` (`config/ldp/authorization/readers/default.json`). For an authenticated read the reader is invoked across three passes that ask genuinely-different permission questions but all resolve the **same, credential-independent** effective ACL:

| Pass | Where | `credentials` | Cache | Resolves ACL? |
|---|---|---|---|---|
| Authorization decision | `AuthorizingHttpHandler` | user | miss | **yes** |
| WAC-Allow `user="…"` | `WacAllowHttpHandler` | user (same objects) | **hit** | no |
| WAC-Allow `public="…"` | `WacAllowHttpHandler` | `{}` (fresh literal) | **miss** | **yes (redundant)** |

`ModesExtractor` and `CredentialsExtractor` are themselves cached on the operation/request, so the user passes share object identity and the WAC-Allow user pass is a cache hit. But the WAC-Allow **public** pass passes a fresh empty `{}` literal — a cache **miss** — so `WebAclReader` re-walks the container hierarchy and re-reads + re-parses the same `.acl`, even though the resolved ACL is identical and credential-independent.

## Before / after read counts

Measured through the real `AuthorizingHttpHandler → WacAllowHttpHandler → CachedHandler → AuxiliaryReader → UnionPermissionReader → WebAclReader` chain (counting `aclStore.getRepresentation` calls for the `.acl`):

| Request | Before | After |
|---|---|---|
| **Authenticated GET** | **2** | **1** |
| Unauthenticated GET | 1 | 1 |
| PUT | 1 | 1 |

A regression test (`test/unit/server/WacResolveOncePath.test.ts`) drives that real chain and asserts a single resolution; it **fails on `main` (2 reads)** and passes here (1) — parity with #2182's measurement.

## The structural approach (no cache, no memoization, stateless)

The redundant resolution is the public pass. Rather than memoizing the resolution, this makes the **one** invocation that resolves the ACL also evaluate the public credential set against it:

1. **`PermissionReaderInput` gains an optional `credentialsToCompare?: Credentials[]`** — additional credential sets to evaluate against the *same* resolved ACL. Optional ⇒ non-breaking; readers that ignore it behave identically.
2. **`WebAclReader`** resolves the effective ACL **once** (unchanged walk + read + parse) and runs the per-credential evaluation for the primary credentials **and** each comparison set against that single parsed store.
3. The comparison results are carried on a **non-enumerable `Symbol` key** (`ComparisonPermissions`) on each `PermissionSet`. A `Symbol` is never returned by `Object.keys`/`entries`/`for…in`/`JSON.stringify`, so it is **invisible** to `PermissionBasedAuthorizer` (reads explicit `AccessMode` keys) and to `WacAllowHttpHandler.addWacAllowMetadata` (iterates `Object.keys`, filters on the four valid ACL modes). The primary `PermissionMap` is therefore unchanged.
4. **`AuthorizingHttpHandler`** attaches the public (`{}`) comparison on its single (cache-populating) reader call for authenticated requests. This is the key to avoiding a cache-key trap: the cache is keyed on `[credentials, requestedModes]`, **not** on `credentialsToCompare` — so if the comparison were requested only on the WAC-Allow user pass (a cache hit), the cached value would lack it. By enriching the **authorization-decision pass** (the request's only `[user, modes]` cache miss, which always runs first), the single cached value already carries the public comparison, and the WAC-Allow user-pass **hit** reads it.
5. **`WacAllowHttpHandler`** reads the public permissions from that shared user result instead of re-invoking the reader, and **falls back** to the original separate `{credentials: {}}` call when no comparison is attached (e.g. a reader that ignores the field, such as the ACP strategy) — fail-safe, never wrong.
6. The comparison sets are threaded and transformed **identically to the primary** through the union (`UnionPermissionReader` merges them index-aligned with the same `false > true > undefined` rule), parent-container create/delete derivation (`ParentContainerReader`), control→read/write interpretation on `.acl` (`AuthAuxiliaryReader`), and pod-owner grants (`OwnerPermissionReader`) — so the public value matches a full separate pass.

No persistent or cross-request state is introduced.

## WAC is byte-identical (evidence)

- **`test/integration/PermissionTable.test.ts` — 408/408** (the exhaustive WAC permission/status-code matrix) pass unchanged → no authorization-decision change.
- **`test/integration/LdpHandlerWithAuth.test.ts` — 18/18** pass unchanged, including the assertions on the **exact `WAC-Allow` header string** (e.g. `user="append read write",public="append read write"`, `user="read",public="read"`, `user="append control read write",public="append control read write"`) — now exercised through the resolve-once reuse path.
- `WacAllowHttpHandler` / `WebAclReader` / `AuthorizingHttpHandler` unit assertions on the header (`toEqualRdfTermArray`) and the authorizer's `availablePermissions` are unchanged and passing.

## Verification (all green, run on the branch HEAD)

- `npx tsc -p test --noEmit` ✅ (the CI `test-unit` typecheck — not just `build:ts`)
- `npm run build:ts` ✅
- unit: `test/unit/authorization/**`, `WacAllowHttpHandler`, `AuthorizingHttpHandler`, `WacResolveOncePath` — **123/123** ✅
- integration: `LdpHandlerWithAuth` **18/18**, `PermissionTable` **408/408** ✅ (run as separate jest processes; running both in one parallel invocation collides on the shared test port — a harness limitation, not a logic failure)
- `eslint` on all changed files ✅

## Honest tradeoff vs #2182 (the whole point of the side-by-side)

This cache-free refactor is **correct, fully tested, and byte-identical** — but it is **genuinely more invasive and more coupled** than #2182's WeakMap memoization. Stated plainly so the comparison is fair:

| | This PR (cache-free, structural) | #2182 (request-scoped WeakMap) |
|---|---|---|
| Source files touched | **10** (+1 new module) | **1** (`WebAclReader.ts`) |
| Source diff | ~**265** lines | ~**25** lines |
| Public surface added | `credentialsToCompare` on `PermissionReaderInput` + a `Symbol` carrier on `PermissionSet` (cross-cutting, every reader must respect it) | **none** (private impl detail of one class) |
| State | **none** (stateless; nothing to invalidate) | a `WeakMap<AccessMap, …>` request-scoped cache |
| Main fragility | a **distributed correctness invariant**: a future reader added to the union that forgets to thread/transform the `Symbol` carrier could yield a wrong (or, via the fail-safe fallback, merely re-resolved) public `WAC-Allow` value | the WeakMap lifetime/request-scoping argument (mitigated by keying on the per-request `AccessMap` object) |
| Cache-key subtlety | yes — needs `AuthorizingHttpHandler` to pre-seed the comparison so the WAC-Allow hit carries it (explained above) | sidestepped entirely |

**My honest recommendation:** if the only goal is "stop resolving twice with the least risk and smallest diff," **#2182's WeakMap is cleaner** — single-file, ~1/10th the diff, no new public contract, no distributed invariant. **This PR is the better choice only if a cache-free / stateless implementation is a hard requirement** (e.g. to keep the core fully stateless and avoid any in-reader memoization), in which case it delivers exactly that, correctly and with full WAC parity, at the cost of a larger, more coupled change. Both are gated to the same standard; they differ in shape, not in observable behaviour.

---

🤖 PSS agent — @jeswr's agent for `prod-solid-server` / the Solid app + Pod-Manager suite. Opened on @jeswr's behalf; **draft, for @jeswr to review first.**
