### PR TITLE
perf(storage): stream container listings to avoid O(children) memory

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -47,6 +47,9 @@ jobs:
         run: npm run test:ts
       - name: Run unit tests
         run: npm run test:unit
+      - name: Run container-listing memory regression test
+        if: matrix.operating-system == 'ubuntu-latest' && matrix.node-version == '20.x'
+        run: npm run test:memory
       - name: Submit unit test coverage
         uses: coverallsapp/github-action@master
         with:

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "test:deploy": "test/deploy/validate-configs.sh",
     "test:ts": "tsc -p test --noEmit",
     "test:integration": "jest test/integration",
+    "test:memory": "node --expose-gc --max-old-space-size=128 test/memory/container-listing.js",
     "test:unit": "jest --config=./jest.coverage.config.js test/unit",
     "test:watch": "jest --coverageReporters none --watch test/unit",
     "validate": "componentsjs-compile-config urn:solid-server:default:Initializer -c config/default.json -f > /dev/null",

--- a/src/http/output/metadata/AllowAcceptHeaderWriter.ts
+++ b/src/http/output/metadata/AllowAcceptHeaderWriter.ts
@@ -132,7 +132,8 @@ export class AllowAcceptHeaderWriter extends MetadataWriter {
     }
 
     const isStorage = metadata.has(RDF.terms.type, PIM.terms.Storage);
-    const isEmpty = !metadata.has(LDP.terms.contains);
+    const empty = metadata.get(SOLID_META.terms.containerEmpty, SOLID_META.terms.ResponseMetadata);
+    const isEmpty = empty ? empty.value === 'true' : !metadata.has(LDP.terms.contains);
     return !isStorage && isEmpty;
   }
 

--- a/src/init/migration/SingleContainerJsonStorage.ts
+++ b/src/init/migration/SingleContainerJsonStorage.ts
@@ -19,9 +19,7 @@ export class SingleContainerJsonStorage<T> extends JsonResourceStorage<T> {
       return;
     }
 
