### PR TITLE
feat: add a maximum hold duration to expiring locks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Community Solid Server release notes
 
+## v7.3.0
+
+### New features
+
+- Expiring read/write lockers can enforce an optional maximum hold duration,
+  independent of activity-based lock renewals.
+
+### Configuration changes
+
+- There is a new opt-in `util/resource-locker/file-capped.json` configuration that caps file-based locks at one hour.
+  Existing resource locker configurations remain uncapped.
+
 ## v7.0.0
 
 ### New features

--- a/config/util/README.md
+++ b/config/util/README.md
@@ -52,6 +52,7 @@ Which locking mechanism to use to for example prevent 2 write simultaneous write
 
 * *debug-void*: No locking mechanism, does not prevent simultaneous read/writes.
 * *file*: Uses a file-system based locking mechanism (process-safe/thread-safe).
+* *file-capped*: Uses the file-system locker with a one-hour maximum hold duration.
 * *memory*: Uses an in-memory locking mechanism.
 * *redis*: Uses a Redis store for locking that supports threadsafe read-write locking (process-safe/thread-safe).
 

--- a/config/util/resource-locker/file-capped.json
+++ b/config/util/resource-locker/file-capped.json
@@ -1,45 +1,14 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/util/resource-locker/file.json"
+  ],
   "@graph": [
     {
-      "comment": [
-        "Allows multiple simultaneous read operations. Locks are stored on filesystem. This locker is threadsafe.",
-        "Locks expire after inactivity, or 1 hour after acquisition, so continually renewed locks can not block a resource forever."
-      ],
+      "comment": "Caps file-based locks at 1 hour so continually renewed locks can not block a resource forever.",
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",
-      "locker": {
-        "@type": "PartialReadWriteLocker",
-        "locker": {
-          "@id": "urn:solid-server:default:FileSystemResourceLocker",
-          "@type": "FileSystemResourceLocker",
-          "args_rootFilePath": { "@id": "urn:solid-server:default:variable:rootFilePath" }
-        }
-      },
-      "expiration": 6000,
       "maxHoldDuration": 3600000
-    },
-    {
-      "@id": "urn:solid-server:default:CleanupInitializer",
-      "@type": "SequenceHandler",
-      "handlers": [
-        {
-          "comment": "Makes sure the FileSystemResourceLocker starts with a clean slate when the application is started.",
-          "@type": "InitializableHandler",
-          "initializable": { "@id": "urn:solid-server:default:FileSystemResourceLocker" }
-        }
-      ]
-    },
-    {
-      "@id": "urn:solid-server:default:CleanupFinalizer",
-      "@type": "SequenceHandler",
-      "handlers": [
-        {
-          "comment": "Makes sure the lock folder is removed when the application stops.",
-          "@type": "FinalizableHandler",
-          "finalizable": { "@id": "urn:solid-server:default:FileSystemResourceLocker" }
-        }
-      ]
     }
   ]
 }

