### PR TITLE
fix: Prevent inconsistencies with repeated slashes in identifiers

### DIFF
--- a/src/http/input/identifier/OriginalUrlExtractor.ts
+++ b/src/http/input/identifier/OriginalUrlExtractor.ts
@@ -6,7 +6,7 @@ import { errorTermsToMetadata } from '../../../util/errors/HttpErrorUtil';
 import { InternalServerError } from '../../../util/errors/InternalServerError';
 import { parseForwarded } from '../../../util/HeaderUtil';
 import type { IdentifierStrategy } from '../../../util/identifiers/IdentifierStrategy';
-import { toCanonicalUriPath } from '../../../util/PathUtil';
+import { normalizeUriPathSlashes, toCanonicalUriPath } from '../../../util/PathUtil';
 import type { ResourceIdentifier } from '../../representation/ResourceIdentifier';
 import { TargetExtractor } from './TargetExtractor';
 
@@ -85,7 +85,7 @@ export class OriginalUrlExtractor extends TargetExtractor {
     // URL object applies punycode encoding to domain
     const originalUrl = new URL(`${protocol}://${host}`);
     const [ , pathname, search ] = /^([^?]*)(.*)/u.exec(toCanonicalUriPath(url))!;
-    originalUrl.pathname = pathname;
+    originalUrl.pathname = normalizeUriPathSlashes(pathname);
     if (this.includeQueryString && search) {
       originalUrl.search = search;
     }

--- a/src/util/PathUtil.ts
+++ b/src/util/PathUtil.ts
@@ -159,6 +159,18 @@ export function toCanonicalUriPath(path: string): string {
     encodeURIComponent(decodeURIComponent(part)));
 }
 
+/**
+ * Collapses repeated forward slashes in the path part of a URI-like string.
+ * Query strings are preserved unchanged.
+ *
+ * @param path - URI path (optionally followed by a query string).
+ */
+export function normalizeUriPathSlashes(path: string): string {
+  const [ , pathname, queryString ] = /^([^?]*)(\?.*)?$/u.exec(path)!;
+  const normalizedPathname = pathname.replaceAll(/\/{2,}/gu, '/');
+  return queryString ? `${normalizedPathname}${queryString}` : normalizedPathname;
+}
+
 /* eslint-disable @typescript-eslint/naming-convention */
 // Characters not allowed in a Windows file path
 const forbiddenSymbols = {

--- a/test/integration/LdpHandlerWithoutAuth.test.ts
+++ b/test/integration/LdpHandlerWithoutAuth.test.ts
@@ -778,4 +778,15 @@ describe.each(stores)('An LDP handler allowing all requests %s', (name, { storeC
     response = await fetch(resourceUrl, { headers: { range: 'bytes=5-15' }});
     expect(response.status).toBe(416);
   });
+
+  it('denies access to internal resources with both single and repeated leading slashes.', async(): Promise<void> => {
+    const internalPath = '.internal/setup/';
+
+    const singleSlash = await fetch(`${baseUrl}${internalPath}`);
+    const doubleSlash = await fetch(`${baseUrl}/${internalPath}`);
+
+    // Both should be blocked by internal path protection.
+    expect(singleSlash.status).toBe(401);
+    expect(doubleSlash.status).toBe(401);
+  });
 });

--- a/test/integration/SparqlStorage.test.ts
+++ b/test/integration/SparqlStorage.test.ts
@@ -3,7 +3,7 @@ import { joinFilePath } from '../../src/';
 import type { App } from '../../src/';
 import { putResource } from '../util/FetchUtil';
 import { describeIf, getPort } from '../util/Util';
-import { getDefaultVariables, getPresetConfigPath, getTestConfigPath, instantiateFromConfig } from './Config';
+import { getDefaultVariables, getPresetConfigPath, instantiateFromConfig } from './Config';
 
 const port = getPort('SparqlStorage');
 const baseUrl = `http://localhost:${port}/`;
@@ -19,15 +19,11 @@ describeIf('docker')('A server with a SPARQL endpoint as storage', (): void => {
     };
 
     // Create and start the server
-    const instances = await instantiateFromConfig(
-      'urn:solid-server:test:Instances',
-      [
-        getPresetConfigPath('storage/backend/sparql.json'),
-        getTestConfigPath('ldp-with-auth.json'),
-      ],
+    app = await instantiateFromConfig(
+      'urn:solid-server:default:App',
+      getPresetConfigPath('sparql-endpoint-root.json'),
       variables,
-    ) as Record<string, any>;
-    ({ app } = instances);
+    ) as App;
 
     await app.start();
   });

--- a/test/integration/config/ldp-with-auth.json
+++ b/test/integration/config/ldp-with-auth.json
@@ -3,6 +3,7 @@
   "import": [
     "css:config/app/init/initialize-root.json",
     "css:config/app/main/default.json",
+
     "css:config/http/handler/simple.json",
     "css:config/http/middleware/default.json",
     "css:config/http/notifications/disabled.json",
@@ -21,7 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
 
-    "css:config/storage/key-value/memory.json",
+    "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/root.json",
     "css:config/storage/middleware/default.json",
     "css:config/util/auxiliary/acl.json",

--- a/test/unit/http/input/identifier/OriginalUrlExtractor.test.ts
+++ b/test/unit/http/input/identifier/OriginalUrlExtractor.test.ts
@@ -64,10 +64,16 @@ describe('A OriginalUrlExtractor', (): void => {
       .resolves.toEqual({ path: 'http://test.com/url' });
   });
 
-  it('returns an input URL with multiple leading slashes.', async(): Promise<void> => {
+  it('normalizes an input URL with multiple leading slashes.', async(): Promise<void> => {
     const noQuery = createExtractor({ includeQueryString: true });
     await expect(noQuery.handle({ request: { url: '///url?abc=def&xyz', headers: { host: 'test.com' }} as any }))
-      .resolves.toEqual({ path: 'http://test.com///url?abc=def&xyz' });
+      .resolves.toEqual({ path: 'http://test.com/url?abc=def&xyz' });
+  });
+
+  it('normalizes repeated slashes for internal paths.', async(): Promise<void> => {
+    await expect(
+      extractor.handle({ request: { url: '//.internal/setup/current-base-url', headers: { host: 'test.com' }} as any }),
+    ).resolves.toEqual({ path: 'http://test.com/.internal/setup/current-base-url' });
   });
 
   it('drops the query string when includeQueryString is set to false.', async(): Promise<void> => {

--- a/test/unit/util/PathUtil.test.ts
+++ b/test/unit/util/PathUtil.test.ts
@@ -21,6 +21,7 @@ import {
   joinUrl,
   modulePath,
   normalizeFilePath,
+  normalizeUriPathSlashes,
   resolveAssetPath,
   resolveModulePath,
   toCanonicalUriPath,
@@ -103,6 +104,16 @@ describe('PathUtil', (): void => {
 
     it('leaves the query string untouched.', (): void => {
       expect(toCanonicalUriPath('/a%20path&/name?abc=def&xyz')).toBe('/a%20path%26/name?abc=def&xyz');
+    });
+  });
+
+  describe('#normalizeUriPathSlashes', (): void => {
+    it('collapses repeated slashes in the path.', (): void => {
+      expect(normalizeUriPathSlashes('///a//b///c')).toBe('/a/b/c');
+    });
+
+    it('preserves the query string.', (): void => {
+      expect(normalizeUriPathSlashes('//a///b?x=//y')).toBe('/a/b?x=//y');
     });
   });
 


### PR DESCRIPTION
#### ✍️ Description

An issue popped up where identifiers with repeated slashes were not always interpreted correctly
