### PR TITLE
feat: Handle data corruption issues

### DIFF
--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -5,6 +5,7 @@ import type { Representation } from '../../http/representation/Representation';
 import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { getLoggerFor } from '../../logging/LogUtil';
+import { createErrorMessage } from '../../util/errors/ErrorUtil';
 import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
 import { isSystemError } from '../../util/errors/SystemError';
 import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
@@ -61,7 +62,18 @@ export class FileDataAccessor implements DataAccessor {
    */
   public async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
     const link = await this.resourceMapper.mapUrlToFilePath(identifier, false);
-    const stats = await this.getStats(link.filePath);
+
+    let stats: Stats;
+    try {
+      stats = await this.getStats(link.filePath);
+    } catch (error: unknown) {
+      if (NotFoundHttpError.isInstance(error) && !isContainerIdentifier(identifier)) {
+        // If the document file vanished out-of-band, remove a potentially orphaned metadata file.
+        await this.cleanupDanglingMetadata(identifier);
+      }
+      throw error;
+    }
+
     if (!isContainerIdentifier(identifier) && stats.isFile()) {
       return this.getFileMetadata(link, stats);
     }
@@ -383,5 +395,17 @@ export class FileDataAccessor implements DataAccessor {
       writeStream.on('error', reject);
       writeStream.on('finish', resolve);
     });
+  }
+
+  /**
+   * Best-effort cleanup for orphaned metadata files when document bodies are missing.
+   */
+  protected async cleanupDanglingMetadata(identifier: ResourceIdentifier): Promise<void> {
+    try {
+      const metadataLink = await this.resourceMapper.mapUrlToFilePath(identifier, true);
+      await remove(metadataLink.filePath);
+    } catch (error: unknown) {
+      this.logger.error(`Failed to remove dangling metadata for ${identifier.path}: ${createErrorMessage(error)}`);
+    }
   }
 }

--- a/test/integration/DataCorruption.test.ts
+++ b/test/integration/DataCorruption.test.ts
@@ -1,0 +1,109 @@
+import fetch from 'cross-fetch';
+import { outputFile, pathExists, remove } from 'fs-extra';
+import { joinFilePath } from '../../src/util/PathUtil';
+import { getPort } from '../util/Util';
+import type { App } from '../../src/init/App';
+import {
+  getDefaultVariables,
+  getTestConfigPath,
+  getTestFolder,
+  instantiateFromConfig,
+  removeFolder,
+} from './Config';
+
+const port = getPort('DataCorruption');
+const baseUrl = `http://localhost:${port}/`;
+const rootFilePath = getTestFolder('data-corruption');
+
+async function createTurtleResource(resourceUrl: string, body = '<#a> <#b> <#c> .'): Promise<Response> {
+  return fetch(resourceUrl, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'text/turtle',
+      'if-none-match': '*',
+    },
+    body,
+  });
+}
+
+async function createDanglingMetadata(metaFile: string): Promise<void> {
+  await outputFile(metaFile, '<> <http://purl.org/dc/terms/title> "corruption test" .\n');
+  await expect(pathExists(metaFile)).resolves.toBe(true);
+}
+
+describe('A server with a file backend and a missing body file', (): void => {
+  const resourceUrl = `${baseUrl}test`;
+  const bodyFile = joinFilePath(rootFilePath, 'test$.ttl');
+  const metaFile = joinFilePath(rootFilePath, 'test.meta');
+
+  let app: App;
+
+  beforeAll(async(): Promise<void> => {
+    const variables = {
+      ...getDefaultVariables(port, baseUrl),
+      'urn:solid-server:default:variable:rootFilePath': rootFilePath,
+    };
+
+    ({ app } = await instantiateFromConfig(
+      'urn:solid-server:test:Instances',
+      getTestConfigPath('server-file.json'),
+      variables,
+    ) as Record<string, any>);
+
+    await app.start();
+  });
+
+  beforeEach(async(): Promise<void> => {
+    await createTurtleResource(resourceUrl);
+  });
+
+  afterEach(async(): Promise<void> => {
+    // Remove any auxiliary file left behind by a test
+    await remove(metaFile);
+  });
+
+  afterAll(async(): Promise<void> => {
+    await removeFolder(rootFilePath);
+    await app.stop();
+  });
+
+  describe('when the body file is missing and there is no metadata', (): void => {
+    beforeEach(async(): Promise<void> => {
+      await remove(bodyFile);
+    });
+
+    it('returns 404 on DELETE and allows recreation.', async(): Promise<void> => {
+      const deleteRes = await fetch(resourceUrl, { method: 'DELETE' });
+      expect(deleteRes.status).toBe(404);
+
+      const recreateRes = await createTurtleResource(resourceUrl, '<#a> <#b> <#d> .');
+      expect(recreateRes.status).toBe(201);
+      await expect(pathExists(bodyFile)).resolves.toBe(true);
+    });
+  });
+
+  describe('when only the metadata file remains', (): void => {
+    beforeEach(async(): Promise<void> => {
+      await createDanglingMetadata(metaFile);
+      await remove(bodyFile);
+    });
+
+    it('returns 404 on GET.', async(): Promise<void> => {
+      const response = await fetch(resourceUrl);
+      expect(response.status).toBe(404);
+      await expect(pathExists(metaFile)).resolves.toBe(false);
+    });
+
+    it('returns 404 on DELETE.', async(): Promise<void> => {
+      const response = await fetch(resourceUrl, { method: 'DELETE' });
+      expect(response.status).toBe(404);
+      await expect(pathExists(metaFile)).resolves.toBe(false);
+    });
+
+    it('allows recreation.', async(): Promise<void> => {
+      const response = await createTurtleResource(resourceUrl, '<#a> <#b> <#d> .');
+      expect(response.status).toBe(201);
+      await expect(pathExists(bodyFile)).resolves.toBe(true);
+    });
+  });
+});

