### PR TITLE
perf(identity): reuse the resolved input account for cookie persistence

### DIFF
--- a/src/identity/interaction/CookieInteractionHandler.ts
+++ b/src/identity/interaction/CookieInteractionHandler.ts
@@ -36,16 +36,16 @@ export class CookieInteractionHandler extends JsonInteractionHandler {
     let { metadata: outputMetadata } = output;
 
     // The cookie could be new, in the output, or the one received in the input if no new cookie is made
-    const cookie = outputMetadata?.get(SOLID_HTTP.terms.accountCookie)?.value ??
+    const outputCookie = outputMetadata?.get(SOLID_HTTP.terms.accountCookie)?.value;
+    const cookie = outputCookie ??
       input.metadata.get(SOLID_HTTP.terms.accountCookie)?.value;
     // Only update the expiration if it wasn't set by the source handler,
     // as that might have a specific reason, such as logging out.
     if (!cookie || outputMetadata?.has(SOLID_HTTP.terms.accountCookieExpiration)) {
       return output;
     }
-    // Not reusing the account ID from the input,
-    // as that could potentially belong to a different account if this is a new login action.
-    const accountId = await this.cookieStore.get(cookie);
+    // An output cookie can belong to a different account.
+    const accountId = outputCookie ? await this.cookieStore.get(cookie) : input.accountId;
 
     // Only refresh the cookie if it points to an account that exists and wants to be remembered
     if (!accountId) {
@@ -56,7 +56,7 @@ export class CookieInteractionHandler extends JsonInteractionHandler {
       return output;
     }
 
-    // Refresh the cookie, could be undefined if it was deleted by the operation
+    // Refresh only if the cookie still exists.
     const expiration = await this.cookieStore.refresh(cookie);
     if (expiration) {
       outputMetadata = outputMetadata ?? new RepresentationMetadata(input.target);

--- a/test/unit/identity/interaction/CookieInteractionHandler.test.ts
+++ b/test/unit/identity/interaction/CookieInteractionHandler.test.ts
@@ -33,6 +33,7 @@ describe('A CookieInteractionHandler', (): void => {
       json: {},
       metadata: new RepresentationMetadata({ [SOLID_HTTP.accountCookie]: cookie }),
       target,
+      accountId,
     };
 
     output = {
@@ -72,8 +73,7 @@ describe('A CookieInteractionHandler', (): void => {
     await expect(handler.handle(input)).resolves.toEqual(output);
     expect(source.handle).toHaveBeenCalledTimes(1);
     expect(source.handle).toHaveBeenLastCalledWith(input);
-    expect(cookieStore.get).toHaveBeenCalledTimes(1);
-    expect(cookieStore.get).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.get).toHaveBeenCalledTimes(0);
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(1);
@@ -87,8 +87,7 @@ describe('A CookieInteractionHandler', (): void => {
     await expect(handler.handle(input)).resolves.toEqual(output);
     expect(source.handle).toHaveBeenCalledTimes(1);
     expect(source.handle).toHaveBeenLastCalledWith(input);
-    expect(cookieStore.get).toHaveBeenCalledTimes(1);
-    expect(cookieStore.get).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.get).toHaveBeenCalledTimes(0);
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(1);
@@ -99,10 +98,26 @@ describe('A CookieInteractionHandler', (): void => {
   });
 
   it('uses the output cookie over the input cookie if there is one.', async(): Promise<void> => {
+    input.accountId = 'input-account';
     output.metadata!.set(SOLID_HTTP.terms.accountCookie, 'other-cookie');
     await expect(handler.handle(input)).resolves.toEqual(output);
+    expect(cookieStore.get).toHaveBeenCalledTimes(1);
+    expect(cookieStore.get).toHaveBeenLastCalledWith('other-cookie');
+    expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookie)?.value).toBe('other-cookie');
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookieExpiration)?.value).toBe(date.toISOString());
+  });
+
+  it('adds no cookie metadata if an output cookie has no account ID.', async(): Promise<void> => {
+    output.metadata!.set(SOLID_HTTP.terms.accountCookie, 'other-cookie');
+    cookieStore.get.mockResolvedValueOnce(undefined);
+    await expect(handler.handle(input)).resolves.toEqual(output);
+    expect(cookieStore.get).toHaveBeenCalledTimes(1);
+    expect(cookieStore.get).toHaveBeenLastCalledWith('other-cookie');
+    expect(accountStore.getSetting).toHaveBeenCalledTimes(0);
+    expect(cookieStore.refresh).toHaveBeenCalledTimes(0);
+    expect(output.metadata?.get(SOLID_HTTP.terms.accountCookie)?.value).toBe('other-cookie');
+    expect(output.metadata?.get(SOLID_HTTP.terms.accountCookieExpiration)).toBeUndefined();
   });
 
   it('adds no cookie metadata if there is no cookie.', async(): Promise<void> => {
@@ -125,10 +140,9 @@ describe('A CookieInteractionHandler', (): void => {
   });
 
   it('adds no cookie metadata if no account ID was found.', async(): Promise<void> => {
-    cookieStore.get.mockResolvedValue(undefined);
+    delete input.accountId;
     await expect(handler.handle(input)).resolves.toEqual(output);
-    expect(cookieStore.get).toHaveBeenCalledTimes(1);
-    expect(cookieStore.get).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.get).toHaveBeenCalledTimes(0);
     expect(accountStore.getSetting).toHaveBeenCalledTimes(0);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(0);
     expect(output.metadata?.get(SOLID_HTTP.terms.accountCookie)).toBeUndefined();
@@ -138,8 +152,7 @@ describe('A CookieInteractionHandler', (): void => {
   it('adds no cookie metadata if the account does not want to be remembered.', async(): Promise<void> => {
     accountStore.getSetting.mockResolvedValueOnce(false);
     await expect(handler.handle(input)).resolves.toEqual(output);
-    expect(cookieStore.get).toHaveBeenCalledTimes(1);
-    expect(cookieStore.get).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.get).toHaveBeenCalledTimes(0);
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(0);
@@ -150,8 +163,7 @@ describe('A CookieInteractionHandler', (): void => {
   it('adds no cookie metadata if the refresh action returns no value.', async(): Promise<void> => {
     cookieStore.refresh.mockResolvedValue(undefined);
     await expect(handler.handle(input)).resolves.toEqual(output);
-    expect(cookieStore.get).toHaveBeenCalledTimes(1);
-    expect(cookieStore.get).toHaveBeenLastCalledWith(cookie);
+    expect(cookieStore.get).toHaveBeenCalledTimes(0);
     expect(accountStore.getSetting).toHaveBeenCalledTimes(1);
     expect(accountStore.getSetting).toHaveBeenLastCalledWith(accountId, ACCOUNT_SETTINGS_REMEMBER_LOGIN);
     expect(cookieStore.refresh).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
#### 📁 Related issues

Closes #2227.

#### ✍️ Description

Reuses the account ID that `IdentityProviderHttpHandler` already resolved for
an input cookie when `CookieInteractionHandler` checks `rememberLogin`.

New output cookies are still looked up because they can belong to a different
account. `CookieStore.refresh(cookie)` is also unchanged and still performs its
storage read, ensuring that a concurrently deleted or naturally expired cookie
is not recreated.

For a normal authenticated `.account` request, cookie-store reads drop from
three to two overall, and from two to one inside `CookieInteractionHandler`.
This saves one storage round trip without changing the public `CookieStore`
interface or cookie lifecycle semantics.

Local verification on current `main`:

- locked dependency install and full source build
- test TypeScript compilation
- ESLint on both changed files
- 18 focused unit tests covering the HTTP-level account lookup, input/output
  cookie handling, and final refresh validation

The intended semver level is **patch**.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label - _**This is a patch change - I do not have permission to apply labels**_
    * semver.patch: Backwards compatible bug fixes.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.
