### PR TITLE
docs: Deprecate buffered quad helpers

### DIFF
--- a/src/storage/accessors/FileDataAccessor.ts
+++ b/src/storage/accessors/FileDataAccessor.ts
@@ -225,6 +225,7 @@ export class FileDataAccessor implements DataAccessor {
     // Write metadata to file if there are quads remaining
     if (quads.length > 0) {
       // Determine required content-type based on mapper
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- Buffered metadata is faster for this call site.
       const serializedMetadata = serializeQuads(quads, metadataLink.contentType);
       await this.writeDataFile(metadataLink.filePath, serializedMetadata);
       wroteMetadata = true;
@@ -266,6 +267,7 @@ export class FileDataAccessor implements DataAccessor {
       const stats = await lstat(metadataLink.filePath);
 
       const readMetadataStream = guardStream(createReadStream(metadataLink.filePath));
+      // eslint-disable-next-line @typescript-eslint/no-deprecated -- Streaming into metadata regresses performance.
       const quads = await parseQuads(
         readMetadataStream,
         { format: metadataLink.contentType, baseIRI: identifier.path },

--- a/src/util/QuadUtil.ts
+++ b/src/util/QuadUtil.ts
@@ -14,6 +14,8 @@ import { toNamedTerm } from './TermUtil';
  * @param contentType - The content-type to serialize to.
  *
  * @returns The Readable object.
+ *
+ * @deprecated Pipe the quad source through an N3 `StreamWriter` at the I/O boundary instead.
  */
 export function serializeQuads(quads: Quad[], contentType?: string): Guarded<Readable> {
   return pipeSafely(guardedStreamFrom(quads), new StreamWriter({ format: contentType }));
@@ -26,6 +28,8 @@ export function serializeQuads(quads: Quad[], contentType?: string): Guarded<Rea
  * @param options - Options for the parser.
  *
  * @returns A promise containing the array of quads.
+ *
+ * @deprecated Pipe the input through an N3 `StreamParser` and consume its quad stream instead.
  */
 export async function parseQuads(readable: Guarded<Readable>, options: ParserOptions = {}): Promise<Quad[]> {
   return arrayifyStream(pipeSafely(readable, new StreamParser(options)));

--- a/test/unit/util/QuadUtil.test.ts
+++ b/test/unit/util/QuadUtil.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-deprecated -- These tests protect the compatibility API. */
 import 'jest-rdf';
 import { DataFactory, Store } from 'n3';
 import { parseQuads, serializeQuads, solveBgp, termToInt, uniqueQuads } from '../../../src/util/QuadUtil';


### PR DESCRIPTION
#### 📁 Related issues

None yet. This is a draft while the API direction is reviewed; an issue can be linked before it is marked ready.

#### ✍️ Description

Marks the exported `parseQuads` and `serializeQuads` compatibility helpers as deprecated. Their signatures and runtime behavior are unchanged.

Both helpers require their quad data to be fully materialized: `parseQuads` resolves to a `Quad[]`, while `serializeQuads` accepts a `Quad[]`. New call sites that already operate at an I/O boundary should instead pipe data through N3's `StreamParser` or `StreamWriter` directly.

The existing `FileDataAccessor` calls remain buffered intentionally. A streaming prototype was benchmarked and then reverted because it made metadata reads slower without reducing peak memory. Narrow lint suppressions document that decision at those two internal call sites.

#### Performance analysis

Benchmarked on Node.js 24.12.0 with warm-up, alternating old/new order, and median timings across repeated samples:

| Metadata | Buffered read | Streaming read | Buffered write | Streaming write |
|---|---:|---:|---:|---:|
| 1 quad / 68 B | 52 µs | 93 µs | 39 µs | 37 µs |
| 1,000 quads / 72 KB | 6.7 ms | 9.0 ms | 3.16 ms | 3.20 ms |
| 10,000 quads / 738 KB | 35.9 ms | 43.8 ms | 19.7 ms | 20.0 ms |

At 100,000 quads, the streaming read path used about 9 MiB more peak heap and 28 MiB more peak RSS. Streaming writes saved only about 1.6% of total peak heap and were approximately 20% slower. Because `RepresentationMetadata` retains the final RDF store, streaming the parser does not materially change its memory complexity.

#### Verification

- TypeScript compilation passes.
- Full ESLint passes with zero warnings, apart from the repository's existing stylistic-plugin configuration notice.
- The directly affected unit suites pass: 57 tests.
- The coverage-gated suite passes 357/358 suites and retains 100% coverage. The remaining `FileSystemResourceLocker` ordering test failed in two full-suite runs but passed 11/11 in isolation; this change does not touch locking code.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.
