### PR TITLE
Add pim:storage triple to WebID when checkbox is checked

### DIFF
--- a/src/pods/settings/PodSettings.ts
+++ b/src/pods/settings/PodSettings.ts
@@ -29,4 +29,8 @@ export interface PodSettings extends NodeJS.Dict<unknown> {
    * The OIDC issuer of the owner's WebId. Necessary if the WebID in the pod is registered with the IDP.
    */
   oidcIssuer?: string;
+  /**
+   * If true: links the pod storage root using a pim:storage triple in the generated WebID.
+   */
+  linkStorage?: boolean;
 }

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -242,6 +242,7 @@ export const OIDC = createVocabulary(
 export const PIM = createVocabulary(
   'http://www.w3.org/ns/pim/space#',
   'Storage',
+  'storage',
 );
 
 export const POSIX = createVocabulary(

--- a/templates/identity/account/create-pod.html.ejs
+++ b/templates/identity/account/create-pod.html.ejs
@@ -17,6 +17,17 @@
           <input type="radio" id="internalWebIdOn" name="internalWebId" value="on" checked>
           Use the WebID in the Pod and register it to your account.
         </label>
+        <ol id="linkStorageForm">
+          <li class="checkbox">
+            <label>
+              <input type="checkbox" id="linkStorage" name="linkStorage" checked>
+              Link to this storage from my WebID.
+              <p class="checkbox-explanation">This adds a <code>pim:storage</code> triple to the WebID document.
+                This triple is the asserts that you own the storage.
+                Without this triple applications will have to ask you where your storage is located.</p>
+            </label>
+          </li>
+        </ol>
       </li>
       <li class="radio">
         <label>
@@ -61,7 +72,7 @@
 
 
 <script>
-  const { mainForm } = getElements('mainForm');
+  const { mainForm, internalWebIdOn, linkStorageCheckbox } = getElements('mainForm', 'internalWebIdOn', 'linkStorageCheckbox');
 
   (async() => {
     let res = await fetch('<%= idpIndex %>', { headers: { accept: 'application/json' } });
@@ -70,6 +81,19 @@
     setRedirectClick('account-link', controls.html.account.account);
     setRedirectClick('response-account-link', controls.html.account.account);
 
+    // Toggle visibility of the "link storage" checkbox based on which WebID option is chosen
+    function updateLinkStorageVisibility() {
+      setVisibility('linkStorageForm', internalWebIdOn.checked);
+      if (!internalWebIdOn.checked) {
+        linkStorageCheckbox.checked = false;
+      }
+    }
+    mainForm.addEventListener('change', (event) => {
+      if (event.target.name === 'internalWebId') {
+        updateLinkStorageVisibility();
+      }
+    });
+
     addPostListener(async() => {
       const formData = new FormData(mainForm);
       const json = {
@@ -77,6 +101,8 @@
       }
       if (formData.get('internalWebId') === '') {
         json.settings = { webId: formData.get('webId') };
+      } else if (formData.get('linkStorage') === 'on') {
+        json.settings = { linkStorage: true };
       }
 
       const res = await postJson(controls.account.pod, json);

--- a/templates/identity/account/create-pod.html.ejs
+++ b/templates/identity/account/create-pod.html.ejs
@@ -24,7 +24,7 @@
               Link to this storage from my WebID.
               <p class="checkbox-explanation">This adds a <code>pim:storage</code> triple to the WebID document.
                 This triple is the asserts that you own the storage.
-                Without this triple applications will have to ask you where your storage is located.</p>
+                Without this triple, applications will have to ask you where your storage is located.</p>
             </label>
           </li>
         </ol>

--- a/templates/pod/base/profile/card$.ttl.hbs
+++ b/templates/pod/base/profile/card$.ttl.hbs
@@ -1,5 +1,6 @@
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
 @prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix pim: <http://www.w3.org/ns/pim/space#>.
 
 <>
     a foaf:PersonalProfileDocument;
@@ -9,4 +10,5 @@
 <{{webId}}>
     {{#if name}}foaf:name "{{name}}";{{/if}}
     {{#if oidcIssuer}}solid:oidcIssuer <{{oidcIssuer}}>;{{/if}}
+    pim:storage <{{base.path}}>;
     a foaf:Person.

--- a/templates/pod/base/profile/card$.ttl.hbs
+++ b/templates/pod/base/profile/card$.ttl.hbs
@@ -10,5 +10,5 @@
 <{{webId}}>
     {{#if name}}foaf:name "{{name}}";{{/if}}
     {{#if oidcIssuer}}solid:oidcIssuer <{{oidcIssuer}}>;{{/if}}
-    pim:storage <{{base.path}}>;
+    {{#if linkStorage}}pim:storage <{{base.path}}>;{{/if}}
     a foaf:Person.

--- a/test/integration/Accounts.test.ts
+++ b/test/integration/Accounts.test.ts
@@ -1,10 +1,12 @@
 import fetch from 'cross-fetch';
+import { Parser } from 'n3';
 import { parse, splitCookiesString } from 'set-cookie-parser';
 import { BasicRepresentation } from '../../src/http/representation/BasicRepresentation';
 import type { App } from '../../src/init/App';
 import type { ResourceStore } from '../../src/storage/ResourceStore';
 import { APPLICATION_X_WWW_FORM_URLENCODED } from '../../src/util/ContentTypes';
 import { joinUrl } from '../../src/util/PathUtil';
+import { PIM } from '../../src/util/Vocabularies';
 import { getPort } from '../util/Util';
 import { getDefaultVariables, getTestConfigPath, getTestFolder, instantiateFromConfig, removeFolder } from './Config';
 
@@ -270,6 +272,22 @@ describe.each(stores)('A server with account management using %s', (name, { conf
     res = await fetch(controls.account.webId, { headers: { cookie }});
     expect(res.status).toBe(200);
     expect((await res.json()).webIdLinks[webId]).toBeDefined();
+  });
+
+  it('includes pim:storage triple in the WebID profile.', async(): Promise<void> => {
+    // Fetch the WebID profile document
+    const profileUrl = webId.split('#')[0];
+    const res = await fetch(profileUrl, { headers: { accept: 'text/turtle' }});
+    expect(res.status).toBe(200);
+
+    // Parse and verify the pim:storage triple points to the pod root
+    const parser = new Parser({ baseIRI: profileUrl });
+    const quads = parser.parse(await res.text());
+    const storageQuads = quads.filter((q): boolean =>
+      q.subject.value === webId &&
+      q.predicate.value === PIM.storage &&
+      q.object.value === pod);
+    expect(storageQuads).toHaveLength(1);
   });
 
   it('can not remove the last owner of a pod.', async(): Promise<void> => {

--- a/test/integration/Accounts.test.ts
+++ b/test/integration/Accounts.test.ts
@@ -274,19 +274,29 @@ describe.each(stores)('A server with account management using %s', (name, { conf
     expect((await res.json()).webIdLinks[webId]).toBeDefined();
   });
 
-  it('includes pim:storage triple in the WebID profile.', async(): Promise<void> => {
+  it('can create a pod with a pim:storage triple.', async(): Promise<void> => {
+    let res = await fetch(controls.account.pod, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'pim', settings: { linkStorage: true }}),
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.pod).toBeDefined();
+    expect(json.webId).toBeDefined();
+
     // Fetch the WebID profile document
-    const profileUrl = webId.split('#')[0];
-    const res = await fetch(profileUrl, { headers: { accept: 'text/turtle' }});
+    const profileUrl = json.webId.split('#')[0];
+    res = await fetch(profileUrl, { headers: { accept: 'text/turtle' }});
     expect(res.status).toBe(200);
 
     // Parse and verify the pim:storage triple points to the pod root
     const parser = new Parser({ baseIRI: profileUrl });
     const quads = parser.parse(await res.text());
     const storageQuads = quads.filter((q): boolean =>
-      q.subject.value === webId &&
+      q.subject.value === json.webId &&
       q.predicate.value === PIM.storage &&
-      q.object.value === pod);
+      q.object.value === json.pod);
     expect(storageQuads).toHaveLength(1);
   });
 


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/910, https://github.com/CommunitySolidServer/CommunitySolidServer/pull/2147

#### ✍️ Description

Adds a checkbox when creating a pod, which, when checked, adds a pim:storage triple to the WebID.