--- a/config/util/resource-locker/file-capped.json
+++ b/config/util/resource-locker/file-capped.json
@@ -3,11 +3,8 @@
   "@graph": [
     {
       "comment": [
-        "Production/perf variant of resource-locker/file.json.",
-        "Identical to the file locker but adds an absolute maxHoldDuration cap of 1 hour (3600000ms).",
-        "This prevents a stream of trickle-readers from renewing a read lock forever and starving a waiting writer.",
-        "1 hour sits far above any realistic single-resource transfer, so it never aborts a legitimate slow",
-        "upload/download (activity renewals also keep write locks alive during slow uploads)."
+        "Allows multiple simultaneous read operations. Locks are stored on filesystem. This locker is threadsafe.",
+        "Locks expire after inactivity, or 1 hour after acquisition, so continually renewed locks can not block a resource forever."
       ],
       "@id": "urn:solid-server:default:ResourceLocker",
       "@type": "WrappedExpiringReadWriteLocker",

--- a/config/util/resource-locker/file-capped.json
+++ b/config/util/resource-locker/file-capped.json
@@ -1,0 +1,48 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": [
+        "Production/perf variant of resource-locker/file.json.",
+        "Identical to the file locker but adds an absolute maxHoldDuration cap of 1 hour (3600000ms).",
+        "This prevents a stream of trickle-readers from renewing a read lock forever and starving a waiting writer.",
+        "1 hour sits far above any realistic single-resource transfer, so it never aborts a legitimate slow",
+        "upload/download (activity renewals also keep write locks alive during slow uploads)."
+      ],
+      "@id": "urn:solid-server:default:ResourceLocker",
+      "@type": "WrappedExpiringReadWriteLocker",
+      "locker": {
+        "@type": "PartialReadWriteLocker",
+        "locker": {
+          "@id": "urn:solid-server:default:FileSystemResourceLocker",
+          "@type": "FileSystemResourceLocker",
+          "args_rootFilePath": { "@id": "urn:solid-server:default:variable:rootFilePath" }
+        }
+      },
+      "expiration": 6000,
+      "maxHoldDuration": 3600000
+    },
+    {
+      "@id": "urn:solid-server:default:CleanupInitializer",
+      "@type": "SequenceHandler",
+      "handlers": [
+        {
+          "comment": "Makes sure the FileSystemResourceLocker starts with a clean slate when the application is started.",
+          "@type": "InitializableHandler",
+          "initializable": { "@id": "urn:solid-server:default:FileSystemResourceLocker" }
+        }
+      ]
+    },
+    {
+      "@id": "urn:solid-server:default:CleanupFinalizer",
+      "@type": "SequenceHandler",
+      "handlers": [
+        {
+          "comment": "Makes sure the lock folder is removed when the application stops.",
+          "@type": "FinalizableHandler",
+          "finalizable": { "@id": "urn:solid-server:default:FileSystemResourceLocker" }
+        }
+      ]
+    }
+  ]
+}

--- a/src/util/locking/WrappedExpiringReadWriteLocker.ts
+++ b/src/util/locking/WrappedExpiringReadWriteLocker.ts
@@ -52,16 +52,13 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
     identifier: ResourceIdentifier,
     whileLocked: (maintainLock: () => void) => PromiseOrValue<T>,
   ): Promise<T> {
-    let timer: Timeout | undefined;
+    let timer: Timeout;
     let maxTimer: Timeout | undefined;
     let createTimeout: () => Timeout;
     let active = true;
 
     function clearTimers(): void {
-      if (timer) {
-        clearTimeout(timer);
-        timer = undefined;
-      }
+      clearTimeout(timer);
       if (maxTimer) {
         clearTimeout(maxTimer);
         maxTimer = undefined;
@@ -72,12 +69,10 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
     const timerPromise = new Promise<never>((resolve, reject): void => {
       // Starts the timer that will cause this promise to error after a given time
       createTimeout = (): Timeout => setTimeout((): void => {
-        if (active) {
-          active = false;
-          clearTimers();
-          this.logger.error(`Lock expired after ${this.expiration}ms on ${identifier.path}`);
-          reject(new InternalServerError(`Lock expired after ${this.expiration}ms on ${identifier.path}`));
-        }
+        active = false;
+        clearTimers();
+        this.logger.error(`Lock expired after ${this.expiration}ms on ${identifier.path}`);
+        reject(new InternalServerError(`Lock expired after ${this.expiration}ms on ${identifier.path}`));
       }, this.expiration);
 
       timer = createTimeout();
@@ -85,16 +80,14 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       // Absolute deadline on the total hold time, which renewals do not extend
       if (this.maxHoldDuration > 0) {
         maxTimer = setTimeout((): void => {
-          if (active) {
-            active = false;
-            clearTimers();
-            this.logger.warn(
-              `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
-            );
-            reject(new InternalServerError(
-              `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
-            ));
-          }
+          active = false;
+          clearTimers();
+          this.logger.warn(
+            `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
+          );
+          reject(new InternalServerError(
+            `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
+          ));
         }, this.maxHoldDuration);
       }
     });
@@ -105,9 +98,7 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
         return;
       }
       this.logger.verbose(`Renewed expiring lock on ${identifier.path}`);
