### PR TITLE
feat(identity): support dedicated storage for OIDC clients

### DIFF
--- a/config/identity/handler/base/adapter-factory.json
+++ b/config/identity/handler/base/adapter-factory.json
@@ -12,17 +12,18 @@
         "converter": { "@id": "urn:solid-server:default:RepresentationConverter" },
         "source": {
           "@type": "ExpiringAdapterFactory",
-          "storage": {
-            "@type": "WrappedExpiringStorage",
-            "source": {
-              "@type": "ContainerPathStorage",
-              "relativePath": "/idp/adapter/",
-              "source": {
-                "@id": "urn:solid-server:default:KeyValueStorage"
-              }
-            }
-          }
+          "storage": { "@id": "urn:solid-server:default:IdpAdapterStorage" },
+          "clientStorage": { "@id": "urn:solid-server:default:IdpAdapterStorage" }
         }
+      }
+    },
+    {
+      "@id": "urn:solid-server:default:IdpAdapterStorage",
+      "@type": "WrappedExpiringStorage",
+      "source": {
+        "@type": "ContainerPathStorage",
+        "relativePath": "/idp/adapter/",
+        "source": { "@id": "urn:solid-server:default:KeyValueStorage" }
       }
     }
   ]

--- a/src/identity/storage/ExpiringAdapterFactory.ts
+++ b/src/identity/storage/ExpiringAdapterFactory.ts
@@ -111,12 +111,17 @@ export class ExpiringAdapter implements Adapter {
  */
 export class ExpiringAdapterFactory implements AdapterFactory {
   private readonly storage: ExpiringStorage<string, unknown>;
+  private readonly clientStorage: ExpiringStorage<string, unknown>;
 
-  public constructor(storage: ExpiringStorage<string, unknown>) {
+  public constructor(
+    storage: ExpiringStorage<string, unknown>,
+    clientStorage: ExpiringStorage<string, unknown> = storage,
+  ) {
     this.storage = storage;
+    this.clientStorage = clientStorage;
   }
 
   public createStorageAdapter(name: string): ExpiringAdapter {
-    return new ExpiringAdapter(name, this.storage);
+    return new ExpiringAdapter(name, name === 'Client' ? this.clientStorage : this.storage);
   }
 }

--- a/test/unit/identity/storage/ExpiringAdapterFactory.test.ts
+++ b/test/unit/identity/storage/ExpiringAdapterFactory.test.ts
@@ -6,28 +6,46 @@ import type { AdapterPayload } from '../../../../templates/types/oidc-provider';
 // Use fixed dates
 jest.useFakeTimers();
 
+function createStorage(): ExpiringStorage<string, unknown> {
+  const map = new Map<string, any>();
+  return {
+    get: jest.fn().mockImplementation((key: string): any => map.get(key)),
+    set: jest.fn().mockImplementation((key: string, value: any): any => map.set(key, value)),
+    delete: jest.fn().mockImplementation((key: string): any => map.delete(key)),
+  } as any;
+}
+
 describe('An ExpiringAdapterFactory', (): void => {
   const name = 'nnaammee';
   const id = 'http://alice.test.com/card#me';
   const grantId = 'grant123456';
   let payload: AdapterPayload;
   let storage: ExpiringStorage<string, unknown>;
+  let clientStorage: ExpiringStorage<string, unknown>;
   let adapter: ExpiringAdapter;
   let factory: ExpiringAdapterFactory;
   const expiresIn = 333 * 1000;
 
   beforeEach(async(): Promise<void> => {
     payload = { data: 'data!' };
-
-    const map = new Map<string, any>();
-    storage = {
-      get: jest.fn().mockImplementation((key: string): any => map.get(key)),
-      set: jest.fn().mockImplementation((key: string, value: any): any => map.set(key, value)),
-      delete: jest.fn().mockImplementation((key: string): any => map.delete(key)),
-    } as any;
-
-    factory = new ExpiringAdapterFactory(storage);
+    storage = createStorage();
+    clientStorage = createStorage();
+    factory = new ExpiringAdapterFactory(storage, clientStorage);
     adapter = factory.createStorageAdapter(name);
+  });
+
+  it('uses the client storage for Client adapters.', async(): Promise<void> => {
+    const clientAdapter = factory.createStorageAdapter('Client');
+    await expect(clientAdapter.upsert(id, payload)).resolves.toBeUndefined();
+    expect(clientStorage.set).toHaveBeenCalledWith(expect.anything(), payload, undefined);
+    expect(storage.set).not.toHaveBeenCalled();
+    await expect(clientAdapter.find(id)).resolves.toBe(payload);
+  });
+
+  it('uses the default storage for Client adapters if none is configured.', async(): Promise<void> => {
+    const clientAdapter = new ExpiringAdapterFactory(storage).createStorageAdapter('Client');
+    await expect(clientAdapter.upsert(id, payload)).resolves.toBeUndefined();
+    expect(storage.set).toHaveBeenCalledWith(expect.anything(), payload, undefined);
   });
 
   it('can find payload by id.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Closes #2216.

#### ✍️ Description

Dynamic OIDC client registrations are long-lived, while most other oidc-provider state is short-lived. This change lets
deployments persist only the `Client` model while keeping sessions, grants, tokens, authorization codes, and replay state
in a faster ephemeral store.

`ExpiringAdapterFactory` now accepts an optional `clientStorage` and selects it only when oidc-provider requests its
`Client` adapter. The argument defaults to the existing storage, so direct consumers retain their current behavior.

The default configuration passes the same named `IdpAdapterStorage` component for both dependencies, preserving current
runtime behavior while making the storage reusable and independently configurable by custom deployments.

Validation:

- Build, source/test TypeScript, component generation, and full lint passed on current `main`.
- Full unit suite: 358 suites / 2,385 tests passed with 100% source coverage.
- Identity integration suite: 1 suite / 34 tests passed for both in-memory and on-disk configurations.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * `semver.minor`: Backwards-compatible configuration capability.
* [x] The change is backwards-compatible and targets the current `main` release line.
* [x] `RELEASE_NOTES.md` does not need an update for this narrowly scoped configuration hook.
* [x] Existing configuration behavior is unchanged; no user-facing documentation update is required.
