### PR TITLE
fix: keep write locks alive while request data is flowing

### DIFF
--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -51,7 +51,6 @@ export class LockingResourceStore implements AtomicResourceStore {
   ): Promise<Representation> {
     return this.lockedRepresentationRun(
       this.getLockIdentifier(identifier),
-      'read',
       async(): Promise<Representation> => this.source.getRepresentation(identifier, preferences, conditions),
     );
   }
@@ -61,12 +60,11 @@ export class LockingResourceStore implements AtomicResourceStore {
     representation: Representation,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.lockedRepresentationRun(
+    return this.lockedWriteRepresentationRun(
       this.getLockIdentifier(container),
-      'write',
+      representation,
       async(expiringRepresentation): Promise<ChangeMap> =>
         this.source.addResource(container, expiringRepresentation, conditions),
-      representation,
     );
   }
 
@@ -75,12 +73,11 @@ export class LockingResourceStore implements AtomicResourceStore {
     representation: Representation,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.lockedRepresentationRun(
+    return this.lockedWriteRepresentationRun(
       this.getLockIdentifier(identifier),
-      'write',
+      representation,
       async(expiringRepresentation): Promise<ChangeMap> =>
         this.source.setRepresentation(identifier, expiringRepresentation, conditions),
-      representation,
     );
   }
 
@@ -96,12 +93,11 @@ export class LockingResourceStore implements AtomicResourceStore {
     patch: Patch,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.lockedRepresentationRun(
+    return this.lockedWriteRepresentationRun(
       this.getLockIdentifier(identifier),
-      'write',
+      patch,
       async(expiringRepresentation): Promise<ChangeMap> =>
         this.source.modifyResource(identifier, expiringRepresentation, conditions),
-      patch,
     );
   }
 
@@ -116,36 +112,19 @@ export class LockingResourceStore implements AtomicResourceStore {
   }
 
   /**
-   * Acquires a lock for an operation involving a representation.
-   * For reads, the lock is only released when all resulting data has been read,
+   * Acquires a read lock that is only released when all data of the resulting representation has been read,
    * an error occurs, or the timeout has been triggered.
-   * For writes, the lock is held until the operation completes.
-   * In both cases the representation is adapted to reset the timer every time data is read.
+   * The representation is adapted to reset the timer every time data is read.
    *
    * In case the data of the resulting stream is not needed it should be closed to prevent a timeout error.
    *
    * @param identifier - Identifier that should be locked.
-   * @param lockType - Type of lock that should be acquired.
    * @param whileLocked - Function to be executed while the resource is locked.
-   * @param inputRepresentation - Representation to pass to a write operation.
    */
-  protected lockedRepresentationRun(
+  protected async lockedRepresentationRun(
     identifier: ResourceIdentifier,
-    lockType: 'read',
     whileLocked: () => Promise<Representation>,
-  ): Promise<Representation>;
-  protected lockedRepresentationRun<T>(
-    identifier: ResourceIdentifier,
-    lockType: 'write',
-    whileLocked: (representation: Representation) => Promise<T>,
-    inputRepresentation: Representation,
-  ): Promise<T>;
-  protected async lockedRepresentationRun<T>(
-    identifier: ResourceIdentifier,
-    lockType: 'read' | 'write',
-    whileLocked: (() => Promise<Representation>) | ((representation: Representation) => Promise<T>),
-    inputRepresentation?: Representation,
-  ): Promise<Representation | T> {
+  ): Promise<Representation> {
     // Create a new Promise that resolves to the resulting Representation
     // while only unlocking when the data has been read (or there's a timeout).
     // Note that we can't just return the result of `withReadLock` since that promise only
@@ -154,46 +133,54 @@ export class LockingResourceStore implements AtomicResourceStore {
     // See https://github.com/CommunitySolidServer/CommunitySolidServer/pull/536#discussion_r562467957
     return new Promise((resolve, reject): void => {
       let representation: Representation | undefined;
-      let operationActive = false;
-      const runWhileLocked = async(maintainLock: () => void): Promise<T | void> => {
-        operationActive = true;
-        try {
-          if (lockType === 'write') {
-            // The write overload requires an input representation.
-            representation = inputRepresentation!;
-            const expiringRepresentation = this.createExpiringRepresentation(representation, maintainLock);
-            return await (whileLocked as (representation: Representation) => Promise<T>)(expiringRepresentation);
-          }
-
-          representation = await (whileLocked as () => Promise<Representation>)();
-          resolve(this.createExpiringRepresentation(representation, maintainLock));
-
-          // Release the lock when an error occurs or the data finished streaming
-          await this.waitForStreamToEnd(representation.data);
-        } finally {
-          operationActive = false;
-        }
-      };
 
       // Make the resource time out to ensure that the lock is always released eventually.
-      const lock = lockType === 'read' ?
-          this.locks.withReadLock(identifier, runWhileLocked) :
-          this.locks.withWriteLock(identifier, runWhileLocked);
-      lock.then((result): void => {
-        if (lockType === 'write') {
-          resolve(result as T);
-        }
-      }).catch((error: unknown): void => {
-        // Destroy the source stream when an acquired lock expires while the operation is still active.
-        // This prevents a source store from continuing a write without the protection of the lock.
-        if (operationActive) {
-          representation?.data.destroy(error as Error);
-        }
+      this.locks.withReadLock(identifier, async(maintainLock): Promise<void> => {
+        representation = await whileLocked();
+        resolve(this.createExpiringRepresentation(representation, maintainLock));
 
-        // Let this function return an error in case something went wrong getting the data,
-        // or in case the lock expired before the operation completed.
+        // Release the lock when an error occurs or the data finished streaming
+        await this.waitForStreamToEnd(representation.data);
+      }).catch((error: unknown): void => {
+        // Destroy the source stream in case the lock times out
+        representation?.data.destroy(error as Error);
+
+        // Let this function return an error in case something went wrong getting the data
+        // or in case the timeout happens before `whileLocked` returned
         reject(error as Error);
       });
+    });
+  }
+
+  /**
+   * Acquires a write lock that is held until the operation completes.
+   * The input representation is adapted to reset the timer every time data is read.
+   *
+   * @param identifier - Identifier that should be locked.
+   * @param inputRepresentation - Representation to pass to the write operation.
+   * @param whileLocked - Function to be executed while the resource is locked.
+   */
+  protected async lockedWriteRepresentationRun<T extends Representation, TResult>(
+    identifier: ResourceIdentifier,
+    inputRepresentation: T,
+    whileLocked: (representation: T) => Promise<TResult>,
+  ): Promise<TResult> {
+    let operationActive = false;
+    return this.locks.withWriteLock(identifier, async(maintainLock): Promise<TResult> => {
+      operationActive = true;
+      try {
+        const expiringRepresentation = this.createExpiringRepresentation(inputRepresentation, maintainLock);
+        return await whileLocked(expiringRepresentation);
+      } finally {
+        operationActive = false;
+      }
+    }).catch((error: unknown): never => {
+      // Destroy the source stream when an acquired lock expires while the operation is still active.
+      // This prevents a source store from continuing a write without the protection of the lock.
+      if (operationActive) {
+        inputRepresentation.data.destroy(error as Error);
+      }
+      throw error;
     });
   }
 

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -52,6 +52,7 @@ export class LockingResourceStore implements AtomicResourceStore {
   ): Promise<Representation> {
     return this.lockedRepresentationRun(
       this.getLockIdentifier(identifier),
+      'read',
       async(): Promise<Representation> => this.source.getRepresentation(identifier, preferences, conditions),
     );
   }
@@ -61,10 +62,12 @@ export class LockingResourceStore implements AtomicResourceStore {
     representation: Representation,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.lockedRepresentationWrite(
+    return this.lockedRepresentationRun(
       this.getLockIdentifier(container),
+      'write',
+      async(expiringRepresentation): Promise<ChangeMap> =>
+        this.source.addResource(container, expiringRepresentation, conditions),
       representation,
-      async(): Promise<ChangeMap> => this.source.addResource(container, representation, conditions),
     );
   }
 
@@ -73,10 +76,12 @@ export class LockingResourceStore implements AtomicResourceStore {
     representation: Representation,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.lockedRepresentationWrite(
+    return this.lockedRepresentationRun(
       this.getLockIdentifier(identifier),
+      'write',
+      async(expiringRepresentation): Promise<ChangeMap> =>
+        this.source.setRepresentation(identifier, expiringRepresentation, conditions),
       representation,
-      async(): Promise<ChangeMap> => this.source.setRepresentation(identifier, representation, conditions),
     );
   }
 
@@ -92,10 +97,12 @@ export class LockingResourceStore implements AtomicResourceStore {
     patch: Patch,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.lockedRepresentationWrite(
+    return this.lockedRepresentationRun(
       this.getLockIdentifier(identifier),
+      'write',
+      async(expiringRepresentation): Promise<ChangeMap> =>
+        this.source.modifyResource(identifier, expiringRepresentation, conditions),
       patch,
-      async(): Promise<ChangeMap> => this.source.modifyResource(identifier, patch, conditions),
     );
   }
 
@@ -110,17 +117,36 @@ export class LockingResourceStore implements AtomicResourceStore {
   }
 
   /**
-   * Acquires a lock that is only released when all data of the resulting representation data has been read,
+   * Acquires a lock for an operation involving a representation.
+   * For reads, the lock is only released when all resulting data has been read,
    * an error occurs, or the timeout has been triggered.
-   * The resulting data stream will be adapted to reset the timer every time data is read.
+   * For writes, the lock is held until the operation completes.
+   * In both cases the representation is adapted to reset the timer every time data is read.
    *
    * In case the data of the resulting stream is not needed it should be closed to prevent a timeout error.
    *
    * @param identifier - Identifier that should be locked.
+   * @param lockType - Type of lock that should be acquired.
    * @param whileLocked - Function to be executed while the resource is locked.
+   * @param inputRepresentation - Representation to pass to a write operation.
    */
-  protected async lockedRepresentationRun(identifier: ResourceIdentifier, whileLocked: () => Promise<Representation>):
-  Promise<Representation> {
+  protected lockedRepresentationRun(
+    identifier: ResourceIdentifier,
+    lockType: 'read',
+    whileLocked: () => Promise<Representation>,
+  ): Promise<Representation>;
+  protected lockedRepresentationRun<T>(
+    identifier: ResourceIdentifier,
+    lockType: 'write',
+    whileLocked: (representation: Representation) => Promise<T>,
+    inputRepresentation: Representation,
+  ): Promise<T>;
+  protected async lockedRepresentationRun<T>(
+    identifier: ResourceIdentifier,
+    lockType: 'read' | 'write',
+    whileLocked: (() => Promise<Representation>) | ((representation: Representation) => Promise<T>),
+    inputRepresentation?: Representation,
+  ): Promise<Representation | T> {
     // Create a new Promise that resolves to the resulting Representation
     // while only unlocking when the data has been read (or there's a timeout).
     // Note that we can't just return the result of `withReadLock` since that promise only
@@ -128,83 +154,48 @@ export class LockingResourceStore implements AtomicResourceStore {
     // once we have the Representation.
     // See https://github.com/CommunitySolidServer/CommunitySolidServer/pull/536#discussion_r562467957
     return new Promise((resolve, reject): void => {
-      let representation: Representation;
+      let representation: Representation | undefined;
+      let operationActive = false;
+      const runWhileLocked = async(maintainLock: () => void): Promise<T | void> => {
+        operationActive = true;
+        try {
+          if (lockType === 'write') {
+            // The write overload requires an input representation.
+            representation = inputRepresentation!;
+            const expiringRepresentation = this.createExpiringRepresentation(representation, maintainLock);
+            return await (whileLocked as (representation: Representation) => Promise<T>)(expiringRepresentation);
+          }
+
+          representation = await (whileLocked as () => Promise<Representation>)();
+          resolve(this.createExpiringRepresentation(representation, maintainLock));
+
+          // Release the lock when an error occurs or the data finished streaming
+          await this.waitForStreamToEnd(representation.data);
+        } finally {
+          operationActive = false;
+        }
+      };
+
       // Make the resource time out to ensure that the lock is always released eventually.
-      this.locks.withReadLock(identifier, async(maintainLock): Promise<void> => {
-        representation = await whileLocked();
-        resolve(this.createExpiringRepresentation(representation, maintainLock));
-
-        // Release the lock when an error occurs or the data finished streaming
-        await this.waitForStreamToEnd(representation.data);
+      const lock = lockType === 'read' ?
+          this.locks.withReadLock(identifier, runWhileLocked) :
+          this.locks.withWriteLock(identifier, runWhileLocked);
+      lock.then((result): void => {
+        if (lockType === 'write') {
+          resolve(result as T);
+        }
       }).catch((error: unknown): void => {
-        // Destroy the source stream in case the lock times out
-        representation?.data.destroy(error as Error);
+        // Destroy the source stream when an acquired lock expires while the operation is still active.
+        // This prevents a source store from continuing a write without the protection of the lock.
+        if (operationActive) {
+          representation?.data.destroy(error as Error);
+        }
 
-        // Let this function return an error in case something went wrong getting the data
-        // or in case the timeout happens before `func` returned
+        // Let this function return an error in case something went wrong getting the data,
+        // or in case the lock expired before the operation completed.
         reject(error as Error);
       });
     });
-  }
-
-  /**
-   * Acquires a write lock and executes the given function,
-   * adapting the incoming data stream to reset the timer every time data is read.
-   * The stream is adapted in place, as source stores do not expect
-   * to receive a different representation than the one that was passed in.
-   * Should the lock expire before the function has finished, the data stream will be destroyed.
-   *
-   * @param identifier - Identifier that should be locked.
-   * @param representation - Representation whose data will be consumed while the resource is locked.
-   * @param whileLocked - Function to be executed while the resource is locked.
-   */
-  protected async lockedRepresentationWrite(
-    identifier: ResourceIdentifier,
-    representation: Representation,
-    whileLocked: () => Promise<ChangeMap>,
-  ): Promise<ChangeMap> {
-    const { data } = representation;
-    const ownReadDescriptor = Object.getOwnPropertyDescriptor(data, 'read');
-    // This method is restored by identity and invoked with an explicit receiver below.
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    const originalRead = data.read;
-    let writeActive = false;
-    function restoreRead(): void {
-      if (ownReadDescriptor) {
-        Object.defineProperty(data, 'read', ownReadDescriptor);
-      } else {
-        Reflect.deleteProperty(data, 'read');
-      }
-      writeActive = false;
-    }
-    try {
-      return await this.locks.withWriteLock(identifier, async(maintainLock): Promise<ChangeMap> => {
-        writeActive = true;
-        // Reset the timeout timer every time data is read while the lock is active
-        Object.defineProperty(data, 'read', {
-          configurable: ownReadDescriptor?.configurable ?? true,
-          enumerable: ownReadDescriptor?.enumerable ?? false,
-          writable: ownReadDescriptor?.writable ?? true,
-          value(this: Readable, size?: number): unknown {
-            maintainLock();
-            return originalRead.call(data, size);
-          },
-        });
-        try {
-          return await whileLocked();
-        } finally {
-          restoreRead();
-        }
-      });
-    } catch (error: unknown) {
-      // Destroy the data stream in case the lock expired while the data was still being consumed,
-      // otherwise the source store could keep on writing data without the protection of the lock.
-      if (writeActive) {
-        restoreRead();
-        data.destroy(error as Error);
-      }
-      throw error;
-    }
   }
 
   /**

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -173,7 +173,7 @@ export class LockingResourceStore implements AtomicResourceStore {
       if (ownReadDescriptor) {
         Object.defineProperty(data, 'read', ownReadDescriptor);
       } else {
-        Reflect.deleteProperty(data as any, 'read');
+        Reflect.deleteProperty(data, 'read');
       }
       writeActive = false;
     }

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -217,10 +217,7 @@ export class LockingResourceStore implements AtomicResourceStore {
 
     // Preserve the representation type and any additional properties, such as those on an N3 or SPARQL patch.
     const descriptors: PropertyDescriptorMap = Object.getOwnPropertyDescriptors(representation);
-    descriptors.data = {
-      ...descriptors.data,
-      value: data,
-    };
+    descriptors.data.value = data;
     return Object.create(Reflect.getPrototypeOf(representation), descriptors) as T;
   }
 

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -16,6 +16,7 @@ import type { ChangeMap, ResourceStore } from './ResourceStore';
  * Store that for every call acquires a lock before executing it on the requested resource,
  * and releases it afterwards.
  * In case the request returns a Representation the lock will only be released when the data stream is finished.
+ * Similarly, for write operations the lock will be maintained as long as the incoming data stream is being read.
  *
  * For auxiliary resources the lock will be applied to the subject resource.
  * The actual operation is still executed on the auxiliary resource.
@@ -60,8 +61,9 @@ export class LockingResourceStore implements AtomicResourceStore {
     representation: Representation,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.locks.withWriteLock(
+    return this.lockedRepresentationWrite(
       this.getLockIdentifier(container),
+      representation,
       async(): Promise<ChangeMap> => this.source.addResource(container, representation, conditions),
     );
   }
@@ -71,8 +73,9 @@ export class LockingResourceStore implements AtomicResourceStore {
     representation: Representation,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.locks.withWriteLock(
+    return this.lockedRepresentationWrite(
       this.getLockIdentifier(identifier),
+      representation,
       async(): Promise<ChangeMap> => this.source.setRepresentation(identifier, representation, conditions),
     );
   }
@@ -89,8 +92,9 @@ export class LockingResourceStore implements AtomicResourceStore {
     patch: Patch,
     conditions?: Conditions,
   ): Promise<ChangeMap> {
-    return this.locks.withWriteLock(
+    return this.lockedRepresentationWrite(
       this.getLockIdentifier(identifier),
+      patch,
       async(): Promise<ChangeMap> => this.source.modifyResource(identifier, patch, conditions),
     );
   }
@@ -141,6 +145,56 @@ export class LockingResourceStore implements AtomicResourceStore {
         reject(error as Error);
       });
     });
+  }
+
+  /**
+   * Acquires a write lock and executes the given function,
+   * adapting the incoming data stream to reset the timer every time data is read.
+   * The stream is adapted in place, as source stores do not expect
+   * to receive a different representation than the one that was passed in.
+   * Should the lock expire before the function has finished, the data stream will be destroyed.
+   *
+   * @param identifier - Identifier that should be locked.
+   * @param representation - Representation whose data will be consumed while the resource is locked.
+   * @param whileLocked - Function to be executed while the resource is locked.
+   */
+  protected async lockedRepresentationWrite(
+    identifier: ResourceIdentifier,
+    representation: Representation,
+    whileLocked: () => Promise<ChangeMap>,
+  ): Promise<ChangeMap> {
+    const { data } = representation;
+    // This method is restored by identity and invoked with an explicit receiver below.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalRead = data.read;
+    let writeActive = false;
+    function restoreRead(): void {
+      data.read = originalRead;
+      writeActive = false;
+    }
+    try {
+      return await this.locks.withWriteLock(identifier, async(maintainLock): Promise<ChangeMap> => {
+        writeActive = true;
+        // Reset the timeout timer every time data is read while the lock is active
+        data.read = (size?: number): unknown => {
+          maintainLock();
+          return originalRead.call(data, size);
+        };
+        try {
+          return await whileLocked();
+        } finally {
+          restoreRead();
+        }
+      });
+    } catch (error: unknown) {
+      // Destroy the data stream in case the lock expired while the data was still being consumed,
+      // otherwise the source store could keep on writing data without the protection of the lock.
+      if (writeActive) {
+        restoreRead();
+        data.destroy(error as Error);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -164,22 +164,32 @@ export class LockingResourceStore implements AtomicResourceStore {
     whileLocked: () => Promise<ChangeMap>,
   ): Promise<ChangeMap> {
     const { data } = representation;
+    const ownReadDescriptor = Object.getOwnPropertyDescriptor(data, 'read');
     // This method is restored by identity and invoked with an explicit receiver below.
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalRead = data.read;
     let writeActive = false;
     function restoreRead(): void {
-      data.read = originalRead;
+      if (ownReadDescriptor) {
+        Object.defineProperty(data, 'read', ownReadDescriptor);
+      } else {
+        Reflect.deleteProperty(data as any, 'read');
+      }
       writeActive = false;
     }
     try {
       return await this.locks.withWriteLock(identifier, async(maintainLock): Promise<ChangeMap> => {
         writeActive = true;
         // Reset the timeout timer every time data is read while the lock is active
-        data.read = (size?: number): unknown => {
-          maintainLock();
-          return originalRead.call(data, size);
-        };
+        Object.defineProperty(data, 'read', {
+          configurable: ownReadDescriptor?.configurable ?? true,
+          enumerable: ownReadDescriptor?.enumerable ?? false,
+          writable: ownReadDescriptor?.writable ?? true,
+          value(this: Readable, size?: number): unknown {
+            maintainLock();
+            return originalRead.call(data, size);
+          },
+        });
         try {
           return await whileLocked();
         } finally {

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -215,7 +215,8 @@ export class LockingResourceStore implements AtomicResourceStore {
       },
     }) as Readable;
 
-    // Preserve the representation type and any additional properties, such as those on an N3 or SPARQL patch.
+    // Write inputs can be specialized representations, such as N3 or SPARQL patches.
+    // Preserve their prototype and properties while replacing only the data stream used to maintain the lock.
     const descriptors: PropertyDescriptorMap = Object.getOwnPropertyDescriptors(representation);
     descriptors.data.value = data;
     return Object.create(Reflect.getPrototypeOf(representation), descriptors) as T;

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -1,6 +1,5 @@
 import type { Readable } from 'node:stream';
 import type { AuxiliaryIdentifierStrategy } from '../http/auxiliary/AuxiliaryIdentifierStrategy';
-import { BasicRepresentation } from '../http/representation/BasicRepresentation';
 import type { Patch } from '../http/representation/Patch';
 import type { Representation } from '../http/representation/Representation';
 import type { RepresentationPreferences } from '../http/representation/RepresentationPreferences';
@@ -204,7 +203,7 @@ export class LockingResourceStore implements AtomicResourceStore {
    * @param representation - The representation to wrap
    * @param maintainLock - Function to call to reset the timer.
    */
-  protected createExpiringRepresentation(representation: Representation, maintainLock: () => void): Representation {
+  protected createExpiringRepresentation<T extends Representation>(representation: T, maintainLock: () => void): T {
     const source = representation.data;
     // Spy on the source to maintain the lock upon reading.
     const data = Object.create(source, {
@@ -215,7 +214,14 @@ export class LockingResourceStore implements AtomicResourceStore {
         },
       },
     }) as Readable;
-    return new BasicRepresentation(data, representation.metadata, representation.binary);
+
+    // Preserve the representation type and any additional properties, such as those on an N3 or SPARQL patch.
+    const descriptors: PropertyDescriptorMap = Object.getOwnPropertyDescriptors(representation);
+    descriptors.data = {
+      ...descriptors.data,
+      value: data,
+    };
+    return Object.create(Reflect.getPrototypeOf(representation), descriptors) as T;
   }
 
   /**

--- a/test/integration/LockingResourceStore.test.ts
+++ b/test/integration/LockingResourceStore.test.ts
@@ -29,6 +29,7 @@ describe('A LockingResourceStore', (): void => {
   let source: ResourceStore;
   let getRepresentationSpy: jest.SpyInstance;
   let setRepresentationSpy: jest.SpyInstance;
+  let expiringRepresentation: Representation | undefined;
 
   beforeEach(async(): Promise<void> => {
     jest.clearAllMocks();
@@ -65,10 +66,13 @@ describe('A LockingResourceStore', (): void => {
     // Make sure something is in the store before we read from it in our tests.
     await source.setRepresentation({ path }, new BasicRepresentation([ 1, 2, 3 ], APPLICATION_OCTET_STREAM));
 
-    // Simulates a source store that consumes the incoming data before resolving
+    // Simulates a source store that waits for the incoming data to end before resolving
     setRepresentationSpy = jest.spyOn(source, 'setRepresentation');
     setRepresentationSpy.mockImplementation(
-      async(identifier, representation: Representation): Promise<any> => endOfStream(representation.data),
+      async(identifier, representation: Representation): Promise<any> => {
+        expiringRepresentation = representation;
+        return endOfStream(representation.data);
+      },
     );
   });
 
@@ -131,6 +135,7 @@ describe('A LockingResourceStore', (): void => {
     // Allow the lock to be acquired
     await flushPromises();
     expect(setRepresentationSpy).toHaveBeenCalledTimes(1);
+    expect(expiringRepresentation).toBeDefined();
 
     // Wait 1000ms without writing
     jest.advanceTimersByTime(1000);
@@ -157,16 +162,20 @@ describe('A LockingResourceStore', (): void => {
     // Allow the lock to be acquired
     await flushPromises();
     expect(setRepresentationSpy).toHaveBeenCalledTimes(1);
+    expect(expiringRepresentation).toBeDefined();
 
     // Wait 750ms and read
     jest.advanceTimersByTime(750);
     expect(representation.data.destroyed).toBe(false);
-    representation.data.read();
+    if (!expiringRepresentation) {
+      throw new Error('The source store did not receive an expiring representation.');
+    }
+    expiringRepresentation.data.read();
 
     // Wait 750ms and read
     jest.advanceTimersByTime(750);
     expect(representation.data.destroyed).toBe(false);
-    representation.data.read();
+    expiringRepresentation.data.read();
 
     // Wait 1000ms and watch the stream be destroyed
     jest.advanceTimersByTime(1000);

--- a/test/integration/LockingResourceStore.test.ts
+++ b/test/integration/LockingResourceStore.test.ts
@@ -14,7 +14,7 @@ import type { ExpiringReadWriteLocker } from '../../src/util/locking/ExpiringRea
 import { MemoryResourceLocker } from '../../src/util/locking/MemoryResourceLocker';
 import type { ReadWriteLocker } from '../../src/util/locking/ReadWriteLocker';
 import { WrappedExpiringReadWriteLocker } from '../../src/util/locking/WrappedExpiringReadWriteLocker';
-import { guardedStreamFrom } from '../../src/util/StreamUtil';
+import { endOfStream, guardedStreamFrom } from '../../src/util/StreamUtil';
 import { PIM, RDF } from '../../src/util/Vocabularies';
 import { SimpleSuffixStrategy } from '../util/SimpleSuffixStrategy';
 import { flushPromises } from '../util/Util';
@@ -28,6 +28,7 @@ describe('A LockingResourceStore', (): void => {
   let expiringLocker: ExpiringReadWriteLocker;
   let source: ResourceStore;
   let getRepresentationSpy: jest.SpyInstance;
+  let setRepresentationSpy: jest.SpyInstance;
 
   beforeEach(async(): Promise<void> => {
     jest.clearAllMocks();
@@ -63,6 +64,12 @@ describe('A LockingResourceStore', (): void => {
 
     // Make sure something is in the store before we read from it in our tests.
     await source.setRepresentation({ path }, new BasicRepresentation([ 1, 2, 3 ], APPLICATION_OCTET_STREAM));
+
+    // Simulates a source store that consumes the incoming data before resolving
+    setRepresentationSpy = jest.spyOn(source, 'setRepresentation');
+    setRepresentationSpy.mockImplementation(
+      async(identifier, representation: Representation): Promise<any> => endOfStream(representation.data),
+    );
   });
 
   it('destroys the stream when nothing is read after 1000ms.', async(): Promise<void> => {
@@ -109,5 +116,67 @@ describe('A LockingResourceStore', (): void => {
 
     // Verify the lock was acquired and released at the right time
     expect(getRepresentationSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroys the incoming stream when nothing is written after 1000ms.', async(): Promise<void> => {
+    const representation = new BasicRepresentation([ 1, 2, 3 ], APPLICATION_OCTET_STREAM);
+    const errorCallback = jest.fn();
+    representation.data.on('error', errorCallback);
+
+    // Catch the expected error so its rejection is handled before the timer fires
+    let error: unknown;
+    const promise = store.setRepresentation({ path }, representation).catch((err: unknown): void => {
+      error = err;
+    });
+    // Allow the lock to be acquired
+    await flushPromises();
+    expect(setRepresentationSpy).toHaveBeenCalledTimes(1);
+
+    // Wait 1000ms without writing
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    expect(representation.data.destroyed).toBe(true);
+    await promise;
+    expect(error).toEqual(new InternalServerError(`Lock expired after 1000ms on ${path}`));
+
+    // Verify a timeout error was thrown
+    expect(errorCallback).toHaveBeenCalledTimes(1);
+    expect(errorCallback).toHaveBeenLastCalledWith(new InternalServerError(`Lock expired after 1000ms on ${path}`));
+  });
+
+  it('destroys the incoming stream when pauses between writes exceed 1000ms.', async(): Promise<void> => {
+    const representation = new BasicRepresentation([ 1, 2, 3 ], APPLICATION_OCTET_STREAM);
+    const errorCallback = jest.fn();
+    representation.data.on('error', errorCallback);
+
+    // Catch the expected error so its rejection is handled before the timer fires
+    let error: unknown;
+    const promise = store.setRepresentation({ path }, representation).catch((err: unknown): void => {
+      error = err;
+    });
+    // Allow the lock to be acquired
+    await flushPromises();
+    expect(setRepresentationSpy).toHaveBeenCalledTimes(1);
+
+    // Wait 750ms and read
+    jest.advanceTimersByTime(750);
+    expect(representation.data.destroyed).toBe(false);
+    representation.data.read();
+
+    // Wait 750ms and read
+    jest.advanceTimersByTime(750);
+    expect(representation.data.destroyed).toBe(false);
+    representation.data.read();
+
+    // Wait 1000ms and watch the stream be destroyed
+    jest.advanceTimersByTime(1000);
+    await flushPromises();
+    expect(representation.data.destroyed).toBe(true);
+    await promise;
+    expect(error).toEqual(new InternalServerError(`Lock expired after 1000ms on ${path}`));
+
+    // Verify a timeout error was thrown
+    expect(errorCallback).toHaveBeenCalledTimes(1);
+    expect(errorCallback).toHaveBeenLastCalledWith(new InternalServerError(`Lock expired after 1000ms on ${path}`));
   });
 });

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -18,7 +18,7 @@ function emptyFn(): void {
 describe('A LockingResourceStore', (): void => {
   const auxiliaryId = { path: 'http://test.com/foo.dummy' };
   const subjectId = { path: 'http://test.com/foo' };
-  const data = { data: 'data!' } as any;
+  let data: Representation;
   let store: LockingResourceStore;
   let locker: jest.Mocked<ExpiringReadWriteLocker>;
   let source: ResourceStore;
@@ -32,6 +32,8 @@ describe('A LockingResourceStore', (): void => {
       order.push(name);
       return input;
     }
+
+    data = { data: guardedStreamFrom([ 1, 2, 3 ]) } as any;
 
     const readable = guardedStreamFrom([ 1, 2, 3 ]);
     const destroy = readable.destroy.bind(readable);
@@ -70,7 +72,12 @@ describe('A LockingResourceStore', (): void => {
       ): Promise<T> => {
         order.push('lock write');
         try {
-          return await whileLocked(emptyFn);
+          // Allows simulating a timeout event
+          const timeout = new Promise<never>((resolve, reject): any => timeoutTrigger.on('timeout', (): void => {
+            order.push('timeout');
+            reject(new Error('timeout'));
+          }));
+          return await Promise.race([ Promise.resolve(whileLocked(emptyFn)), timeout ]);
         } finally {
           order.push('unlock write');
         }
@@ -157,6 +164,83 @@ describe('A LockingResourceStore', (): void => {
     expect(source.modifyResource).toHaveBeenCalledTimes(2);
     expect(source.modifyResource).toHaveBeenLastCalledWith(auxiliaryId, data, undefined);
     expect(order).toEqual([ 'lock write', 'modifyResource', 'unlock write' ]);
+  });
+
+  it('resets the write lock expiration every time incoming data is read.', async(): Promise<void> => {
+    const originalRead = jest.spyOn(data.data, 'read');
+    const maintainLock = jest.fn();
+    locker.withWriteLock.mockImplementationOnce((async <T>(
+      identifier: ResourceIdentifier,
+      whileLocked: (maintain: () => void) => PromiseOrValue<T>,
+    ): Promise<T> => whileLocked(maintainLock)) satisfies ReadWriteLocker['withWriteLock'] as any);
+    jest.spyOn(source, 'setRepresentation').mockImplementation(
+      async(identifier: ResourceIdentifier, representation: Representation): Promise<any> => {
+        representation.data.read();
+        representation.data.read();
+        order.push('setRepresentation');
+      },
+    );
+
+    await store.setRepresentation(subjectId, data);
+    expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenLastCalledWith(subjectId, data, undefined);
+    expect(maintainLock).toHaveBeenCalledTimes(2);
+
+    // The original read function is restored once the write is finished
+    expect(data.data.read).toBe(originalRead);
+    data.data.read();
+    expect(maintainLock).toHaveBeenCalledTimes(2);
+  });
+
+  it('destroys the incoming data stream if the write lock expires.', async(): Promise<void> => {
+    const originalRead = jest.spyOn(data.data, 'read');
+    const destroy = jest.spyOn(data.data, 'destroy');
+    jest.spyOn(source, 'setRepresentation').mockImplementation((): any => {
+      order.push('useless set');
+      // This will never resolve
+      return new Promise(emptyFn);
+    });
+
+    const prom = store.setRepresentation(subjectId, data);
+
+    timeoutTrigger.emit('timeout');
+
+    await expect(prom).rejects.toThrow('timeout');
+    expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenLastCalledWith(new Error('timeout'));
+    expect(data.data.read).toBe(originalRead);
+    expect(order).toEqual([ 'lock write', 'useless set', 'timeout', 'unlock write' ]);
+  });
+
+  it('does not destroy the incoming data stream if the write itself errors.', async(): Promise<void> => {
+    const destroy = jest.spyOn(data.data, 'destroy');
+    jest.spyOn(source, 'setRepresentation').mockImplementation((): any => {
+      order.push('bad set');
+      throw new Error('dummy');
+    });
+
+    await expect(store.setRepresentation(subjectId, data)).rejects.toThrow('dummy');
+    expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(0);
+    expect(order).toEqual([ 'lock write', 'bad set', 'unlock write' ]);
+  });
+
+  it('does not destroy the incoming data stream if the write lock can not be acquired.', async(): Promise<void> => {
+    const destroy = jest.spyOn(data.data, 'destroy');
+    locker.withWriteLock.mockImplementationOnce(async(): Promise<never> => {
+      order.push('failed lock');
+      throw new Error('lock error');
+    });
+
+    await expect(store.setRepresentation(subjectId, data)).rejects.toThrow('lock error');
+    expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(0);
+    expect(destroy).toHaveBeenCalledTimes(0);
+    expect(order).toEqual([ 'failed lock' ]);
   });
 
   it('releases the lock if an error was thrown.', async(): Promise<void> => {

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -103,7 +103,7 @@ describe('A LockingResourceStore', (): void => {
     expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
     expect(locker.withWriteLock.mock.calls[0][0]).toEqual(subjectId);
     expect(source.addResource).toHaveBeenCalledTimes(1);
-    expect(source.addResource).toHaveBeenLastCalledWith(subjectId, data, undefined);
+    expect(source.addResource).toHaveBeenLastCalledWith(subjectId, expect.any(Object), undefined);
     expect(order).toEqual([ 'lock write', 'addResource', 'unlock write' ]);
 
     order = [];
@@ -111,7 +111,7 @@ describe('A LockingResourceStore', (): void => {
     expect(locker.withWriteLock).toHaveBeenCalledTimes(2);
     expect(locker.withWriteLock.mock.calls[1][0]).toEqual(subjectId);
     expect(source.addResource).toHaveBeenCalledTimes(2);
-    expect(source.addResource).toHaveBeenLastCalledWith(auxiliaryId, data, undefined);
+    expect(source.addResource).toHaveBeenLastCalledWith(auxiliaryId, expect.any(Object), undefined);
     expect(order).toEqual([ 'lock write', 'addResource', 'unlock write' ]);
   });
 
@@ -120,7 +120,7 @@ describe('A LockingResourceStore', (): void => {
     expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
     expect(locker.withWriteLock.mock.calls[0][0]).toEqual(subjectId);
     expect(source.setRepresentation).toHaveBeenCalledTimes(1);
-    expect(source.setRepresentation).toHaveBeenLastCalledWith(subjectId, data, undefined);
+    expect(source.setRepresentation).toHaveBeenLastCalledWith(subjectId, expect.any(Object), undefined);
     expect(order).toEqual([ 'lock write', 'setRepresentation', 'unlock write' ]);
 
     order = [];
@@ -128,7 +128,7 @@ describe('A LockingResourceStore', (): void => {
     expect(locker.withWriteLock).toHaveBeenCalledTimes(2);
     expect(locker.withWriteLock.mock.calls[1][0]).toEqual(subjectId);
     expect(source.setRepresentation).toHaveBeenCalledTimes(2);
-    expect(source.setRepresentation).toHaveBeenLastCalledWith(auxiliaryId, data, undefined);
+    expect(source.setRepresentation).toHaveBeenLastCalledWith(auxiliaryId, expect.any(Object), undefined);
     expect(order).toEqual([ 'lock write', 'setRepresentation', 'unlock write' ]);
   });
 
@@ -154,7 +154,7 @@ describe('A LockingResourceStore', (): void => {
     expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
     expect(locker.withWriteLock.mock.calls[0][0]).toEqual(subjectId);
     expect(source.modifyResource).toHaveBeenCalledTimes(1);
-    expect(source.modifyResource).toHaveBeenLastCalledWith(subjectId, data, undefined);
+    expect(source.modifyResource).toHaveBeenLastCalledWith(subjectId, expect.any(Object), undefined);
     expect(order).toEqual([ 'lock write', 'modifyResource', 'unlock write' ]);
 
     order = [];
@@ -162,7 +162,7 @@ describe('A LockingResourceStore', (): void => {
     expect(locker.withWriteLock).toHaveBeenCalledTimes(2);
     expect(locker.withWriteLock.mock.calls[1][0]).toEqual(subjectId);
     expect(source.modifyResource).toHaveBeenCalledTimes(2);
-    expect(source.modifyResource).toHaveBeenLastCalledWith(auxiliaryId, data, undefined);
+    expect(source.modifyResource).toHaveBeenLastCalledWith(auxiliaryId, expect.any(Object), undefined);
     expect(order).toEqual([ 'lock write', 'modifyResource', 'unlock write' ]);
   });
 
@@ -184,10 +184,13 @@ describe('A LockingResourceStore', (): void => {
     await store.setRepresentation(subjectId, data);
     expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
     expect(source.setRepresentation).toHaveBeenCalledTimes(1);
-    expect(source.setRepresentation).toHaveBeenLastCalledWith(subjectId, data, undefined);
+    const expiringRepresentation = jest.mocked(source.setRepresentation).mock.calls[0][1];
+    expect(source.setRepresentation).toHaveBeenLastCalledWith(subjectId, expiringRepresentation, undefined);
+    expect(expiringRepresentation).not.toBe(data);
+    expect(expiringRepresentation.data).not.toBe(data.data);
     expect(maintainLock).toHaveBeenCalledTimes(2);
 
-    // The original read function is restored once the write is finished
+    // The original stream is not adapted
     expect(data.data.read).toBe(originalRead);
     data.data.read();
     expect(maintainLock).toHaveBeenCalledTimes(2);

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import type { AuxiliaryIdentifierStrategy } from '../../../src/http/auxiliary/AuxiliaryIdentifierStrategy';
-import type { Patch } from '../../../src/http/representation/Patch';
+import type { N3Patch } from '../../../src/http/representation/N3Patch';
 import type { Representation } from '../../../src/http/representation/Representation';
 import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
 import { LockingResourceStore } from '../../../src/storage/LockingResourceStore';
@@ -150,15 +150,28 @@ describe('A LockingResourceStore', (): void => {
   });
 
   it('acquires a lock on the resource when modifying its representation.', async(): Promise<void> => {
-    await store.modifyResource(subjectId, data as Patch);
+    const patch: N3Patch = {
+      ...data,
+      deletes: [],
+      inserts: [],
+      conditions: [],
+    };
+
+    await store.modifyResource(subjectId, patch);
     expect(locker.withWriteLock).toHaveBeenCalledTimes(1);
     expect(locker.withWriteLock.mock.calls[0][0]).toEqual(subjectId);
     expect(source.modifyResource).toHaveBeenCalledTimes(1);
-    expect(source.modifyResource).toHaveBeenLastCalledWith(subjectId, expect.any(Object), undefined);
+    const expiringPatch = jest.mocked(source.modifyResource).mock.calls[0][1] as N3Patch;
+    expect(source.modifyResource).toHaveBeenLastCalledWith(subjectId, expiringPatch, undefined);
+    expect(expiringPatch).not.toBe(patch);
+    expect(expiringPatch.data).not.toBe(patch.data);
+    expect(expiringPatch.deletes).toBe(patch.deletes);
+    expect(expiringPatch.inserts).toBe(patch.inserts);
+    expect(expiringPatch.conditions).toBe(patch.conditions);
     expect(order).toEqual([ 'lock write', 'modifyResource', 'unlock write' ]);
 
     order = [];
-    await expect(store.modifyResource(auxiliaryId, data as Patch)).resolves.toBeUndefined();
+    await expect(store.modifyResource(auxiliaryId, patch)).resolves.toBeUndefined();
     expect(locker.withWriteLock).toHaveBeenCalledTimes(2);
     expect(locker.withWriteLock.mock.calls[1][0]).toEqual(subjectId);
     expect(source.modifyResource).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
#### 📁 Related issues

Closes #2215.

#### ✍️ Description

`LockingResourceStore` already renews expiring locks while response streams are read. This change applies the same
protection to incoming representations used by `addResource`, `setRepresentation`, and `modifyResource`.

The write helper adapts the existing stream in place so representation and patch-specific properties are preserved.
Every read renews the held write lock. If that lock expires before the source call completes, the helper first restores
the exact original `read` function and then destroys the stream, preventing the source store from continuing an
unprotected write.

Lock-acquisition failures and source write errors do not destroy the request stream. The original `read` function is
restored after both successful and failed writes.

Validation:

- Build and affected-file ESLint passed on current `main`.
- Focused unit and integration suites: 2 suites / 21 tests passed after rebase.
- Full unit suite: 358 suites / 2,379 tests passed with 100% source coverage.
- Full integration suite: 28 suites / 808 tests passed; 3 suites / 23 tests skipped.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label - _**this is a patch, I do not have permission to apply labels**_
    * `semver.patch`: Backwards-compatible bug fix.
* [x] the correct branch is targeted: patch updates target `main`.
* [x] `RELEASE_NOTES.md` does not need an update for this internal bug fix.
* [x] No user-facing documentation changes are required.