-      if (timer) {
-        clearTimeout(timer);
-      }
+      clearTimeout(timer);
       timer = createTimeout();
     };
 

--- a/src/util/locking/WrappedExpiringReadWriteLocker.ts
+++ b/src/util/locking/WrappedExpiringReadWriteLocker.ts
@@ -19,13 +19,9 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
   /**
    * @param locker - Instance of ResourceLocker to use for acquiring a lock.
    * @param expiration - Time in ms after which the lock expires due to inactivity.
-   * @param maxHoldDuration - Absolute time in ms a lock may be held in total, counted from acquisition and
-   *                          independent of activity renewals. Once exceeded the lock expires even if it is
-   *                          still being renewed, which prevents a stream of trickle-readers from holding a
-   *                          read lock forever and starving a waiting writer. A value of `0` (the default)
-   *                          disables the cap, keeping the renewal behaviour unlimited. Because activity
-   *                          renewals now also keep write locks alive during slow uploads/downloads, this
-   *                          value must sit well above any realistic single-resource transfer.
+   * @param maxHoldDuration - Maximum total time in ms a lock can be held, independent of activity renewals,
+   *                          to prevent continually renewed locks from blocking a resource forever.
+   *                          `0`, the default, disables the cap.
    */
   public constructor(locker: ReadWriteLocker, expiration: number, maxHoldDuration = 0) {
     this.locker = locker;
@@ -70,8 +66,7 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
 
       timer = createTimeout();
 
-      // Absolute deadline on the total hold time, independent of the renewable idle timer above.
-      // Never renewed, so a stream of renewals can not extend the lock past this cap.
+      // Absolute deadline on the total hold time, which renewals do not extend
       if (this.maxHoldDuration > 0) {
         maxTimer = setTimeout((): void => {
           this.logger.warn(`Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`);
@@ -82,7 +77,7 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       }
     });
 
-    // Restarts the idle timer, but never affects the absolute maximum-hold deadline
+    // Restarts the timer
     const renewTimer = (): void => {
       this.logger.verbose(`Renewed expiring lock on ${identifier.path}`);
       clearTimeout(timer);

--- a/src/util/locking/WrappedExpiringReadWriteLocker.ts
+++ b/src/util/locking/WrappedExpiringReadWriteLocker.ts
@@ -52,16 +52,32 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
     identifier: ResourceIdentifier,
     whileLocked: (maintainLock: () => void) => PromiseOrValue<T>,
   ): Promise<T> {
-    let timer: Timeout;
+    let timer: Timeout | undefined;
     let maxTimer: Timeout | undefined;
     let createTimeout: () => Timeout;
+    let active = true;
+
+    function clearTimers(): void {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      if (maxTimer) {
+        clearTimeout(maxTimer);
+        maxTimer = undefined;
+      }
+    }
 
     // Promise that throws an error when the timer finishes
     const timerPromise = new Promise<never>((resolve, reject): void => {
       // Starts the timer that will cause this promise to error after a given time
       createTimeout = (): Timeout => setTimeout((): void => {
-        this.logger.error(`Lock expired after ${this.expiration}ms on ${identifier.path}`);
-        reject(new InternalServerError(`Lock expired after ${this.expiration}ms on ${identifier.path}`));
+        if (active) {
+          active = false;
+          clearTimers();
+          this.logger.error(`Lock expired after ${this.expiration}ms on ${identifier.path}`);
+          reject(new InternalServerError(`Lock expired after ${this.expiration}ms on ${identifier.path}`));
+        }
       }, this.expiration);
 
       timer = createTimeout();
@@ -69,18 +85,29 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       // Absolute deadline on the total hold time, which renewals do not extend
       if (this.maxHoldDuration > 0) {
         maxTimer = setTimeout((): void => {
-          this.logger.warn(`Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`);
-          reject(new InternalServerError(
-            `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
-          ));
+          if (active) {
+            active = false;
+            clearTimers();
+            this.logger.warn(
+              `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
+            );
+            reject(new InternalServerError(
+              `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
+            ));
+          }
         }, this.maxHoldDuration);
       }
     });
 
     // Restarts the timer
     const renewTimer = (): void => {
+      if (!active) {
+        return;
+      }
       this.logger.verbose(`Renewed expiring lock on ${identifier.path}`);
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       timer = createTimeout();
     };
 
@@ -89,10 +116,8 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       try {
         return await whileLocked(renewTimer);
       } finally {
-        clearTimeout(timer);
-        if (maxTimer) {
-          clearTimeout(maxTimer);
-        }
+        active = false;
+        clearTimers();
       }
     }
 

--- a/src/util/locking/WrappedExpiringReadWriteLocker.ts
+++ b/src/util/locking/WrappedExpiringReadWriteLocker.ts
@@ -58,6 +58,7 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
     let active = true;
 
     function clearTimers(): void {
+      active = false;
       clearTimeout(timer);
       if (maxTimer) {
         clearTimeout(maxTimer);
@@ -67,12 +68,20 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
 
     // Promise that throws an error when the timer finishes
     const timerPromise = new Promise<never>((resolve, reject): void => {
+      const logger = this.logger;
+
+      function rejectAfterTimeout(message: string, logLevel: 'error' | 'warn'): void {
+        clearTimers();
+        logger[logLevel](message);
+        reject(new InternalServerError(message));
+      }
+
       // Starts the timer that will cause this promise to error after a given time
       createTimeout = (): Timeout => setTimeout((): void => {
-        active = false;
-        clearTimers();
-        this.logger.error(`Lock expired after ${this.expiration}ms on ${identifier.path}`);
-        reject(new InternalServerError(`Lock expired after ${this.expiration}ms on ${identifier.path}`));
+        rejectAfterTimeout(
+          `Lock expired after ${this.expiration}ms on ${identifier.path}`,
+          'error',
+        );
       }, this.expiration);
 
       timer = createTimeout();
@@ -80,14 +89,10 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       // Absolute deadline on the total hold time, which renewals do not extend
       if (this.maxHoldDuration > 0) {
         maxTimer = setTimeout((): void => {
-          active = false;
-          clearTimers();
-          this.logger.warn(
+          rejectAfterTimeout(
             `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
+            'warn',
           );
-          reject(new InternalServerError(
-            `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
-          ));
         }, this.maxHoldDuration);
       }
     });
@@ -107,7 +112,6 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       try {
         return await whileLocked(renewTimer);
       } finally {
-        active = false;
         clearTimers();
       }
     }

--- a/src/util/locking/WrappedExpiringReadWriteLocker.ts
+++ b/src/util/locking/WrappedExpiringReadWriteLocker.ts
@@ -14,14 +14,23 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
 
   protected readonly locker: ReadWriteLocker;
   protected readonly expiration: number;
+  protected readonly maxHoldDuration: number;
 
   /**
    * @param locker - Instance of ResourceLocker to use for acquiring a lock.
-   * @param expiration - Time in ms after which the lock expires.
+   * @param expiration - Time in ms after which the lock expires due to inactivity.
+   * @param maxHoldDuration - Absolute time in ms a lock may be held in total, counted from acquisition and
+   *                          independent of activity renewals. Once exceeded the lock expires even if it is
+   *                          still being renewed, which prevents a stream of trickle-readers from holding a
+   *                          read lock forever and starving a waiting writer. A value of `0` (the default)
+   *                          disables the cap, keeping the renewal behaviour unlimited. Because activity
+   *                          renewals now also keep write locks alive during slow uploads/downloads, this
+   *                          value must sit well above any realistic single-resource transfer.
    */
-  public constructor(locker: ReadWriteLocker, expiration: number) {
+  public constructor(locker: ReadWriteLocker, expiration: number, maxHoldDuration = 0) {
     this.locker = locker;
     this.expiration = expiration;
+    this.maxHoldDuration = maxHoldDuration;
   }
 
   public async withReadLock<T>(
@@ -48,6 +57,7 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
     whileLocked: (maintainLock: () => void) => PromiseOrValue<T>,
   ): Promise<T> {
     let timer: Timeout;
+    let maxTimer: Timeout | undefined;
     let createTimeout: () => Timeout;
 
     // Promise that throws an error when the timer finishes
@@ -59,21 +69,35 @@ export class WrappedExpiringReadWriteLocker implements ExpiringReadWriteLocker {
       }, this.expiration);
 
       timer = createTimeout();
+
+      // Absolute deadline on the total hold time, independent of the renewable idle timer above.
+      // Never renewed, so a stream of renewals can not extend the lock past this cap.
+      if (this.maxHoldDuration > 0) {
+        maxTimer = setTimeout((): void => {
+          this.logger.warn(`Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`);
+          reject(new InternalServerError(
+            `Lock reached its maximum hold duration of ${this.maxHoldDuration}ms on ${identifier.path}`,
+          ));
+        }, this.maxHoldDuration);
+      }
     });
 
-    // Restarts the timer
+    // Restarts the idle timer, but never affects the absolute maximum-hold deadline
     const renewTimer = (): void => {
       this.logger.verbose(`Renewed expiring lock on ${identifier.path}`);
       clearTimeout(timer);
       timer = createTimeout();
     };
 
-    // Runs the main function and cleans up the timer afterwards
+    // Runs the main function and cleans up the timers afterwards
     async function runWithTimeout(): Promise<T> {
       try {
         return await whileLocked(renewTimer);
       } finally {
         clearTimeout(timer);
+        if (maxTimer) {
+          clearTimeout(maxTimer);
+        }
       }
     }
 

--- a/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
+++ b/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
@@ -1,4 +1,6 @@
 import type { ResourceIdentifier } from '../../../../src/http/representation/ResourceIdentifier';
+import { EqualReadWriteLocker } from '../../../../src/util/locking/EqualReadWriteLocker';
+import { MemoryResourceLocker } from '../../../../src/util/locking/MemoryResourceLocker';
 import type { ReadWriteLocker } from '../../../../src/util/locking/ReadWriteLocker';
 import { WrappedExpiringReadWriteLocker } from '../../../../src/util/locking/WrappedExpiringReadWriteLocker';
 import type { PromiseOrValue } from '../../../../src/util/PromiseUtil';
@@ -27,6 +29,10 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
     }));
 
     locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration);
+  });
+
+  afterEach((): void => {
+    jest.clearAllTimers();
   });
 
   it('calls the wrapped locker for locking.', async(): Promise<void> => {
@@ -118,7 +124,7 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
     await expect(prom).resolves.toBe('refresh');
   });
 
-  it('releases the lock once the maximum hold duration is exceeded, even while being renewed.', async():
+  it('rejects once the maximum hold duration is exceeded, even while being renewed.', async():
   Promise<void> => {
     const maxHoldDuration = 2000;
     locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration, maxHoldDuration);
@@ -133,6 +139,55 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
     jest.advanceTimersByTime(maxHoldDuration);
     await expect(prom).rejects
       .toThrow(`Lock reached its maximum hold duration of ${maxHoldDuration}ms on ${identifier.path}`);
+  });
+
+  it('releases the underlying resource lock once the maximum hold duration is exceeded.', async(): Promise<void> => {
+    const maxHoldDuration = 2000;
+    const resourceLocker = new MemoryResourceLocker();
+    const release = jest.spyOn(resourceLocker, 'release');
+    locker = new WrappedExpiringReadWriteLocker(
+      new EqualReadWriteLocker(resourceLocker),
+      expiration,
+      maxHoldDuration,
+    );
+    let indicateLockAcquired: () => void;
+    const lockAcquired = new Promise<void>((resolve): void => {
+      indicateLockAcquired = resolve;
+    });
+
+    const prom = locker.withWriteLock(identifier, async(maintainLock): Promise<never> => {
+      indicateLockAcquired();
+      setTimeout(maintainLock, 750);
+      setTimeout(maintainLock, 1500);
+      return new Promise<never>((): void => undefined);
+    });
+    await lockAcquired;
+    jest.advanceTimersByTime(maxHoldDuration);
+
+    await expect(prom).rejects
+      .toThrow(`Lock reached its maximum hold duration of ${maxHoldDuration}ms on ${identifier.path}`);
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledWith(identifier);
+  });
+
+  it('ignores renewals after the maximum hold duration is exceeded.', async(): Promise<void> => {
+    const maxHoldDuration = 2000;
+    locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration, maxHoldDuration);
+    let maintainLock: (() => void) | undefined;
+    const prom = locker.withWriteLock(identifier, async(renew): Promise<never> => {
+      maintainLock = renew;
+      setTimeout(renew, 750);
+      setTimeout(renew, 1500);
+      return new Promise<never>((): void => undefined);
+    });
+    jest.advanceTimersByTime(maxHoldDuration);
+    await expect(prom).rejects
+      .toThrow(`Lock reached its maximum hold duration of ${maxHoldDuration}ms on ${identifier.path}`);
+    expect(jest.getTimerCount()).toBe(0);
+
+    expect(maintainLock).toBeDefined();
+    maintainLock?.();
+    expect(jest.getTimerCount()).toBe(0);
   });
 
   it('still allows renewals up to the maximum hold duration.', async(): Promise<void> => {

--- a/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
+++ b/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
@@ -90,7 +90,6 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
   });
 
   it('does not cap the total hold time when maxHoldDuration defaults to 0.', async(): Promise<void> => {
-    // Renews the idle timer repeatedly and resolves well past the idle expiration.
     async function refreshCb(maintainLock: () => void): Promise<string> {
       return new Promise((resolve): any => {
         setTimeout(maintainLock, 750);
@@ -99,7 +98,6 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
         setTimeout((): void => resolve('refresh'), 2900);
       });
     }
-    // Default locker (no maxHoldDuration argument) must behave exactly as before: renewals are unlimited.
     const prom = locker.withReadLock(identifier, refreshCb);
     jest.advanceTimersByTime(2900);
     await expect(prom).resolves.toBe('refresh');
@@ -124,7 +122,6 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
   Promise<void> => {
     const maxHoldDuration = 2000;
     locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration, maxHoldDuration);
-    // Keeps renewing the idle timer so it never expires, but never resolves before the cap.
     async function trickleCb(maintainLock: () => void): Promise<void> {
       return new Promise((resolve): any => {
         setTimeout(maintainLock, 750);

--- a/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
+++ b/test/unit/util/locking/WrappedExpiringReadWriteLocker.test.ts
@@ -88,4 +88,69 @@ describe('A WrappedExpiringReadWriteLocker', (): void => {
     jest.advanceTimersByTime(5000);
     await expect(prom).rejects.toThrow(`Lock expired after ${expiration}ms on ${identifier.path}`);
   });
+
+  it('does not cap the total hold time when maxHoldDuration defaults to 0.', async(): Promise<void> => {
+    // Renews the idle timer repeatedly and resolves well past the idle expiration.
+    async function refreshCb(maintainLock: () => void): Promise<string> {
+      return new Promise((resolve): any => {
+        setTimeout(maintainLock, 750);
+        setTimeout(maintainLock, 1500);
+        setTimeout(maintainLock, 2250);
+        setTimeout((): void => resolve('refresh'), 2900);
+      });
+    }
+    // Default locker (no maxHoldDuration argument) must behave exactly as before: renewals are unlimited.
+    const prom = locker.withReadLock(identifier, refreshCb);
+    jest.advanceTimersByTime(2900);
+    await expect(prom).resolves.toBe('refresh');
+  });
+
+  it('does not cap the total hold time when maxHoldDuration is explicitly 0.', async(): Promise<void> => {
+    locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration, 0);
+    async function refreshCb(maintainLock: () => void): Promise<string> {
+      return new Promise((resolve): any => {
+        setTimeout(maintainLock, 750);
+        setTimeout(maintainLock, 1500);
+        setTimeout(maintainLock, 2250);
+        setTimeout((): void => resolve('refresh'), 2900);
+      });
+    }
+    const prom = locker.withReadLock(identifier, refreshCb);
+    jest.advanceTimersByTime(2900);
+    await expect(prom).resolves.toBe('refresh');
+  });
+
+  it('releases the lock once the maximum hold duration is exceeded, even while being renewed.', async():
+  Promise<void> => {
+    const maxHoldDuration = 2000;
+    locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration, maxHoldDuration);
+    // Keeps renewing the idle timer so it never expires, but never resolves before the cap.
+    async function trickleCb(maintainLock: () => void): Promise<void> {
+      return new Promise((resolve): any => {
+        setTimeout(maintainLock, 750);
+        setTimeout(maintainLock, 1500);
+        setTimeout(resolve, 10000);
+      });
+    }
+    const prom = locker.withWriteLock(identifier, trickleCb);
+    jest.advanceTimersByTime(maxHoldDuration);
+    await expect(prom).rejects
+      .toThrow(`Lock reached its maximum hold duration of ${maxHoldDuration}ms on ${identifier.path}`);
+  });
+
+  it('still allows renewals up to the maximum hold duration.', async(): Promise<void> => {
+    const maxHoldDuration = 5000;
+    locker = new WrappedExpiringReadWriteLocker(wrappedLocker, expiration, maxHoldDuration);
+    async function refreshCb(maintainLock: () => void): Promise<string> {
+      return new Promise((resolve): any => {
+        setTimeout(maintainLock, 750);
+        setTimeout(maintainLock, 1500);
+        setTimeout(maintainLock, 2250);
+        setTimeout((): void => resolve('refresh'), 3000);
+      });
+    }
+    const prom = locker.withReadLock(identifier, refreshCb);
+    jest.advanceTimersByTime(3000);
+    await expect(prom).resolves.toBe('refresh');
+  });
 });


### PR DESCRIPTION
#### 📁 Related issues

Related to #2219.

This is the `main` port of [jeswr/CommunitySolidServer#87](https://github.com/jeswr/CommunitySolidServer/pull/87).

#### ✍️ Description

Adds an optional absolute maximum hold duration to `WrappedExpiringReadWriteLocker`. The existing inactivity timeout can still be renewed, while the new deadline is never extended; reaching either deadline releases the wrapped lock and rejects the operation.

The new constructor argument defaults to `0`, preserving the current uncapped behavior. An opt-in file-locker configuration imports the existing file-locker setup and caps total hold time at one hour.

Suggested label: `semver.minor`.

Validation:

* `npm run build`
* ESLint on the affected source and test files
* Markdownlint on the affected documentation
* `WrappedExpiringReadWriteLocker.test.ts` (11 tests)

Direct configuration compilation is currently blocked while parsing the generated `AuxiliaryLinkMetadataWriter` component metadata. That source is unchanged from `main`; TypeScript and Components.js metadata generation both complete successfully before the parser reaches that existing error.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label - _**this is a minor change, I do not have permission to apply labels**_
    * semver.minor: Backwards compatible feature additions.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.
