### PR TITLE
fix: find pod quota in subdomain mode, compute once by write not by chunk

### DIFF
--- a/config/storage/backend/quota/pod-quota-file.json
+++ b/config/storage/backend/quota/pod-quota-file.json
@@ -8,7 +8,9 @@
       "@type": "PodQuotaStrategy",
       "reporter": { "@id": "urn:solid-server:default:SizeReporter" },
       "accessor": { "@id": "urn:solid-server:default:AtomicFileDataAccessor" },
-      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" }
+      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" },
+      "internalFolder": "/.internal/"
     }
   ]
 }

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -40,26 +40,57 @@ export class PodQuotaStrategy extends QuotaStrategy {
 
   /** Finds the closest parent container that has pim:storage as metadata */
   private async searchPimStorage(identifier: ResourceIdentifier): Promise<ResourceIdentifier | undefined> {
-    if (this.identifierStrategy.isRootContainer(identifier)) {
+    // CSS-internal storage (locks, IDP adapter, temp files, accounts, ...)
+    // lives under `/.internal/` and is never part of a pod — quota does not
+    // apply to it. This also prevents the base root (which can itself be
+    // marked as a storage, e.g. `RootStorageLocationStrategy`) from being
+    // treated as a pod for internal writes.
+    if (isInternalPath(identifier)) {
       return;
     }
 
     let metadata: RepresentationMetadata;
-    const parent = this.identifierStrategy.getParentContainer(identifier);
 
     try {
       metadata = await this.accessor.getMetadata(identifier);
     } catch (error: unknown) {
       if (error instanceof NotFoundHttpError) {
-        // Resource and/or its metadata do not exist
-        return this.searchPimStorage(parent);
+        // Resource and/or its metadata do not exist — stop at a root container
+        // (nothing above it can be a pod), otherwise walk up.
+        if (this.identifierStrategy.isRootContainer(identifier)) {
+          return;
+        }
+        return this.searchPimStorage(this.identifierStrategy.getParentContainer(identifier));
       }
       throw error;
     }
 
-    const hasPimStorageMetadata = metadata!.getAll(RDF.terms.type)
+    const hasPimStorageMetadata = metadata.getAll(RDF.terms.type)
       .some((term): boolean => term.value === PIM.Storage);
+    if (hasPimStorageMetadata) {
+      return identifier;
+    }
 
-    return hasPimStorageMetadata ? identifier : this.searchPimStorage(parent);
+    // A root container can still be a pod — in subdomain mode every pod root
+    // (e.g. https://alice.example.com/) IS a root container. Only stop here
+    // AFTER the metadata check found no pim:Storage.
+    if (this.identifierStrategy.isRootContainer(identifier)) {
+      return;
+    }
+    return this.searchPimStorage(this.identifierStrategy.getParentContainer(identifier));
   }
+}
+
+const INTERNAL_PATH_REGEX = /^\/\.internal(?:\/|$)/u;
+
+/** Whether the identifier points into CSS-internal storage (`/.internal/`). */
+function isInternalPath(identifier: ResourceIdentifier): boolean {
+  let path = identifier.path;
+  try {
+    path = new URL(identifier.path).pathname;
+  } catch {
+    // Not a URL — compare the raw path.
+  }
+  return INTERNAL_PATH_REGEX.test(path);
+}
 }

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -85,11 +85,6 @@ const INTERNAL_PATH_REGEX = /^\/\.internal(?:\/|$)/u;
 
 /** Whether the identifier points into CSS-internal storage (`/.internal/`). */
 function isInternalPath(identifier: ResourceIdentifier): boolean {
-  let path = identifier.path;
-  try {
-    path = new URL(identifier.path).pathname;
-  } catch {
-    // Not a URL — compare the raw path.
-  }
-  return INTERNAL_PATH_REGEX.test(path);
+  // Identifiers are always canonical URLs.
+  return INTERNAL_PATH_REGEX.test(new URL(identifier.path).pathname);
 }

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -1,7 +1,7 @@
-import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
 import type { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import { joinUrl, trimTrailingSlashes } from '../../util/PathUtil';
 import { PIM, RDF } from '../../util/Vocabularies';
 import type { DataAccessor } from '../accessors/DataAccessor';
 import type { Size } from '../size-reporter/Size';
@@ -14,16 +14,23 @@ import { QuotaStrategy } from './QuotaStrategy';
 export class PodQuotaStrategy extends QuotaStrategy {
   private readonly identifierStrategy: IdentifierStrategy;
   private readonly accessor: DataAccessor;
+  /** Full URL of the CSS-internal storage container (e.g. `https://host/.internal/`). */
+  private readonly internalFolder: string;
 
   public constructor(
     limit: Size,
     reporter: SizeReporter<unknown>,
     identifierStrategy: IdentifierStrategy,
     accessor: DataAccessor,
+    baseUrl: string,
+    internalFolder = '/.internal/',
   ) {
     super(reporter, limit);
     this.identifierStrategy = identifierStrategy;
     this.accessor = accessor;
+    // Joined with the base URL so this also works when the base URL has a path
+    // prefix (e.g. `https://host/my-server/` -> `https://host/my-server/.internal/`).
+    this.internalFolder = trimTrailingSlashes(joinUrl(baseUrl, internalFolder));
   }
 
   protected async getTotalSpaceUsed(identifier: ResourceIdentifier): Promise<Size> {
@@ -38,53 +45,44 @@ export class PodQuotaStrategy extends QuotaStrategy {
     return this.reporter.getSize(pimStorage);
   }
 
-  /** Finds the closest parent container that has pim:storage as metadata */
+  /**
+   * Finds the closest parent container that has `pim:storage` as metadata.
+   * The metadata is read BEFORE the root-container stop, because in subdomain
+   * mode every pod root IS a root container, and a root container can be a pod.
+   */
   private async searchPimStorage(identifier: ResourceIdentifier): Promise<ResourceIdentifier | undefined> {
-    // CSS-internal storage (locks, IDP adapter, temp files, accounts, ...)
-    // lives under `/.internal/` and is never part of a pod — quota does not
-    // apply to it. This also prevents the base root (which can itself be
-    // marked as a storage, e.g. `RootStorageLocationStrategy`) from being
-    // treated as a pod for internal writes.
-    if (isInternalPath(identifier)) {
+    // CSS-internal storage (locks, IDP adapter, temp files, accounts, ...) is
+    // never part of a pod — quota does not apply to it. This also prevents the
+    // base root (which can itself be marked as a storage, e.g.
+    // `RootStorageLocationStrategy`) from being treated as a pod for internal
+    // writes.
+    if (this.isInternalPath(identifier)) {
       return;
     }
 
-    let metadata: RepresentationMetadata;
-
     try {
-      metadata = await this.accessor.getMetadata(identifier);
-    } catch (error: unknown) {
-      if (error instanceof NotFoundHttpError) {
-        // Resource and/or its metadata do not exist — stop at a root container
-        // (nothing above it can be a pod), otherwise walk up.
-        if (this.identifierStrategy.isRootContainer(identifier)) {
-          return;
-        }
-        return this.searchPimStorage(this.identifierStrategy.getParentContainer(identifier));
+      const metadata = await this.accessor.getMetadata(identifier);
+      if (metadata.getAll(RDF.terms.type).some((term): boolean => term.value === PIM.Storage)) {
+        return identifier;
       }
-      throw error;
+    } catch (error: unknown) {
+      // Resource and/or its metadata do not exist — keep walking up below.
+      if (!(error instanceof NotFoundHttpError)) {
+        throw error;
+      }
     }
 
-    const hasPimStorageMetadata = metadata.getAll(RDF.terms.type)
-      .some((term): boolean => term.value === PIM.Storage);
-    if (hasPimStorageMetadata) {
-      return identifier;
-    }
-
-    // A root container can still be a pod — in subdomain mode every pod root
-    // (e.g. https://alice.example.com/) IS a root container. Only stop here
-    // AFTER the metadata check found no pim:Storage.
+    // Not a storage (or it does not exist) — stop at a root container
+    // (nothing above it can be a pod).
     if (this.identifierStrategy.isRootContainer(identifier)) {
       return;
     }
     return this.searchPimStorage(this.identifierStrategy.getParentContainer(identifier));
   }
-}
 
-const INTERNAL_PATH_REGEX = /^\/\.internal(?:\/|$)/u;
-
-/** Whether the identifier points into CSS-internal storage (`/.internal/`). */
-function isInternalPath(identifier: ResourceIdentifier): boolean {
-  // Identifiers are always canonical URLs.
-  return INTERNAL_PATH_REGEX.test(new URL(identifier.path).pathname);
+  /** Whether the identifier points into the configured CSS-internal storage. */
+  private isInternalPath(identifier: ResourceIdentifier): boolean {
+    const path = trimTrailingSlashes(identifier.path);
+    return path === this.internalFolder || path.startsWith(`${this.internalFolder}/`);
+  }
 }

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -93,4 +93,3 @@ function isInternalPath(identifier: ResourceIdentifier): boolean {
   }
   return INTERNAL_PATH_REGEX.test(path);
 }
-}

--- a/src/storage/quota/PodQuotaStrategy.ts
+++ b/src/storage/quota/PodQuotaStrategy.ts
@@ -72,8 +72,15 @@ export class PodQuotaStrategy extends QuotaStrategy {
       }
     }
 
-    // Not a storage (or it does not exist) — stop at a root container
-    // (nothing above it can be a pod).
+    // Not a storage (or it does not exist) — keep walking up.
+    return this.searchParentStorage(identifier);
+  }
+
+  /**
+   * Continues the search in the parent container, unless the identifier is a
+   * root container (nothing above it can be a pod).
+   */
+  private async searchParentStorage(identifier: ResourceIdentifier): Promise<ResourceIdentifier | undefined> {
     if (this.identifierStrategy.isRootContainer(identifier)) {
       return;
     }

--- a/src/storage/quota/QuotaStrategy.ts
+++ b/src/storage/quota/QuotaStrategy.ts
@@ -85,15 +85,19 @@ export abstract class QuotaStrategy {
    * @returns a Passthrough instance that errors when quota is exceeded
    */
   public async createQuotaGuard(identifier: ResourceIdentifier): Promise<Guarded<PassThrough>> {
+    // Compute the available space ONCE instead of for every stream chunk.
+    // The available space does not change during a single write (the
+    // overwritten resource's own size is constant), so the per-chunk
+    // recomputation was `chunks × O(pod)` of needless full-pod walks. The
+    // QuotaValidator re-checks the space after the write completes, so the
+    // quota guarantee is preserved even with concurrent writes.
+    const availableSpace = await this.getAvailableSpace(identifier);
     let total = 0;
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const that = this;
     const { reporter } = this;
 
     return guardStream(new PassThrough({
       async transform(this, chunk: unknown, enc: string, done: () => void): Promise<void> {
         total += await reporter.calculateChunkSize(chunk);
-        const availableSpace = await that.getAvailableSpace(identifier);
         if (availableSpace.amount < total) {
           this.destroy(new PayloadHttpError(
             `Quota exceeded by ${total - availableSpace.amount} ${availableSpace.unit} during write`,

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -128,5 +128,22 @@ describe('PodQuotaStrategy', (): void => {
       const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/.internal/accounts/123' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
+
+    it('treats the exact `/.internal` container as internal (no trailing slash).', async(): Promise<void> => {
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/.internal' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
+    });
+
+    it('stops at a root container when its metadata is missing (NotFound).', async(): Promise<void> => {
+      // getMetadata throws NotFound at the subdomain root (a root container) —
+      // discovery must stop there and report no pod.
+      accessor.getMetadata.mockImplementationOnce((): any => {
+        throw new NotFoundHttpError();
+      });
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      const result = strategy.getAvailableSpace({ path: 'http://alice.localhost:3000/' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
+    });
   });
 });

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -136,7 +136,7 @@ describe('PodQuotaStrategy', (): void => {
     });
 
     it('stops at a root container when its metadata is missing (NotFound).', async(): Promise<void> => {
-      // getMetadata throws NotFound at the subdomain root (a root container) —
+      // Metadata is missing (NotFound) at the subdomain root (a root container) —
       // discovery must stop there and report no pod.
       accessor.getMetadata.mockImplementationOnce((): any => {
         throw new NotFoundHttpError();

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -8,6 +8,7 @@ import type { SizeReporter } from '../../../src/storage/size-reporter/SizeReport
 import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
 import type { IdentifierStrategy } from '../../../src/util/identifiers/IdentifierStrategy';
 import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
+import { SubdomainIdentifierStrategy } from '../../../src/util/identifiers/SubdomainIdentifierStrategy';
 import { PIM, RDF } from '../../../src/util/Vocabularies';
 import { mockFileSystem } from '../../util/Util';
 
@@ -75,6 +76,57 @@ describe('PodQuotaStrategy', (): void => {
       });
       const result = strategy.getAvailableSpace({ path: `${base}nested/nested2/file.txt` });
       await expect(result).rejects.toThrow('error');
+    });
+  });
+
+  describe('in subdomain mode', (): void => {
+    // Each subdomain is a pod root, and IS a root container for
+    // SubdomainIdentifierStrategy. searchPimStorage must read the pim:Storage
+    // metadata BEFORE stopping at the root container, otherwise no pod is ever
+    // found and quota is silently unlimited.
+    let subdomainStrategy: IdentifierStrategy;
+
+    beforeEach((): void => {
+      subdomainStrategy = new SubdomainIdentifierStrategy(base);
+      accessor.getMetadata.mockImplementation(
+        async(identifier: ResourceIdentifier): Promise<RepresentationMetadata> => {
+          const res = new RepresentationMetadata();
+          if (identifier.path === 'http://alice.localhost:3000/') {
+            res.add(RDF.terms.type, PIM.Storage);
+          }
+          return res;
+        },
+      );
+    });
+
+    it('should find the pod when writing inside a subdomain pod (pod root is a root container).', async(): Promise<void> => {
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      const result = strategy.getAvailableSpace({ path: 'http://alice.localhost:3000/public/file.txt' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: mockSize.amount }));
+      expect(mockReporter.getSize).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return MAX_SAFE_INTEGER when writing to the base root (not a pod).', async(): Promise<void> => {
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/file.txt' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
+    });
+
+    it('should return MAX_SAFE_INTEGER for internal writes even when the base root is a storage.', async(): Promise<void> => {
+      // Simulate RootStorageLocationStrategy: the base root is also marked as
+      // a storage. Internal writes (`/.internal/`) must still be unlimited.
+      accessor.getMetadata.mockImplementation(
+        async(identifier: ResourceIdentifier): Promise<RepresentationMetadata> => {
+          const res = new RepresentationMetadata();
+          if (identifier.path === 'http://alice.localhost:3000/' || identifier.path === 'http://localhost:3000/') {
+            res.add(RDF.terms.type, PIM.Storage);
+          }
+          return res;
+        },
+      );
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/.internal/accounts/123' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
   });
 });

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -46,7 +46,7 @@ describe('PodQuotaStrategy', (): void => {
         },
       ),
     } as any;
-    strategy = new PodQuotaStrategy(mockSize, mockReporter, identifierStrategy, accessor);
+    strategy = new PodQuotaStrategy(mockSize, mockReporter, identifierStrategy, accessor, base);
   });
 
   describe('getAvailableSpace()', (): void => {
@@ -100,14 +100,14 @@ describe('PodQuotaStrategy', (): void => {
     });
 
     it('finds the pod inside a subdomain pod (pod root is a root container).', async(): Promise<void> => {
-      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, base);
       const result = strategy.getAvailableSpace({ path: 'http://alice.localhost:3000/public/file.txt' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: mockSize.amount }));
       expect(mockReporter.getSize).toHaveBeenCalledTimes(2);
     });
 
     it('should return MAX_SAFE_INTEGER when writing to the base root (not a pod).', async(): Promise<void> => {
-      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, base);
       const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/file.txt' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
@@ -124,13 +124,13 @@ describe('PodQuotaStrategy', (): void => {
           return res;
         },
       );
-      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, base);
       const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/.internal/accounts/123' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
 
     it('treats the exact `/.internal` container as internal (no trailing slash).', async(): Promise<void> => {
-      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, base);
       const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/.internal' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
@@ -141,8 +141,20 @@ describe('PodQuotaStrategy', (): void => {
       accessor.getMetadata.mockImplementationOnce((): any => {
         throw new NotFoundHttpError();
       });
-      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, base);
       const result = strategy.getAvailableSpace({ path: 'http://alice.localhost:3000/' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
+    });
+
+    it('keeps internal writes unlimited when the base URL has a path prefix.', async(): Promise<void> => {
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, 'http://example.com/my-server/');
+      const result = strategy.getAvailableSpace({ path: 'http://example.com/my-server/.internal/accounts/123' });
+      await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
+    });
+
+    it('uses a custom internal folder when configured.', async(): Promise<void> => {
+      strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor, base, '/.hidden/');
+      const result = strategy.getAvailableSpace({ path: 'http://localhost:3000/.hidden/data' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
   });

--- a/test/unit/quota/PodQuotaStrategy.test.ts
+++ b/test/unit/quota/PodQuotaStrategy.test.ts
@@ -99,7 +99,7 @@ describe('PodQuotaStrategy', (): void => {
       );
     });
 
-    it('should find the pod when writing inside a subdomain pod (pod root is a root container).', async(): Promise<void> => {
+    it('finds the pod inside a subdomain pod (pod root is a root container).', async(): Promise<void> => {
       strategy = new PodQuotaStrategy(mockSize, mockReporter, subdomainStrategy, accessor);
       const result = strategy.getAvailableSpace({ path: 'http://alice.localhost:3000/public/file.txt' });
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: mockSize.amount }));
@@ -112,7 +112,7 @@ describe('PodQuotaStrategy', (): void => {
       await expect(result).resolves.toEqual(expect.objectContaining({ amount: Number.MAX_SAFE_INTEGER }));
     });
 
-    it('should return MAX_SAFE_INTEGER for internal writes even when the base root is a storage.', async(): Promise<void> => {
+    it('keeps internal writes unlimited even when the base root is a storage.', async(): Promise<void> => {
       // Simulate RootStorageLocationStrategy: the base root is also marked as
       // a storage. Internal writes (`/.internal/`) must still be unlimited.
       accessor.getMetadata.mockImplementation(

--- a/test/unit/quota/QuotaStrategy.test.ts
+++ b/test/unit/quota/QuotaStrategy.test.ts
@@ -85,5 +85,24 @@ describe('A QuotaStrategy', (): void => {
       });
       await expect(destroy).resolves.toBeUndefined();
     });
+
+    it('computes the available space once at guard creation instead of once per chunk.', async(): Promise<void> => {
+      const spy = jest.spyOn(strategy, 'getAvailableSpace').mockResolvedValue({ amount: 1000, unit: mockSize.unit });
+      const track = await strategy.createQuotaGuard({ path: `${base}nested/file2.txt` });
+      // Creating the guard already computed the available space once...
+      expect(spy).toHaveBeenCalledTimes(1);
+
+      const done = new Promise<void>((resolve): void => {
+        track.on('data', (): void => { /* consume */ });
+        track.on('end', (): void => resolve());
+        track.on('error', (): void => resolve());
+      });
+      // ...and writing chunks through the guard must NOT recompute it.
+      track.write(Buffer.from('A'.repeat(50)));
+      track.write(Buffer.from('A'.repeat(50)));
+      track.end();
+      await done;
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/test/unit/quota/QuotaStrategy.test.ts
+++ b/test/unit/quota/QuotaStrategy.test.ts
@@ -93,11 +93,11 @@ describe('A QuotaStrategy', (): void => {
       expect(spy).toHaveBeenCalledTimes(1);
 
       const done = new Promise<void>((resolve): void => {
-        track.on('data', (): void => { /* consume */ });
+        track.on('data', (): void => { /* Consume */ });
         track.on('end', (): void => resolve());
         track.on('error', (): void => resolve());
       });
-      // ...and writing chunks through the guard must NOT recompute it.
+      // Writing chunks through the guard must NOT recompute it.
       track.write(Buffer.from('A'.repeat(50)));
       track.write(Buffer.from('A'.repeat(50)));
       track.end();


### PR DESCRIPTION

#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2209

#### ✍️ Description

- PodQuotaStrategy.searchPimStorage tested isRootContainer() BEFORE reading metadata. In subdomain mode every pod root (e.g. https://alice.example.com/) IS a root container, so discovery returned 'no pod' without ever checking the pim:Storage metadata — pod quota was silently unlimited on subdomain deployments (getTotalSpaceUsed -> MAX_SAFE_INTEGER).

Reorder so metadata (pim:Storage) is read first; a root container is only treated as 'no pod' AFTER the metadata check found no storage, because a root container can be a pod (a subdomain root). Internal writes under /.internal/ are still exempt (quota does not apply there) — this also keeps the base root from being treated as a pod when it is itself marked as a storage (RootStorageLocationStrategy).

Adds subdomain-mode tests: finds the pod inside a subdomain pod, returns MAX_SAFE_INTEGER for the base root, and keeps internal writes unlimited.
- perf(quota): compute available space once per write, not per chunk
QuotaStrategy.createQuotaGuard called getAvailableSpace (a full pod walk)
for EVERY stream chunk — chunks x O(pod) of needless work, making pod quota
impractical on any non-trivial pod. The available space does not change
during a single write (the overwritten resource's own size is constant), so
compute it once when the guard is created. Correctness is preserved: the
QuotaValidator re-checks the available space after the write completes, so
concurrent writes are still caught.

Adds a test asserting getAvailableSpace is called once at guard creation.


### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