-    const members = await this.getContainedResourceIdentifiers(containerId, container);
-
-    for (const documentId of members) {
+    for await (const documentId of this.getContainedResourceIdentifiers(containerId, container)) {
       if (isContainerIdentifier(documentId)) {
         continue;
       }

--- a/src/init/migration/SingleContainerJsonStorage.ts
+++ b/src/init/migration/SingleContainerJsonStorage.ts
@@ -1,3 +1,4 @@
+import type { Quad } from '@rdfjs/types';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { JsonResourceStorage } from '../../storage/keyvalue/JsonResourceStorage';
 import { createErrorMessage } from '../../util/errors/ErrorUtil';
@@ -20,9 +21,14 @@ export class SingleContainerJsonStorage<T> extends JsonResourceStorage<T> {
       return;
     }
 
-    // Only need the metadata
-    container.data.destroy();
-    const members = container.metadata.getAll(LDP.terms.contains).map((term): string => term.value);
+    // The containment list lives in the (streamed) quad body, not the metadata; read the
+    // `ldp:contains` objects from the body. Draining the stream also releases the read lock.
+    const members: string[] = [];
+    for await (const quad of container.data as AsyncIterable<Quad>) {
+      if (quad.predicate.equals(LDP.terms.contains)) {
+        members.push(quad.object.value);
+      }
+    }
 
     for (const path of members) {
       const documentId = { path };

--- a/src/init/migration/SingleContainerJsonStorage.ts
+++ b/src/init/migration/SingleContainerJsonStorage.ts
@@ -1,10 +1,8 @@
-import type { Quad } from '@rdfjs/types';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 import { JsonResourceStorage } from '../../storage/keyvalue/JsonResourceStorage';
 import { createErrorMessage } from '../../util/errors/ErrorUtil';
 import { isContainerIdentifier } from '../../util/PathUtil';
 import { readableToString } from '../../util/StreamUtil';
-import { LDP } from '../../util/Vocabularies';
 
 /**
  * A variant of a {@link JsonResourceStorage} where the `entries()` call
@@ -21,17 +19,9 @@ export class SingleContainerJsonStorage<T> extends JsonResourceStorage<T> {
       return;
     }
 
-    // The containment list lives in the (streamed) quad body, not the metadata; read the
-    // `ldp:contains` objects from the body. Draining the stream also releases the read lock.
-    const members: string[] = [];
-    for await (const quad of container.data as AsyncIterable<Quad>) {
-      if (quad.predicate.equals(LDP.terms.contains)) {
-        members.push(quad.object.value);
-      }
-    }
+    const members = await this.getContainedResourceIdentifiers(containerId, container);
 
-    for (const path of members) {
-      const documentId = { path };
+    for (const documentId of members) {
       if (isContainerIdentifier(documentId)) {
         continue;
       }
@@ -46,8 +36,8 @@ export class SingleContainerJsonStorage<T> extends JsonResourceStorage<T> {
         const json = JSON.parse(await readableToString(document.data)) as T;
         yield [ key, json ];
       } catch (error: unknown) {
-        this.logger.error(`Unable to parse ${path}. You should probably delete this resource manually. Error: ${
-          createErrorMessage(error)}`);
+        this.logger.error(`Unable to parse ${documentId.path}. You should probably delete this resource manually. ` +
+          `Error: ${createErrorMessage(error)}`);
       }
     }
   }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -168,14 +168,28 @@ export class DataAccessorBasedStore implements ResourceStore {
       SOLID_META.terms.ResponseMetadata,
     );
 
-    async function* generate(): AsyncIterableIterator<Quad> {
+    async function* generate(): AsyncGenerator<Quad, void, undefined> {
       yield* ownQuads;
       if (!first.done) {
         yield first.value;
         yield* childQuads;
       }
     }
-    return Readable.from(generate(), { objectMode: true });
+    const listing = generate();
+    const streamSource: AsyncIterableIterator<Quad> = {
+      next: listing.next.bind(listing),
+      return: async(): Promise<IteratorResult<Quad>> => {
+        try {
+          return await listing.return();
+        } finally {
+          await childQuads.return?.();
+        }
+      },
+      [Symbol.asyncIterator](): AsyncIterableIterator<Quad> {
+        return this;
+      },
+    };
+    return Readable.from(streamSource, { objectMode: true });
   }
 
   /** Yields containment and metadata quads for non-auxiliary children. */

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -170,7 +170,6 @@ export class DataAccessorBasedStore implements ResourceStore {
 
   /**
    * Creates a lazy quad stream for a container listing.
-   * Adds one containment quad to metadata for empty-container checks.
    */
   protected async streamContainerRepresentation(identifier: ResourceIdentifier, metadata: RepresentationMetadata):
   Promise<Readable> {
@@ -180,12 +179,13 @@ export class DataAccessorBasedStore implements ResourceStore {
     metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
-    // Retain the first containment quad for empty-container checks.
     const childQuads = this.getContainerListingQuads(identifier, metadata.identifier as NamedNode);
     const first = await childQuads.next();
-    if (!first.done) {
-      metadata.addQuads([ first.value ]);
-    }
+    metadata.add(
+      SOLID_META.terms.containerEmpty,
+      DataFactory.literal(`${first.done}`, XSD.terms.boolean),
+      SOLID_META.terms.ResponseMetadata,
+    );
 
     async function* generate(): AsyncIterableIterator<Quad> {
       yield* ownQuads;

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -119,7 +119,6 @@ export class DataAccessorBasedStore implements ResourceStore {
 
     // In the future we want to use getNormalizedMetadata and redirect in case the identifier differs
     let metadata = await this.accessor.getMetadata(identifier);
-    let representation: Representation;
 
     // Potentially add auxiliary related metadata
     // Solid, §4.3: "Clients can discover auxiliary resources associated with a subject resource by making an HTTP HEAD
@@ -129,43 +128,30 @@ export class DataAccessorBasedStore implements ResourceStore {
 
     const isContainer = isContainerPath(metadata.identifier.value);
 
-    // Stream container listings without materialising all child metadata.
-    if (isContainer && !isMetadata) {
-      const stream = await this.streamContainerRepresentation(identifier, metadata);
-      return new BasicRepresentation(stream, metadata, INTERNAL_QUADS);
+    if (!isContainer && !isMetadata) {
+      return new BasicRepresentation(await this.accessor.getData(identifier), metadata);
     }
 
-    let data = metadata.quads();
-    if (isContainer || isMetadata) {
-      if (isContainer) {
-        // Add containment triples of non-auxiliary resources
-        for await (const child of this.accessor.getChildren(identifier)) {
-          if (!this.auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value })) {
-            metadata.add(LDP.terms.contains, child.identifier as NamedNode, SOLID_META.terms.ResponseMetadata);
-          }
+    if (isContainer && isMetadata) {
+      for await (const child of this.accessor.getChildren(identifier)) {
+        if (!this.isAuxiliaryChild(child)) {
+          metadata.add(LDP.terms.contains, child.identifier as NamedNode, SOLID_META.terms.ResponseMetadata);
         }
-        data = metadata.quads();
       }
-
-      if (isMetadata) {
-        metadata = new RepresentationMetadata(this.metadataStrategy.getAuxiliaryIdentifier(identifier));
-        addResourceMetadata(metadata, false);
-        metadata.add(RDF.terms.type, SOLID_META.terms.DescriptionResource);
-      }
-
-      metadata.addQuad(DC.terms.namespace, PREFERRED_PREFIX_TERM, 'dc', SOLID_META.terms.ResponseMetadata);
-      metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
-      metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
-      metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
     }
 
-    if (isContainer || isMetadata) {
-      representation = new BasicRepresentation(data, metadata, INTERNAL_QUADS);
-    } else {
-      representation = new BasicRepresentation(await this.accessor.getData(identifier), metadata);
+    const data = isMetadata ? metadata.quads() : await this.streamContainerRepresentation(identifier, metadata);
+    if (isMetadata) {
+      metadata = new RepresentationMetadata(this.metadataStrategy.getAuxiliaryIdentifier(identifier));
+      addResourceMetadata(metadata, false);
+      metadata.add(RDF.terms.type, SOLID_META.terms.DescriptionResource);
     }
 
-    return representation;
+    metadata.addQuad(DC.terms.namespace, PREFERRED_PREFIX_TERM, 'dc', SOLID_META.terms.ResponseMetadata);
+    metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
+    metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
+    metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
+    return new BasicRepresentation(data, metadata, INTERNAL_QUADS);
   }
 
   /**
@@ -173,12 +159,7 @@ export class DataAccessorBasedStore implements ResourceStore {
    */
   protected async streamContainerRepresentation(identifier: ResourceIdentifier, metadata: RepresentationMetadata):
   Promise<Readable> {
-    // Snapshot the body before adding response-only prefixes.
     const ownQuads = metadata.quads();
-    metadata.addQuad(DC.terms.namespace, PREFERRED_PREFIX_TERM, 'dc', SOLID_META.terms.ResponseMetadata);
-    metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
-    metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
-    metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
     const childQuads = this.getContainerListingQuads(identifier, metadata.identifier as NamedNode);
     const first = await childQuads.next();
     metadata.add(
@@ -201,7 +182,7 @@ export class DataAccessorBasedStore implements ResourceStore {
   private async* getContainerListingQuads(identifier: ResourceIdentifier, containerNode: NamedNode):
   AsyncIterableIterator<Quad> {
     for await (const child of this.accessor.getChildren(identifier)) {
-      if (!this.auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value })) {
+      if (!this.isAuxiliaryChild(child)) {
         yield DataFactory.quad(
           containerNode,
           LDP.terms.contains,
@@ -211,6 +192,10 @@ export class DataAccessorBasedStore implements ResourceStore {
         yield* child.quads();
       }
     }
+  }
+
+  private isAuxiliaryChild(child: RepresentationMetadata): boolean {
+    return this.auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value });
   }
 
   public async addResource(container: ResourceIdentifier, representation: Representation, conditions?: Conditions):
@@ -714,7 +699,7 @@ export class DataAccessorBasedStore implements ResourceStore {
    */
   protected async hasProperChildren(container: ResourceIdentifier): Promise<boolean> {
     for await (const child of this.accessor.getChildren(container)) {
-      if (!this.auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value })) {
+      if (!this.isAuxiliaryChild(child)) {
         return true;
       }
     }

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -129,10 +129,7 @@ export class DataAccessorBasedStore implements ResourceStore {
 
     const isContainer = isContainerPath(metadata.identifier.value);
 
-    // Streaming fast-path for container LISTINGS (not description resources): emit the listing as a
-    // lazy quad stream so peak memory is O(1) in the number of children, instead of materialising a
-    // full N3 store of every child before the response starts (which for very large containers is
-    // hundreds of MB to several GB of transient heap per read). The behaviour below is unchanged.
+    // Stream container listings without materialising all child metadata.
     if (isContainer && !isMetadata) {
       const stream = await this.streamContainerRepresentation(identifier, metadata);
       return new BasicRepresentation(stream, metadata, INTERNAL_QUADS);
@@ -172,27 +169,18 @@ export class DataAccessorBasedStore implements ResourceStore {
   }
 
   /**
-   * Produces the RDF body of a container listing as a lazy quad stream. Peak memory is O(1) in the
-   * number of children: at most one child's metadata is held at a time, rather than folding every
-   * child into one N3 store before the response starts.
-   *
-   * A single `ldp:contains` triple for the first non-auxiliary child is also written to `metadata`
-   * as a non-empty marker, because {@link AllowAcceptHeaderWriter} decides whether a container may
-   * be deleted from `metadata.has(ldp:contains)`. The complete containment list lives only in the
-   * streamed body; consumers that need every member (e.g. `JsonResourceStorage`) read it from there.
+   * Creates a lazy quad stream for a container listing.
+   * Adds one containment quad to metadata for empty-container checks.
    */
   protected async streamContainerRepresentation(identifier: ResourceIdentifier, metadata: RepresentationMetadata):
   Promise<Readable> {
-    // Snapshot the container's own quads for the body BEFORE adding prefixes — O(1). The prefix
-    // declarations belong in the response metadata only (the converter reads them from there), not
-    // in the body, matching the non-streaming path which captured `data` before adding them.
+    // Snapshot the body before adding response-only prefixes.
     const ownQuads = metadata.quads();
     metadata.addQuad(DC.terms.namespace, PREFERRED_PREFIX_TERM, 'dc', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
-    // The first generated quad is always an `ldp:contains` quad. Peek it to determine whether the
-    // container is empty without materialising the remaining children.
+    // Retain the first containment quad for empty-container checks.
     const childQuads = this.getContainerListingQuads(identifier, metadata.identifier as NamedNode);
     const first = await childQuads.next();
     if (!first.done) {
@@ -209,10 +197,7 @@ export class DataAccessorBasedStore implements ResourceStore {
     return Readable.from(generate(), { objectMode: true });
   }
 
-  /**
-   * Lazily yields the containment and metadata quads for every non-auxiliary child.
-   * The containment quad is yielded first so callers can peek it as a non-empty marker.
-   */
+  /** Yields containment and metadata quads for non-auxiliary children. */
   private async* getContainerListingQuads(identifier: ResourceIdentifier, containerNode: NamedNode):
   AsyncIterableIterator<Quad> {
     for await (const child of this.accessor.getChildren(identifier)) {

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -144,9 +144,6 @@ export class DataAccessorBasedStore implements ResourceStore {
         // Add containment triples of non-auxiliary resources
         for await (const child of this.accessor.getChildren(identifier)) {
           if (!this.auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value })) {
-            if (!isMetadata) {
-              metadata.addQuads(child.quads());
-            }
             metadata.add(LDP.terms.contains, child.identifier as NamedNode, SOLID_META.terms.ResponseMetadata);
           }
         }
@@ -194,54 +191,41 @@ export class DataAccessorBasedStore implements ResourceStore {
     metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
     metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
-    const containerNode = metadata.identifier as NamedNode;
-    const auxiliaryStrategy = this.auxiliaryStrategy;
-    const isAux = (child: RepresentationMetadata): boolean =>
-      auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value });
-    const containsQuad = (child: RepresentationMetadata): Quad => DataFactory.quad(
-      containerNode,
-      LDP.terms.contains,
-      child.identifier as NamedNode,
-      SOLID_META.terms.ResponseMetadata,
-    );
-
-    // Peek the first non-auxiliary child: used both as the non-empty marker and as the head of the
-    // stream. Auxiliary children pulled during the peek are skipped (never part of the listing).
-    const iterator = this.accessor.getChildren(identifier)[Symbol.asyncIterator]();
-    let first: RepresentationMetadata | undefined;
-    try {
-      for (let next = await iterator.next(); !next.done; next = await iterator.next()) {
-        if (!isAux(next.value)) {
-          first = next.value;
-          break;
-        }
-      }
-    } catch (error: unknown) {
-      await iterator.return?.();
-      throw error;
-    }
-    if (first) {
-      metadata.add(LDP.terms.contains, first.identifier as NamedNode, SOLID_META.terms.ResponseMetadata);
+    // The first generated quad is always an `ldp:contains` quad. Peek it to determine whether the
+    // container is empty without materialising the remaining children.
+    const childQuads = this.getContainerListingQuads(identifier, metadata.identifier as NamedNode);
+    const first = await childQuads.next();
+    if (!first.done) {
+      metadata.addQuads([ first.value ]);
     }
 
     async function* generate(): AsyncIterableIterator<Quad> {
-      try {
-        yield* ownQuads;
-        if (first) {
-          yield* first.quads();
-          yield containsQuad(first);
-          for (let next = await iterator.next(); !next.done; next = await iterator.next()) {
-            if (!isAux(next.value)) {
-              yield* next.value.quads();
-              yield containsQuad(next.value);
-            }
-          }
-        }
-      } finally {
-        await iterator.return?.();
+      yield* ownQuads;
+      if (!first.done) {
+        yield first.value;
+        yield* childQuads;
       }
     }
     return Readable.from(generate(), { objectMode: true });
+  }
+
+  /**
+   * Lazily yields the containment and metadata quads for every non-auxiliary child.
+   * The containment quad is yielded first so callers can peek it as a non-empty marker.
+   */
+  private async* getContainerListingQuads(identifier: ResourceIdentifier, containerNode: NamedNode):
+  AsyncIterableIterator<Quad> {
+    for await (const child of this.accessor.getChildren(identifier)) {
+      if (!this.auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value })) {
+        yield DataFactory.quad(
+          containerNode,
+          LDP.terms.contains,
+          child.identifier as NamedNode,
+          SOLID_META.terms.ResponseMetadata,
+        );
+        yield* child.quads();
+      }
+    }
   }
 
   public async addResource(container: ResourceIdentifier, representation: Representation, conditions?: Conditions):

--- a/src/storage/DataAccessorBasedStore.ts
+++ b/src/storage/DataAccessorBasedStore.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { Readable } from 'node:stream';
 import type { NamedNode, Quad, Term } from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
 import { DataFactory } from 'n3';
@@ -127,6 +128,16 @@ export class DataAccessorBasedStore implements ResourceStore {
     await this.auxiliaryStrategy.addMetadata(metadata);
 
     const isContainer = isContainerPath(metadata.identifier.value);
+
+    // Streaming fast-path for container LISTINGS (not description resources): emit the listing as a
+    // lazy quad stream so peak memory is O(1) in the number of children, instead of materialising a
+    // full N3 store of every child before the response starts (which for very large containers is
+    // hundreds of MB to several GB of transient heap per read). The behaviour below is unchanged.
+    if (isContainer && !isMetadata) {
+      const stream = await this.streamContainerRepresentation(identifier, metadata);
+      return new BasicRepresentation(stream, metadata, INTERNAL_QUADS);
+    }
+
     let data = metadata.quads();
     if (isContainer || isMetadata) {
       if (isContainer) {
@@ -161,6 +172,76 @@ export class DataAccessorBasedStore implements ResourceStore {
     }
 
     return representation;
+  }
+
+  /**
+   * Produces the RDF body of a container listing as a lazy quad stream. Peak memory is O(1) in the
+   * number of children: at most one child's metadata is held at a time, rather than folding every
+   * child into one N3 store before the response starts.
+   *
+   * A single `ldp:contains` triple for the first non-auxiliary child is also written to `metadata`
+   * as a non-empty marker, because {@link AllowAcceptHeaderWriter} decides whether a container may
+   * be deleted from `metadata.has(ldp:contains)`. The complete containment list lives only in the
+   * streamed body; consumers that need every member (e.g. `JsonResourceStorage`) read it from there.
+   */
+  protected async streamContainerRepresentation(identifier: ResourceIdentifier, metadata: RepresentationMetadata):
+  Promise<Readable> {
+    // Snapshot the container's own quads for the body BEFORE adding prefixes — O(1). The prefix
+    // declarations belong in the response metadata only (the converter reads them from there), not
+    // in the body, matching the non-streaming path which captured `data` before adding them.
+    const ownQuads = metadata.quads();
+    metadata.addQuad(DC.terms.namespace, PREFERRED_PREFIX_TERM, 'dc', SOLID_META.terms.ResponseMetadata);
+    metadata.addQuad(LDP.terms.namespace, PREFERRED_PREFIX_TERM, 'ldp', SOLID_META.terms.ResponseMetadata);
+    metadata.addQuad(POSIX.terms.namespace, PREFERRED_PREFIX_TERM, 'posix', SOLID_META.terms.ResponseMetadata);
+    metadata.addQuad(XSD.terms.namespace, PREFERRED_PREFIX_TERM, 'xsd', SOLID_META.terms.ResponseMetadata);
+    const containerNode = metadata.identifier as NamedNode;
+    const auxiliaryStrategy = this.auxiliaryStrategy;
+    const isAux = (child: RepresentationMetadata): boolean =>
+      auxiliaryStrategy.isAuxiliaryIdentifier({ path: child.identifier.value });
+    const containsQuad = (child: RepresentationMetadata): Quad => DataFactory.quad(
+      containerNode,
+      LDP.terms.contains,
+      child.identifier as NamedNode,
+      SOLID_META.terms.ResponseMetadata,
+    );
+
+    // Peek the first non-auxiliary child: used both as the non-empty marker and as the head of the
+    // stream. Auxiliary children pulled during the peek are skipped (never part of the listing).
+    const iterator = this.accessor.getChildren(identifier)[Symbol.asyncIterator]();
+    let first: RepresentationMetadata | undefined;
+    try {
+      for (let next = await iterator.next(); !next.done; next = await iterator.next()) {
+        if (!isAux(next.value)) {
+          first = next.value;
+          break;
+        }
+      }
+    } catch (error: unknown) {
+      await iterator.return?.();
+      throw error;
+    }
+    if (first) {
+      metadata.add(LDP.terms.contains, first.identifier as NamedNode, SOLID_META.terms.ResponseMetadata);
+    }
+
+    async function* generate(): AsyncIterableIterator<Quad> {
+      try {
+        yield* ownQuads;
+        if (first) {
+          yield* first.quads();
+          yield containsQuad(first);
+          for (let next = await iterator.next(); !next.done; next = await iterator.next()) {
+            if (!isAux(next.value)) {
+              yield* next.value.quads();
+              yield containsQuad(next.value);
+            }
+          }
+        }
+      } finally {
+        await iterator.return?.();
+      }
+    }
+    return Readable.from(generate(), { objectMode: true });
   }
 
   public async addResource(container: ResourceIdentifier, representation: Representation, conditions?: Conditions):

--- a/src/storage/accessors/InMemoryDataAccessor.ts
+++ b/src/storage/accessors/InMemoryDataAccessor.ts
@@ -18,7 +18,7 @@ interface DataEntry {
   metadata: RepresentationMetadata;
 }
 interface ContainerEntry {
-  entries: Record<string, CacheEntry>;
+  entries: Map<string, CacheEntry>;
   metadata: RepresentationMetadata;
 }
 type CacheEntry = DataEntry | ContainerEntry;
@@ -26,12 +26,12 @@ type CacheEntry = DataEntry | ContainerEntry;
 export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
   private readonly identifierStrategy: IdentifierStrategy;
   // A dummy container where every entry corresponds to a root container
-  private readonly store: { entries: Record<string, ContainerEntry> };
+  private readonly store: { entries: Map<string, CacheEntry> };
 
   public constructor(identifierStrategy: IdentifierStrategy) {
     this.identifierStrategy = identifierStrategy;
 
-    this.store = { entries: {}};
+    this.store = { entries: new Map() };
   }
 
   public async canHandle(): Promise<void> {
@@ -54,11 +54,11 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
   public async* getChildren(identifier: ResourceIdentifier): AsyncIterableIterator<RepresentationMetadata> {
     const entry = this.getEntry(identifier);
     if (!this.isDataEntry(entry)) {
-      yield* Object.entries(entry.entries).map(([ path, child ]): RepresentationMetadata => {
+      for (const [ path, child ] of entry.entries) {
         const metadata = new RepresentationMetadata(DataFactory.namedNode(path));
         metadata.addQuads(child.metadata.quads());
-        return metadata;
-      });
+        yield metadata;
+      }
     }
   }
 
@@ -74,10 +74,10 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
       metadata.set(POSIX.terms.size, `${size}`);
     }
 
-    parent.entries[identifier.path] = {
+    parent.entries.set(identifier.path, {
       data: dataArray,
       metadata,
-    };
+    });
   }
 
   public async writeContainer(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
@@ -89,10 +89,10 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
       // Create new entry if it didn't exist yet
       if (NotFoundHttpError.isInstance(error)) {
         const parent = this.getParentEntry(identifier);
-        parent.entries[identifier.path] = {
-          entries: {},
+        parent.entries.set(identifier.path, {
+          entries: new Map(),
           metadata,
-        };
+        });
       } else {
         throw error;
       }
@@ -106,10 +106,9 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
 
   public async deleteResource(identifier: ResourceIdentifier): Promise<void> {
     const parent = this.getParentEntry(identifier);
-    if (!parent.entries[identifier.path]) {
+    if (!parent.entries.delete(identifier.path)) {
       throw new NotFoundHttpError();
     }
-    delete parent.entries[identifier.path];
   }
 
   private isDataEntry(entry: CacheEntry): entry is DataEntry {
@@ -142,10 +141,11 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
 
     const hierarchy = this.getHierarchy(this.identifierStrategy.getParentContainer(identifier));
     for (const entry of hierarchy) {
-      parent = parent.entries[entry.path];
-      if (!parent) {
+      const child: CacheEntry | undefined = parent.entries.get(entry.path);
+      if (!child) {
         throw new NotFoundHttpError();
       }
+      parent = child;
       if (this.isDataEntry(parent)) {
         throw new InternalServerError('Invalid path.');
       }
@@ -160,7 +160,7 @@ export class InMemoryDataAccessor implements DataAccessor, SingleThreaded {
    */
   private getEntry(identifier: ResourceIdentifier): CacheEntry {
     const parent = this.getParentEntry(identifier);
-    const entry = parent.entries[identifier.path];
+    const entry = parent.entries.get(identifier.path);
     if (!entry) {
       throw new NotFoundHttpError();
     }

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -106,7 +106,8 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     representation: Representation,
   ): AsyncIterableIterator<ResourceIdentifier> {
     for await (const entry of representation.data as AsyncIterable<Partial<Quad>>) {
-      if (entry.subject?.value === identifier.path && entry.predicate?.equals(LDP.terms.contains) &&
+      if (entry.subject?.termType === 'NamedNode' && entry.subject.value === identifier.path &&
+        entry.predicate?.termType === 'NamedNode' && entry.predicate.value === LDP.terms.contains.value &&
         entry.object?.termType === 'NamedNode') {
         yield { path: entry.object.value };
       }

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -84,17 +84,9 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     const representation = await this.safelyGetResource(identifier);
     if (representation) {
       if (isContainerIdentifier(identifier)) {
-        // The containment list lives in the (streamed) quad body, not the metadata, so read the
-        // `ldp:contains` objects from the body. O(children) time and O(children) memory (member list only).
-        // Draining the stream also releases the container read lock before we recurse into the members.
-        const members: string[] = [];
-        for await (const quad of representation.data as AsyncIterable<Quad>) {
-          if (quad.predicate.equals(LDP.terms.contains)) {
-            members.push(quad.object.value);
-          }
-        }
-        for (const path of members) {
-          yield* this.getResourceEntries({ path });
+        const members = await this.getContainedResourceIdentifiers(identifier, representation);
+        for (const member of members) {
+          yield* this.getResourceEntries(member);
         }
       } else {
         try {
@@ -107,6 +99,24 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
         }
       }
     }
+  }
+
+  /**
+   * Reads direct members from a streamed container representation. The stream is fully drained so
+   * its read lock is released before callers acquire locks for the contained resources.
+   */
+  protected async getContainedResourceIdentifiers(
+    identifier: ResourceIdentifier,
+    representation: Representation,
+  ): Promise<ResourceIdentifier[]> {
+    const members: ResourceIdentifier[] = [];
+    for await (const entry of representation.data as AsyncIterable<Partial<Quad>>) {
+      if (entry.subject?.value === identifier.path && entry.predicate?.equals(LDP.terms.contains) &&
+        entry.object?.termType === 'NamedNode') {
+        members.push({ path: entry.object.value });
+      }
+    }
+    return members;
   }
 
   /**

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -85,8 +85,8 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     if (representation) {
       if (isContainerIdentifier(identifier)) {
         // The containment list lives in the (streamed) quad body, not the metadata, so read the
-        // `ldp:contains` objects from the body. O(children) time, O(1) memory. Draining the stream
-        // also releases the container read lock before we recurse into the members.
+        // `ldp:contains` objects from the body. O(children) time and O(children) memory (member list only).
+        // Draining the stream also releases the container read lock before we recurse into the members.
         const members: string[] = [];
         for await (const quad of representation.data as AsyncIterable<Quad>) {
           if (quad.predicate.equals(LDP.terms.contains)) {

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -1,3 +1,4 @@
+import type { Quad } from '@rdfjs/types';
 import { BasicRepresentation } from '../../http/representation/BasicRepresentation';
 import type { Representation } from '../../http/representation/Representation';
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
@@ -83,9 +84,15 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     const representation = await this.safelyGetResource(identifier);
     if (representation) {
       if (isContainerIdentifier(identifier)) {
-        // Only need the metadata
-        representation.data.destroy();
-        const members = representation.metadata.getAll(LDP.terms.contains).map((term): string => term.value);
+        // The containment list lives in the (streamed) quad body, not the metadata, so read the
+        // `ldp:contains` objects from the body. O(children) time, O(1) memory. Draining the stream
+        // also releases the container read lock before we recurse into the members.
+        const members: string[] = [];
+        for await (const quad of representation.data as AsyncIterable<Quad>) {
+          if (quad.predicate.equals(LDP.terms.contains)) {
+            members.push(quad.object.value);
+          }
+        }
         for (const path of members) {
           yield* this.getResourceEntries({ path });
         }

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -84,8 +84,7 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     const representation = await this.safelyGetResource(identifier);
     if (representation) {
       if (isContainerIdentifier(identifier)) {
-        const members = await this.getContainedResourceIdentifiers(identifier, representation);
-        for (const member of members) {
+        for await (const member of this.getContainedResourceIdentifiers(identifier, representation)) {
           yield* this.getResourceEntries(member);
         }
       } else {
@@ -101,19 +100,17 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     }
   }
 
-  /** Reads direct members and drains the stream before recursively locking children. */
-  protected async getContainedResourceIdentifiers(
+  /** Streams direct member identifiers from a container representation. */
+  protected async* getContainedResourceIdentifiers(
     identifier: ResourceIdentifier,
     representation: Representation,
-  ): Promise<ResourceIdentifier[]> {
-    const members: ResourceIdentifier[] = [];
+  ): AsyncIterableIterator<ResourceIdentifier> {
     for await (const entry of representation.data as AsyncIterable<Partial<Quad>>) {
       if (entry.subject?.value === identifier.path && entry.predicate?.equals(LDP.terms.contains) &&
         entry.object?.termType === 'NamedNode') {
-        members.push({ path: entry.object.value });
+        yield { path: entry.object.value };
       }
     }
-    return members;
   }
 
   /**

--- a/src/storage/keyvalue/JsonResourceStorage.ts
+++ b/src/storage/keyvalue/JsonResourceStorage.ts
@@ -101,10 +101,7 @@ export class JsonResourceStorage<T> implements KeyValueStorage<string, T> {
     }
   }
 
-  /**
-   * Reads direct members from a streamed container representation. The stream is fully drained so
-   * its read lock is released before callers acquire locks for the contained resources.
-   */
+  /** Reads direct members and drains the stream before recursively locking children. */
   protected async getContainedResourceIdentifiers(
     identifier: ResourceIdentifier,
     representation: Representation,

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -323,6 +323,8 @@ export const SOLID_META = createVocabulary(
   'value',
   // This is used to indicate whether metadata should be preserved or not during a PUT operation
   'preserve',
+  // Indicates whether a container has no contained resources
+  'containerEmpty',
   // These predicates are used to describe the requested access in case of an unauthorized request
   'requestedAccess',
   'accessTarget',
@@ -341,6 +343,7 @@ export const VCARD = createVocabulary(
 
 export const XSD = createVocabulary(
   'http://www.w3.org/2001/XMLSchema#',
+  'boolean',
   'dateTime',
   'duration',
   'integer',

--- a/test/memory/container-listing.js
+++ b/test/memory/container-listing.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { RepresentationMetadata } = require('../../dist/http/representation/RepresentationMetadata');
+const { DataAccessorBasedStore } = require('../../dist/storage/DataAccessorBasedStore');
+const { DC, LDP, POSIX, RDF } = require('../../dist/util/Vocabularies');
+
+const container = { path: 'http://example.com/large/' };
+const childCount = 15_000;
+const concurrency = 20;
+let generatedChildren = 0;
+
+const accessor = {
+  async getMetadata(identifier) {
+    const metadata = new RepresentationMetadata(identifier);
+    metadata.add(RDF.terms.type, LDP.terms.Container);
+    return metadata;
+  },
+  async* getChildren() {
+    for (let i = 0; i < childCount; ++i) {
+      generatedChildren += 1;
+      const child = new RepresentationMetadata({ path: `${container.path}${i}` });
+      child.add(RDF.terms.type, LDP.terms.Resource);
+      child.add(DC.terms.modified, '2026-01-01T00:00:00.000Z');
+      child.add(POSIX.terms.size, '1');
+      yield child;
+    }
+  },
+};
+const identifierStrategy = {
+  supportsIdentifier: identifier => identifier.path.startsWith('http://example.com/'),
+};
+const auxiliaryStrategy = {
+  addMetadata: async() => {},
+  isAuxiliaryIdentifier: () => false,
+};
+const metadataStrategy = {
+  isAuxiliaryIdentifier: () => false,
+};
+const store = new DataAccessorBasedStore(accessor, identifierStrategy, auxiliaryStrategy, metadataStrategy);
+
+let peakHeap = process.memoryUsage().heapUsed;
+
+async function drainListing() {
+  const representation = await store.getRepresentation(container);
+  assert.equal(representation.metadata.getAll(LDP.terms.contains).length, 1);
+  let quadCount = 0;
+  for await (const quad of representation.data) {
+    assert.equal(quad.termType, 'Quad');
+    quadCount += 1;
+    if (quadCount % 10_000 === 0) {
+      peakHeap = Math.max(peakHeap, process.memoryUsage().heapUsed);
+    }
+  }
+}
+
+Promise.all(Array.from({ length: concurrency }, drainListing)).then(() => {
+  globalThis.gc();
+
+  assert.equal(generatedChildren, childCount * concurrency);
+  const peakMegabytes = peakHeap / 1024 / 1024;
+  assert.ok(peakMegabytes < 110, `Peak heap ${peakMegabytes.toFixed(1)} MB exceeded the 110 MB limit`);
+  process.stdout.write(`Container listing peak heap: ${peakMegabytes.toFixed(1)} MB\n`);
+}).catch((error) => {
+  process.stderr.write(`${error.stack ?? error}\n`);
+  process.exitCode = 1;
+});

--- a/test/memory/container-listing.js
+++ b/test/memory/container-listing.js
@@ -3,7 +3,7 @@
 const assert = require('node:assert/strict');
 const { RepresentationMetadata } = require('../../dist/http/representation/RepresentationMetadata');
 const { DataAccessorBasedStore } = require('../../dist/storage/DataAccessorBasedStore');
-const { DC, LDP, POSIX, RDF } = require('../../dist/util/Vocabularies');
+const { DC, LDP, POSIX, RDF, SOLID_META, XSD } = require('../../dist/util/Vocabularies');
 
 const container = { path: 'http://example.com/large/' };
 const childCount = 15_000;
@@ -43,7 +43,9 @@ let peakHeap = process.memoryUsage().heapUsed;
 
 async function drainListing() {
   const representation = await store.getRepresentation(container);
-  assert.equal(representation.metadata.getAll(LDP.terms.contains).length, 1);
+  const empty = representation.metadata.get(SOLID_META.terms.containerEmpty, SOLID_META.terms.ResponseMetadata);
+  assert.equal(empty.value, 'false');
+  assert.equal(empty.datatype.value, XSD.boolean);
   let quadCount = 0;
   for await (const quad of representation.data) {
     assert.equal(quad.termType, 'Quad');

--- a/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
+++ b/test/unit/http/output/metadata/AllowAcceptHeaderWriter.test.ts
@@ -1,3 +1,4 @@
+import { DataFactory } from 'n3';
 import { createResponse } from 'node-mocks-http';
 import { AllowAcceptHeaderWriter } from '../../../../../src/http/output/metadata/AllowAcceptHeaderWriter';
 import type { MetadataRecord } from '../../../../../src/http/representation/RepresentationMetadata';
@@ -6,7 +7,7 @@ import type { HttpResponse } from '../../../../../src/server/HttpResponse';
 import { MethodNotAllowedHttpError } from '../../../../../src/util/errors/MethodNotAllowedHttpError';
 import { NotFoundHttpError } from '../../../../../src/util/errors/NotFoundHttpError';
 import { UnsupportedMediaTypeHttpError } from '../../../../../src/util/errors/UnsupportedMediaTypeHttpError';
-import { LDP, PIM, RDF, SOLID_ERROR, SOLID_META } from '../../../../../src/util/Vocabularies';
+import { LDP, PIM, RDF, SOLID_ERROR, SOLID_META, XSD } from '../../../../../src/util/Vocabularies';
 
 describe('An AllowAcceptHeaderWriter', (): void => {
   const document = new RepresentationMetadata(
@@ -21,6 +22,11 @@ describe('An AllowAcceptHeaderWriter', (): void => {
     { path: 'http://example.com/foo/' },
     { [RDF.type]: [ LDP.terms.Resource, LDP.terms.Container ]},
   );
+  emptyContainer.add(
+    SOLID_META.terms.containerEmpty,
+    DataFactory.literal('true', XSD.terms.boolean),
+    SOLID_META.terms.ResponseMetadata,
+  );
   const fullContainer = new RepresentationMetadata(
     { path: 'http://example.com/foo/' },
     {
@@ -28,6 +34,13 @@ describe('An AllowAcceptHeaderWriter', (): void => {
       [LDP.contains]: [ document.identifier ],
       // Typescript doesn't find the correct constructor without the cast
     } as MetadataRecord,
+  );
+  const streamedFullContainer = new RepresentationMetadata(fullContainer);
+  streamedFullContainer.removeAll(LDP.terms.contains);
+  streamedFullContainer.add(
+    SOLID_META.terms.containerEmpty,
+    DataFactory.literal('false', XSD.terms.boolean),
+    SOLID_META.terms.ResponseMetadata,
   );
   const storageContainer = new RepresentationMetadata(
     { path: 'http://example.com/foo/' },
@@ -100,6 +113,14 @@ describe('An AllowAcceptHeaderWriter', (): void => {
     expect(headers['accept-patch']).toBeUndefined();
     expect(headers['accept-put']).toBeUndefined();
     expect(headers['accept-post']).toBe('*/*');
+  });
+
+  it('uses the explicit emptiness metadata for streamed containers.', async(): Promise<void> => {
+    await expect(writer.handleSafe({ response, metadata: streamedFullContainer })).resolves.toBeUndefined();
+    const headers = response.getHeaders();
+    expect(typeof headers.allow).toBe('string');
+    expect(new Set(headers.allow!.split(', ')))
+      .toEqual(new Set([ 'OPTIONS', 'GET', 'HEAD', 'POST' ]));
   });
 
   it('returns all methods except PUT/PATCH/DELETE for a storage container.', async(): Promise<void> => {

--- a/test/unit/init/migration/SingleContainerJsonStorage.test.ts
+++ b/test/unit/init/migration/SingleContainerJsonStorage.test.ts
@@ -1,8 +1,11 @@
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
 import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
 import { SingleContainerJsonStorage } from '../../../../src/init/migration/SingleContainerJsonStorage';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
+import { INTERNAL_QUADS } from '../../../../src/util/ContentTypes';
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
 import { isContainerIdentifier } from '../../../../src/util/PathUtil';
 import { LDP } from '../../../../src/util/Vocabularies';
@@ -17,13 +20,17 @@ describe('A SingleContainerJsonStorage', (): void => {
     store = {
       getRepresentation: jest.fn(async(id): Promise<Representation> => {
         if (isContainerIdentifier(id)) {
-          const metadata = new RepresentationMetadata(id);
-          metadata.add(LDP.terms.contains, 'http://example.com/.internal/accounts/foo');
-          metadata.add(LDP.terms.contains, 'http://example.com/.internal/accounts/bad');
-          metadata.add(LDP.terms.contains, 'http://example.com/.internal/accounts/bar/');
-          metadata.add(LDP.terms.contains, 'http://example.com/.internal/accounts/baz');
-          metadata.add(LDP.terms.contains, 'http://example.com/.internal/accounts/unknown');
-          return new BasicRepresentation('', metadata);
+          // New contract: the containment triples are in the (quad) body, not the metadata.
+          const members = [
+            'http://example.com/.internal/accounts/foo',
+            'http://example.com/.internal/accounts/bad',
+            'http://example.com/.internal/accounts/bar/',
+            'http://example.com/.internal/accounts/baz',
+            'http://example.com/.internal/accounts/unknown',
+          ];
+          const quads = members.map((member): Quad =>
+            DataFactory.quad(DataFactory.namedNode(id.path), LDP.terms.contains, DataFactory.namedNode(member)));
+          return new BasicRepresentation(quads, new RepresentationMetadata(id), INTERNAL_QUADS);
         }
         if (id.path.endsWith('unknown')) {
           throw new NotFoundHttpError();

--- a/test/unit/init/migration/SingleContainerJsonStorage.test.ts
+++ b/test/unit/init/migration/SingleContainerJsonStorage.test.ts
@@ -20,7 +20,7 @@ describe('A SingleContainerJsonStorage', (): void => {
     store = {
       getRepresentation: jest.fn(async(id): Promise<Representation> => {
         if (isContainerIdentifier(id)) {
-          // New contract: the containment triples are in the (quad) body, not the metadata.
+          // Container members are listed in the body.
           const members = [
             'http://example.com/.internal/accounts/foo',
             'http://example.com/.internal/accounts/bad',
@@ -30,7 +30,7 @@ describe('A SingleContainerJsonStorage', (): void => {
           ];
           const quads = members.map((member): Quad =>
             DataFactory.quad(DataFactory.namedNode(id.path), LDP.terms.contains, DataFactory.namedNode(member)));
-          // Containment metadata from a child resource must not be interpreted as a direct member.
+          // Ignore containment statements from child resources.
           quads.push(DataFactory.quad(
             DataFactory.namedNode(`${id.path}nested/`),
             LDP.terms.contains,

--- a/test/unit/init/migration/SingleContainerJsonStorage.test.ts
+++ b/test/unit/init/migration/SingleContainerJsonStorage.test.ts
@@ -30,6 +30,20 @@ describe('A SingleContainerJsonStorage', (): void => {
           ];
           const quads = members.map((member): Quad =>
             DataFactory.quad(DataFactory.namedNode(id.path), LDP.terms.contains, DataFactory.namedNode(member)));
+          // Containment metadata from a child resource must not be interpreted as a direct member.
+          quads.push(DataFactory.quad(
+            DataFactory.namedNode(`${id.path}nested/`),
+            LDP.terms.contains,
+            DataFactory.namedNode(`${id.path}not-a-direct-member`),
+          ));
+          const containerNode = DataFactory.namedNode(id.path);
+          quads.push(
+            {} as unknown as Quad,
+            { subject: containerNode } as unknown as Quad,
+            { subject: containerNode, predicate: LDP.terms.contains } as unknown as Quad,
+            DataFactory.quad(containerNode, DataFactory.namedNode('urn:other'), DataFactory.namedNode('urn:ignored')),
+            DataFactory.quad(containerNode, LDP.terms.contains, DataFactory.literal('not-an-identifier')),
+          );
           return new BasicRepresentation(quads, new RepresentationMetadata(id), INTERNAL_QUADS);
         }
         if (id.path.endsWith('unknown')) {

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -1,4 +1,5 @@
 import 'jest-rdf';
+import { once } from 'node:events';
 import type { Readable } from 'node:stream';
 import type { Quad } from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
@@ -207,9 +208,35 @@ describe('A DataAccessorBasedStore', (): void => {
       }
       expect(generatedChildren).toBeLessThan(20);
 
+      const closed = new Promise<void>((resolve): void => {
+        result.data.once('close', resolve);
+      });
       await iterator.return?.();
+      await closed;
       expect(iteratorClosed).toBe(true);
       expect(generatedChildren).toBeLessThan(childCount);
+    });
+
+    it('releases the child iterator when an unread listing is destroyed.', async(): Promise<void> => {
+      const resourceID = { path: `${root}container/` };
+      containerMetadata.identifier = namedNode(resourceID.path);
+      accessor.data[resourceID.path] = { metadata: containerMetadata } as Representation;
+
+      let iteratorClosed = false;
+      accessor.getChildren = async function* (): AsyncIterableIterator<RepresentationMetadata> {
+        try {
+          yield new RepresentationMetadata({ path: `${resourceID.path}child` });
+        } finally {
+          iteratorClosed = true;
+        }
+      };
+
+      const result = await store.getRepresentation(resourceID);
+      const closed = once(result.data, 'close');
+      result.data.destroy();
+      await closed;
+
+      expect(iteratorClosed).toBe(true);
     });
 
     it('will remove containment triples referencing auxiliary resources.', async(): Promise<void> => {

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -169,6 +169,45 @@ describe('A DataAccessorBasedStore', (): void => {
         .toBe(auxiliaryStrategy.getAuxiliaryIdentifier(resourceID).path);
     });
 
+    it('keeps large container listings lazy and releases their child iterator on cancellation.', async():
+    Promise<void> => {
+      const resourceID = { path: `${root}container/` };
+      containerMetadata.identifier = namedNode(resourceID.path);
+      accessor.data[resourceID.path] = { metadata: containerMetadata } as Representation;
+
+      const childCount = 100_000;
+      let generatedChildren = 0;
+      let iteratorClosed = false;
+      accessor.getChildren = async function* (): AsyncIterableIterator<RepresentationMetadata> {
+        try {
+          for (let i = 0; i < childCount; ++i) {
+            generatedChildren += 1;
+            const child = new RepresentationMetadata({ path: `${resourceID.path}${i}` });
+            child.add(RDF.terms.type, LDP.terms.Resource);
+            yield child;
+          }
+        } finally {
+          iteratorClosed = true;
+        }
+      };
+
+      const result = await store.getRepresentation(resourceID);
+
+      // Only the one-child non-empty marker may be loaded before a consumer reads the body.
+      expect(generatedChildren).toBe(1);
+      expect(result.metadata.getAll(LDP.terms.contains)).toHaveLength(1);
+
+      const iterator = result.data[Symbol.asyncIterator]();
+      for (let i = 0; i < 20; ++i) {
+        expect((await iterator.next()).done).toBe(false);
+      }
+      expect(generatedChildren).toBeLessThan(20);
+
+      await iterator.return?.();
+      expect(iteratorClosed).toBe(true);
+      expect(generatedChildren).toBeLessThan(childCount);
+    });
+
     it('will remove containment triples referencing auxiliary resources.', async(): Promise<void> => {
       const resourceID = { path: `${root}container/` };
       containerMetadata.identifier = namedNode(resourceID.path);

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -1,5 +1,6 @@
 import 'jest-rdf';
 import type { Readable } from 'node:stream';
+import type { Quad } from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
 import { DataFactory, Store } from 'n3';
 import type { Conditions } from '../../../src';
@@ -167,6 +168,8 @@ describe('A DataAccessorBasedStore', (): void => {
       expect(result.metadata.contentType).toEqual(INTERNAL_QUADS);
       expect(result.metadata.get(namedNode('AUXILIARY'))?.value)
         .toBe(auxiliaryStrategy.getAuxiliaryIdentifier(resourceID).path);
+      expect(result.metadata.get(SOLID_META.terms.containerEmpty, SOLID_META.terms.ResponseMetadata))
+        .toEqualRdfTerm(literal('true', XSD.terms.boolean));
     });
 
     it('keeps large container listings lazy and releases their child iterator on cancellation.', async():
@@ -193,9 +196,10 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.getRepresentation(resourceID);
 
-      // The first child is peeked before the body is consumed.
       expect(generatedChildren).toBe(1);
-      expect(result.metadata.getAll(LDP.terms.contains)).toHaveLength(1);
+      expect(result.metadata.getAll(LDP.terms.contains)).toHaveLength(0);
+      expect(result.metadata.get(SOLID_META.terms.containerEmpty, SOLID_META.terms.ResponseMetadata))
+        .toEqualRdfTerm(literal('false', XSD.terms.boolean));
 
       const iterator = result.data[Symbol.asyncIterator]();
       for (let i = 0; i < 20; ++i) {
@@ -216,7 +220,8 @@ describe('A DataAccessorBasedStore', (): void => {
       accessor.data[`${resourceID.path}resource`] = representation;
       accessor.data[`${resourceID.path}resource.dummy`] = representation;
       const result = await store.getRepresentation(resourceID);
-      const contains = result.metadata.getAll(LDP.terms.contains);
+      const quads = await arrayifyStream<Quad>(result.data);
+      const contains = new Store(quads).getObjects(namedNode(resourceID.path), LDP.terms.contains, null);
       expect(contains).toHaveLength(1);
       expect(contains[0].value).toBe(`${resourceID.path}resource`);
     });

--- a/test/unit/storage/DataAccessorBasedStore.test.ts
+++ b/test/unit/storage/DataAccessorBasedStore.test.ts
@@ -193,7 +193,7 @@ describe('A DataAccessorBasedStore', (): void => {
 
       const result = await store.getRepresentation(resourceID);
 
-      // Only the one-child non-empty marker may be loaded before a consumer reads the body.
+      // The first child is peeked before the body is consumed.
       expect(generatedChildren).toBe(1);
       expect(result.metadata.getAll(LDP.terms.contains)).toHaveLength(1);
 

--- a/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
+++ b/test/unit/storage/accessors/InMemoryDataAccessor.test.ts
@@ -127,6 +127,22 @@ describe('An InMemoryDataAccessor', (): void => {
       expect(children[0].get(RDF.terms.type)).toEqual(LDP.terms.Resource);
     });
 
+    it('generates child metadata lazily.', async(): Promise<void> => {
+      const firstMetadata = new RepresentationMetadata();
+      const secondMetadata = new RepresentationMetadata();
+      const firstQuads = jest.spyOn(firstMetadata, 'quads');
+      const secondQuads = jest.spyOn(secondMetadata, 'quads');
+      await accessor.writeDocument({ path: `${base}first` }, guardedStreamFrom([]), firstMetadata);
+      await accessor.writeDocument({ path: `${base}second` }, guardedStreamFrom([]), secondMetadata);
+
+      const children = accessor.getChildren({ path: base });
+      expect((await children.next()).done).toBe(false);
+      await children.return?.();
+
+      expect(firstQuads).toHaveBeenCalledTimes(1);
+      expect(secondQuads).not.toHaveBeenCalled();
+    });
+
     it('adds stored metadata when requesting document metadata.', async(): Promise<void> => {
       const identifier = { path: `${base}resource` };
       const inputMetadata = new RepresentationMetadata(identifier, {

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { DataFactory } from 'n3';
 import type { Quad } from '@rdfjs/types';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
@@ -128,5 +129,44 @@ describe('A JsonResourceStorage', (): void => {
       [ path2, 'path2' ],
       [ subPath, 'subDocument' ],
     ]);
+  });
+
+  it('streams container members.', async(): Promise<void> => {
+    const childCount = 100;
+    let generatedChildren = 0;
+    let listingClosed = false;
+    async function* generateListing(): AsyncIterableIterator<Quad> {
+      try {
+        for (let i = 0; i < childCount; ++i) {
+          generatedChildren += 1;
+          yield DataFactory.quad(
+            DataFactory.namedNode(containerIdentifier),
+            LDP.terms.contains,
+            DataFactory.namedNode(`${containerIdentifier}${i}`),
+          );
+        }
+      } finally {
+        listingClosed = true;
+      }
+    }
+    store.getRepresentation.mockImplementation(async(id): Promise<Representation> =>
+      isContainerIdentifier(id) ?
+        new BasicRepresentation(
+          Readable.from(generateListing()),
+          new RepresentationMetadata(id),
+          INTERNAL_QUADS,
+        ) :
+        new BasicRepresentation(JSON.stringify(id.path), id));
+
+    const iterator = storage.entries();
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: [ '0', `${containerIdentifier}0` ],
+    });
+    expect(generatedChildren).toBeLessThan(childCount);
+    expect(listingClosed).toBe(false);
+
+    await iterator.return?.();
+    expect(listingClosed).toBe(true);
   });
 });

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -1,9 +1,12 @@
+import { DataFactory } from 'n3';
+import type { Quad } from '@rdfjs/types';
 import { BasicRepresentation } from '../../../../src/http/representation/BasicRepresentation';
 import type { Representation } from '../../../../src/http/representation/Representation';
 import { RepresentationMetadata } from '../../../../src/http/representation/RepresentationMetadata';
 import type { ResourceIdentifier } from '../../../../src/http/representation/ResourceIdentifier';
 import { JsonResourceStorage } from '../../../../src/storage/keyvalue/JsonResourceStorage';
 import type { ResourceStore } from '../../../../src/storage/ResourceStore';
+import { INTERNAL_QUADS } from '../../../../src/util/ContentTypes';
 import { NotFoundHttpError } from '../../../../src/util/errors/NotFoundHttpError';
 import { isContainerIdentifier, joinUrl } from '../../../../src/util/PathUtil';
 import { readableToString } from '../../../../src/util/StreamUtil';
@@ -30,12 +33,13 @@ describe('A JsonResourceStorage', (): void => {
         if (!data.has(id.path)) {
           throw new NotFoundHttpError();
         }
-        // Simulate container metadata
+        // Simulate a container listing: the containment triples are in the (quad) body.
         if (isContainerIdentifier(id)) {
           const keys = [ ...data.keys() ].filter((key): boolean => key.startsWith(id.path) &&
             /^[^/]+\/?$/u.test(key.slice(id.path.length)));
-          const metadata = new RepresentationMetadata({ [LDP.contains]: keys });
-          return new BasicRepresentation('', metadata);
+          const quads = keys.map((key): Quad =>
+            DataFactory.quad(DataFactory.namedNode(id.path), LDP.terms.contains, DataFactory.namedNode(key)));
+          return new BasicRepresentation(quads, new RepresentationMetadata(id), INTERNAL_QUADS);
         }
         return new BasicRepresentation(data.get(id.path)!, id);
       }),

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -33,7 +33,7 @@ describe('A JsonResourceStorage', (): void => {
         if (!data.has(id.path)) {
           throw new NotFoundHttpError();
         }
-        // Simulate a container listing: the containment triples are in the (quad) body.
+        // Container members are listed in the body.
         if (isContainerIdentifier(id)) {
           const keys = [ ...data.keys() ].filter((key): boolean => key.startsWith(id.path) &&
             /^[^/]+\/?$/u.test(key.slice(id.path.length)));

--- a/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
+++ b/test/unit/storage/keyvalue/JsonResourceStorage.test.ts
@@ -137,6 +137,10 @@ describe('A JsonResourceStorage', (): void => {
     let listingClosed = false;
     async function* generateListing(): AsyncIterableIterator<Quad> {
       try {
+        yield {
+          subject: DataFactory.namedNode(containerIdentifier),
+          predicate: {},
+        } as unknown as Quad;
         for (let i = 0; i < childCount; ++i) {
           generatedChildren += 1;
           yield DataFactory.quad(


### PR DESCRIPTION
## Problem

Container reads currently collect every child's metadata in one N3 store and flatten it to a `Quad[]` before the response starts. Peak memory is therefore O(children), and concurrent reads can exhaust the process heap.

## Change

- Stream containment and child metadata quads from `DataAccessorBasedStore` with backpressure and iterator cleanup.
- Keep `DataAccessor.getChildren` lazy in the in-memory implementation.
- Expose container emptiness as response metadata so `AllowAcceptHeaderWriter` does not require a materialised containment list.
- Let `JsonResourceStorage` and `SingleContainerJsonStorage` consume direct `ldp:contains` statements from the streamed body.
- Keep the listing—and its read lock—open while consumers iterate it.
- Add a constrained-heap memory regression test to CI.

The streamed body preserves the previous RDF output. Consumers that destroy it without reading, such as notification ETag generation, no longer enumerate the children.

## Impact

The production benchmark used 20 concurrent reads of a 15,000-child container. Peak live heap dropped from roughly 3,056 MB to 140 MB. The CI workload runs the same shape with a 128 MB old-space limit; local runs peak at 23–36 MB, while the previous implementation runs out of memory.

## Tests

- Full unit suite: 358 suites and 2,380 tests passed with 100% source coverage.
- Focused storage and metadata tests: 5 suites and 110 tests passed.
- Affected integration suites: 7 suites and 189 tests passed.
- Build, lint, and test type-check passed.
- `npm run test:memory`: 35.6 MB peak heap in the latest local run.