--- a/test/unit/storage/accessors/FileDataAccessor.test.ts
+++ b/test/unit/storage/accessors/FileDataAccessor.test.ts
@@ -87,6 +87,24 @@ describe('A FileDataAccessor', (): void => {
       await expect(accessor.getMetadata({ path: `${base}container/` })).rejects.toThrow(NotFoundHttpError);
     });
 
+    it('cleans up orphaned auxiliary metadata files for missing document bodies.', async(): Promise<void> => {
+      cache.data = { 'resource.ttl.meta': '<http://this> <http://is> <http://metadata>.' };
+
+      await expect(accessor.getMetadata({ path: `${base}resource.ttl` })).rejects.toThrow(NotFoundHttpError);
+      expect(cache.data['resource.ttl.meta']).toBeUndefined();
+    });
+
+    it('logs cleanup errors when removing orphaned auxiliary metadata files.', async(): Promise<void> => {
+      cache.data = { 'resource.ttl.meta': '<http://this> <http://is> <http://metadata>.' };
+      jest.requireMock('fs-extra').remove = (): never => {
+        throw new Error('cleanup failed');
+      };
+      const logSpy = jest.spyOn((accessor as any).logger, 'error');
+
+      await expect(accessor.getMetadata({ path: `${base}resource.ttl` })).rejects.toThrow(NotFoundHttpError);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to remove dangling metadata'));
+    });
+
     it('throws a 404 if it matches something that is no file or directory.', async(): Promise<void> => {
       cache.data = { resource: 5 };
       await expect(accessor.getMetadata({ path: `${base}resource` })).rejects.toThrow(NotFoundHttpError);

--- a/test/util/Util.ts
+++ b/test/util/Util.ts
@@ -9,6 +9,7 @@ const portNames = [
   'AcpServer',
   'Conditions',
   'ContentNegotiation',
+  'DataCorruption',
   'DynamicPods',
   'ExpiringDataCleanup',
   'FileBackend',


### PR DESCRIPTION
#### 📁 Related issues

Closes https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2163

#### ✍️ Description

The problem was caused by the metadata file still being there when the data file was gone. This adds a check to handle this kind of situation.