### PR TITLE
perf: Add a reusable promise cache abstraction

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+- A promise cache and caching decorator are now exported for deduplicating asynchronous computations.
 - Backend resources are cached, as long as they don't change, improving response speed.
   This only works for servers running on a single thread.
 - Several parts of the codebase have been exported to external libraries.

--- a/src/index.ts
+++ b/src/index.ts
@@ -526,6 +526,10 @@ export * from './storage/ResourceSet';
 export * from './storage/ResourceStore';
 export * from './storage/RoutingResourceStore';
 
+// Util/Caching
+export * from './util/caching/CachedDecorator';
+export * from './util/caching/PromiseCache';
+
 // Util/Errors
 export * from './util/errors/BadRequestHttpError';
 export * from './util/errors/ConflictHttpError';

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -21,7 +21,9 @@ export function cached<TThis extends object, TArgs extends unknown[], TValue>(
 
   return (target: (this: TThis, ...args: TArgs) => Promise<TValue>):
   (this: TThis, ...args: TArgs) => Promise<TValue> =>
-    async function(this: TThis, ...args: TArgs): Promise<TValue> {
+    // Returning the promise directly preserves its identity.
+    // eslint-disable-next-line @typescript-eslint/promise-function-async
+    function(this: TThis, ...args: TArgs): Promise<TValue> {
       let cache = caches.get(this);
       if (!cache) {
         // The caller guarantees object keys when enabling `weak`.

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -3,9 +3,6 @@ import { PromiseCache } from './PromiseCache';
 
 /**
  * Options for the {@link cached} method decorator.
- *
- * @typeParam TThis - Type of the instance the decorated method belongs to.
- * @typeParam TArgs - Argument tuple of the decorated method.
  */
 export interface CachedOptions<TThis, TArgs extends unknown[]> {
   /**
@@ -14,10 +11,9 @@ export interface CachedOptions<TThis, TArgs extends unknown[]> {
    */
   readonly key?: (this: TThis, ...args: TArgs) => unknown;
   /**
-   * Whether to back the per-instance cache with a `WeakMap` instead of a `Map`.
-   * A `WeakMap` keys entries on object identity and lets them be garbage collected once the key is unreachable,
-   * which requires the cache key to be an object and is the memory-safe choice for request-scoped keys.
-   * Defaults to `false`, using a `Map` that caches for the lifetime of the instance.
+   * Whether to back the cache with a `WeakMap` instead of a `Map`,
+   * letting entries be garbage collected once their key object is unreachable.
+   * Requires the cache key to be an object. Defaults to `false`.
    */
   readonly weak?: boolean;
   /**
@@ -28,30 +24,18 @@ export interface CachedOptions<TThis, TArgs extends unknown[]> {
 }
 
 /**
- * Method decorator that memoizes an asynchronous method with a {@link PromiseCache},
- * making the widely repeated "look up a cached promise, otherwise compute and cache it" pattern
- * a single, minimally invasive annotation.
+ * Method decorator that memoizes an asynchronous method with a {@link PromiseCache}.
+ * Every instance gets its own cache, so instances never share cached results.
+ * By default the first argument is used as cache key;
+ * see {@link CachedOptions} for the key derivation, backing store, and error eviction.
  *
- * Each instance gets its own cache, so instances never share cached results.
- * The returned promise is cached (not just its resolved value),
- * so concurrent calls with the same key deduplicate onto a single in-flight computation.
+ * @param options - Options determining the caching behaviour.
  *
- * By default the first argument is used as cache key and entries live for the lifetime of the instance;
- * use {@link CachedOptions.key} to derive the key differently
- * and {@link CachedOptions.weak} to instead key entries on object identity in a `WeakMap`.
- *
- * @param options - {@link CachedOptions} controlling the key, backing store, and error eviction.
- *
- * @returns A decorator applying the described caching to the method.
- *
- * @typeParam TThis - Type of the instance the decorated method belongs to.
- * @typeParam TArgs - Argument tuple of the decorated method.
- * @typeParam TValue - Value the decorated method's promise resolves to.
+ * @returns A decorator applying the caching to the method.
  */
 export function cached<TThis extends object, TArgs extends unknown[], TValue>(
   options: CachedOptions<TThis, TArgs> = {},
 ): (target: (this: TThis, ...args: TArgs) => Promise<TValue>) => (this: TThis, ...args: TArgs) => Promise<TValue> {
-  // One cache per instance, keyed on the instance itself so instances never share results.
   const caches = new WeakMap<TThis, PromiseCache<unknown, TValue>>();
 
   return (target: (this: TThis, ...args: TArgs) => Promise<TValue>):
@@ -59,8 +43,7 @@ export function cached<TThis extends object, TArgs extends unknown[], TValue>(
     async function(this: TThis, ...args: TArgs): Promise<TValue> {
       let cache = caches.get(this);
       if (!cache) {
-        // A WeakMap only accepts object keys, which the caller opts into via `weak`;
-        // the cast mirrors that the key type is only known to be an object at that call site.
+        // A WeakMap only accepts object keys, so a cast is needed to match the store interface
         const store = options.weak ?
           new WeakMap<object, Promise<TValue>>() as unknown as PromiseCacheStore<unknown, Promise<TValue>> :
           new Map<unknown, Promise<TValue>>();

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -1,0 +1,73 @@
+import type { PromiseCacheStore } from './PromiseCache';
+import { PromiseCache } from './PromiseCache';
+
+/**
+ * Options for the {@link cached} method decorator.
+ *
+ * @typeParam TThis - Type of the instance the decorated method belongs to.
+ * @typeParam TArgs - Argument tuple of the decorated method.
+ */
+export interface CachedOptions<TThis, TArgs extends unknown[]> {
+  /**
+   * Derives the cache key from the arguments of the decorated method.
+   * Defaults to using the first argument as key.
+   */
+  readonly key?: (this: TThis, ...args: TArgs) => unknown;
+  /**
+   * Whether to back the per-instance cache with a `WeakMap` instead of a `Map`.
+   * A `WeakMap` keys entries on object identity and lets them be garbage collected once the key is unreachable,
+   * which requires the cache key to be an object and is the memory-safe choice for request-scoped keys.
+   * Defaults to `false`, using a `Map` that caches for the lifetime of the instance.
+   */
+  readonly weak?: boolean;
+  /**
+   * Whether an entry whose promise rejects is evicted so the call is retried next time.
+   * Defaults to `true`.
+   */
+  readonly evictOnError?: boolean;
+}
+
+/**
+ * Method decorator that memoizes an asynchronous method with a {@link PromiseCache},
+ * making the widely repeated "look up a cached promise, otherwise compute and cache it" pattern
+ * a single, minimally invasive annotation.
+ *
+ * Each instance gets its own cache, so instances never share cached results.
+ * The returned promise is cached (not just its resolved value),
+ * so concurrent calls with the same key deduplicate onto a single in-flight computation.
+ *
+ * By default the first argument is used as cache key and entries live for the lifetime of the instance;
+ * use {@link CachedOptions.key} to derive the key differently
+ * and {@link CachedOptions.weak} to instead key entries on object identity in a `WeakMap`.
+ *
+ * @param options - {@link CachedOptions} controlling the key, backing store, and error eviction.
+ *
+ * @returns A decorator applying the described caching to the method.
+ *
+ * @typeParam TThis - Type of the instance the decorated method belongs to.
+ * @typeParam TArgs - Argument tuple of the decorated method.
+ * @typeParam TValue - Value the decorated method's promise resolves to.
+ */
+export function cached<TThis extends object, TArgs extends unknown[], TValue>(
+  options: CachedOptions<TThis, TArgs> = {},
+): (target: (this: TThis, ...args: TArgs) => Promise<TValue>) => (this: TThis, ...args: TArgs) => Promise<TValue> {
+  // One cache per instance, keyed on the instance itself so instances never share results.
+  const caches = new WeakMap<TThis, PromiseCache<unknown, TValue>>();
+
+  return (target: (this: TThis, ...args: TArgs) => Promise<TValue>):
+  (this: TThis, ...args: TArgs) => Promise<TValue> =>
+    async function(this: TThis, ...args: TArgs): Promise<TValue> {
+      let cache = caches.get(this);
+      if (!cache) {
+        // A WeakMap only accepts object keys, which the caller opts into via `weak`;
+        // the cast mirrors that the key type is only known to be an object at that call site.
+        const store = options.weak ?
+          new WeakMap<object, Promise<TValue>>() as unknown as PromiseCacheStore<unknown, Promise<TValue>> :
+          new Map<unknown, Promise<TValue>>();
+        cache = new PromiseCache<unknown, TValue>(store, { evictOnError: options.evictOnError });
+        caches.set(this, cache);
+      }
+      const key = options.key ? options.key.apply(this, args) : args[0];
+      return cache.getOrCreate(key, async(): Promise<TValue> => target.apply(this, args));
+    };
+}

--- a/src/util/caching/CachedDecorator.ts
+++ b/src/util/caching/CachedDecorator.ts
@@ -1,37 +1,18 @@
 import type { PromiseCacheStore } from './PromiseCache';
 import { PromiseCache } from './PromiseCache';
 
-/**
- * Options for the {@link cached} method decorator.
- */
+/** Options for the {@link cached} decorator. */
 export interface CachedOptions<TThis, TArgs extends unknown[]> {
-  /**
-   * Derives the cache key from the arguments of the decorated method.
-   * Defaults to using the first argument as key.
-   */
+  /** Derives the cache key. Defaults to the first argument. */
   readonly key?: (this: TThis, ...args: TArgs) => unknown;
-  /**
-   * Whether to back the cache with a `WeakMap` instead of a `Map`,
-   * letting entries be garbage collected once their key object is unreachable.
-   * Requires the cache key to be an object. Defaults to `false`.
-   */
+  /** Uses a `WeakMap`; requires object keys. */
   readonly weak?: boolean;
-  /**
-   * Whether an entry whose promise rejects is evicted so the call is retried next time.
-   * Defaults to `true`.
-   */
+  /** Evicts rejected promises. Defaults to `true`. */
   readonly evictOnError?: boolean;
 }
 
 /**
- * Method decorator that memoizes an asynchronous method with a {@link PromiseCache}.
- * Every instance gets its own cache, so instances never share cached results.
- * By default the first argument is used as cache key;
- * see {@link CachedOptions} for the key derivation, backing store, and error eviction.
- *
- * @param options - Options determining the caching behaviour.
- *
- * @returns A decorator applying the caching to the method.
+ * Caches asynchronous method results per instance.
  */
 export function cached<TThis extends object, TArgs extends unknown[], TValue>(
   options: CachedOptions<TThis, TArgs> = {},
@@ -43,7 +24,7 @@ export function cached<TThis extends object, TArgs extends unknown[], TValue>(
     async function(this: TThis, ...args: TArgs): Promise<TValue> {
       let cache = caches.get(this);
       if (!cache) {
-        // A WeakMap only accepts object keys, so a cast is needed to match the store interface
+        // The caller guarantees object keys when enabling `weak`.
         const store = options.weak ?
           new WeakMap<object, Promise<TValue>>() as unknown as PromiseCacheStore<unknown, Promise<TValue>> :
           new Map<unknown, Promise<TValue>>();

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -1,0 +1,85 @@
+/**
+ * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries.
+ * Both `Map` and `WeakMap` structurally satisfy this interface,
+ * which lets a cache be backed by either of them:
+ * a `Map` keeps its entries for as long as the cache exists (process-lifetime caching of a bounded key space),
+ * while a `WeakMap` keyed on object identity lets entries be garbage collected
+ * once their key object becomes unreachable, avoiding unbounded growth.
+ */
+export interface PromiseCacheStore<TKey, TValue> {
+  get: (key: TKey) => TValue | undefined;
+  set: (key: TKey, value: TValue) => unknown;
+  delete: (key: TKey) => unknown;
+}
+
+/**
+ * Options for a {@link PromiseCache}.
+ */
+export interface PromiseCacheOptions {
+  /**
+   * Whether an entry whose promise rejects is removed from the cache as soon as it rejects,
+   * so the failed computation is retried on the next call instead of being remembered.
+   * Defaults to `true`.
+   */
+  readonly evictOnError?: boolean;
+}
+
+/**
+ * A small, reusable cache for asynchronous, keyed computations.
+ *
+ * The *promise* returned by the factory is cached rather than its resolved value,
+ * so concurrent callers requesting the same key share a single in-flight computation and deduplicate,
+ * instead of each starting their own.
+ *
+ * The cache is backed by an injected {@link PromiseCacheStore}, allowing the caller to pick the lifetime:
+ * a `Map` (the default) caches for the lifetime of this object, which suits a bounded set of keys,
+ * whereas a `WeakMap` keyed on object identity lets entries be collected once their key is unreachable,
+ * which suits keys scoped to, for example, a single request.
+ *
+ * By default an entry whose promise rejects is evicted (see {@link PromiseCacheOptions.evictOnError}),
+ * so transient failures are retried rather than cached.
+ */
+export class PromiseCache<TKey, TValue> {
+  private readonly store: PromiseCacheStore<TKey, Promise<TValue>>;
+  private readonly evictOnError: boolean;
+
+  /**
+   * @param store - Backing store for the cached promises. Defaults to a new `Map`, which caches
+   *                entries for the lifetime of this object. Pass a `WeakMap` to instead key entries
+   *                on object identity and let them be garbage collected once the key is unreachable.
+   * @param options - Additional {@link PromiseCacheOptions}.
+   */
+  public constructor(
+    store: PromiseCacheStore<TKey, Promise<TValue>> = new Map<TKey, Promise<TValue>>(),
+    options: PromiseCacheOptions = {},
+  ) {
+    this.store = store;
+    this.evictOnError = options.evictOnError ?? true;
+  }
+
+  /**
+   * Returns the cached promise for the given key,
+   * or, on a cache miss, creates a new promise with the provided factory, caches it, and returns it.
+   *
+   * @param key - Key to look up.
+   * @param createPromise - Factory generating the promise on a cache miss. It receives the key.
+   *
+   * @returns The cached or newly created promise.
+   */
+  public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
+    const cached = this.store.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const promise = createPromise(key);
+    this.store.set(key, promise);
+    if (this.evictOnError) {
+      // Evict a rejected entry so the failed computation is retried on the next call.
+      promise.catch((): void => {
+        this.store.delete(key);
+      });
+    }
+    return promise;
+  }
+}

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -1,40 +1,26 @@
-/**
- * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries,
- * allowing a cache to be backed by either of them.
- */
+/** Store operations required by {@link PromiseCache}. */
 export interface PromiseCacheStore<TKey, TValue> {
   get: (key: TKey) => TValue | undefined;
   set: (key: TKey, value: TValue) => unknown;
   delete: (key: TKey) => unknown;
 }
 
-/**
- * Options for a {@link PromiseCache}.
- */
+/** Options for {@link PromiseCache}. */
 export interface PromiseCacheOptions {
-  /**
-   * Whether an entry whose promise rejects is removed from the cache,
-   * so the failed computation is retried on the next call.
-   * Defaults to `true`.
-   */
+  /** Evicts rejected promises. Defaults to `true`. */
   readonly evictOnError?: boolean;
 }
 
 /**
- * Caches asynchronous computations by key.
- * The promise is cached rather than its resolved value,
- * so concurrent calls for the same key share a single in-flight computation.
- * The injected {@link PromiseCacheStore} determines the entry lifetime:
- * a `Map` (the default) keeps entries for the lifetime of this object,
- * while a `WeakMap` lets them be garbage collected once their key object is unreachable.
+ * Deduplicates asynchronous computations by caching their promises.
  */
 export class PromiseCache<TKey, TValue> {
   private readonly store: PromiseCacheStore<TKey, Promise<TValue>>;
   private readonly evictOnError: boolean;
 
   /**
-   * @param store - Backing store for the cached promises. Defaults to a new `Map`.
-   * @param options - Additional {@link PromiseCacheOptions}.
+   * @param store - Cache storage. Defaults to a new `Map`.
+   * @param options - Cache options.
    */
   public constructor(
     store: PromiseCacheStore<TKey, Promise<TValue>> = new Map<TKey, Promise<TValue>>(),
@@ -44,13 +30,7 @@ export class PromiseCache<TKey, TValue> {
     this.evictOnError = options.evictOnError ?? true;
   }
 
-  /**
-   * Returns the cached promise for the given key,
-   * or creates and caches a new one with the given factory on a cache miss.
-   *
-   * @param key - Key to look up.
-   * @param createPromise - Factory generating the promise on a cache miss.
-   */
+  /** Returns the cached promise, creating it on a miss. */
   public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
     const cached = this.store.get(key);
     if (cached) {

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -31,7 +31,9 @@ export class PromiseCache<TKey, TValue> {
   }
 
   /** Returns the cached promise, creating it on a miss. */
-  public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
+  // Returning the promise directly preserves its identity.
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  public getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
     const cached = this.store.get(key);
     if (cached) {
       return cached;
@@ -41,7 +43,9 @@ export class PromiseCache<TKey, TValue> {
     this.store.set(key, promise);
     if (this.evictOnError) {
       promise.catch((): void => {
-        this.store.delete(key);
+        if (this.store.get(key) === promise) {
+          this.store.delete(key);
+        }
       });
     }
     return promise;

--- a/src/util/caching/PromiseCache.ts
+++ b/src/util/caching/PromiseCache.ts
@@ -1,10 +1,6 @@
 /**
- * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries.
- * Both `Map` and `WeakMap` structurally satisfy this interface,
- * which lets a cache be backed by either of them:
- * a `Map` keeps its entries for as long as the cache exists (process-lifetime caching of a bounded key space),
- * while a `WeakMap` keyed on object identity lets entries be garbage collected
- * once their key object becomes unreachable, avoiding unbounded growth.
+ * The subset of the `Map`/`WeakMap` API that a {@link PromiseCache} uses to store its entries,
+ * allowing a cache to be backed by either of them.
  */
 export interface PromiseCacheStore<TKey, TValue> {
   get: (key: TKey) => TValue | undefined;
@@ -17,36 +13,27 @@ export interface PromiseCacheStore<TKey, TValue> {
  */
 export interface PromiseCacheOptions {
   /**
-   * Whether an entry whose promise rejects is removed from the cache as soon as it rejects,
-   * so the failed computation is retried on the next call instead of being remembered.
+   * Whether an entry whose promise rejects is removed from the cache,
+   * so the failed computation is retried on the next call.
    * Defaults to `true`.
    */
   readonly evictOnError?: boolean;
 }
 
 /**
- * A small, reusable cache for asynchronous, keyed computations.
- *
- * The *promise* returned by the factory is cached rather than its resolved value,
- * so concurrent callers requesting the same key share a single in-flight computation and deduplicate,
- * instead of each starting their own.
- *
- * The cache is backed by an injected {@link PromiseCacheStore}, allowing the caller to pick the lifetime:
- * a `Map` (the default) caches for the lifetime of this object, which suits a bounded set of keys,
- * whereas a `WeakMap` keyed on object identity lets entries be collected once their key is unreachable,
- * which suits keys scoped to, for example, a single request.
- *
- * By default an entry whose promise rejects is evicted (see {@link PromiseCacheOptions.evictOnError}),
- * so transient failures are retried rather than cached.
+ * Caches asynchronous computations by key.
+ * The promise is cached rather than its resolved value,
+ * so concurrent calls for the same key share a single in-flight computation.
+ * The injected {@link PromiseCacheStore} determines the entry lifetime:
+ * a `Map` (the default) keeps entries for the lifetime of this object,
+ * while a `WeakMap` lets them be garbage collected once their key object is unreachable.
  */
 export class PromiseCache<TKey, TValue> {
   private readonly store: PromiseCacheStore<TKey, Promise<TValue>>;
   private readonly evictOnError: boolean;
 
   /**
-   * @param store - Backing store for the cached promises. Defaults to a new `Map`, which caches
-   *                entries for the lifetime of this object. Pass a `WeakMap` to instead key entries
-   *                on object identity and let them be garbage collected once the key is unreachable.
+   * @param store - Backing store for the cached promises. Defaults to a new `Map`.
    * @param options - Additional {@link PromiseCacheOptions}.
    */
   public constructor(
@@ -59,12 +46,10 @@ export class PromiseCache<TKey, TValue> {
 
   /**
    * Returns the cached promise for the given key,
-   * or, on a cache miss, creates a new promise with the provided factory, caches it, and returns it.
+   * or creates and caches a new one with the given factory on a cache miss.
    *
    * @param key - Key to look up.
-   * @param createPromise - Factory generating the promise on a cache miss. It receives the key.
-   *
-   * @returns The cached or newly created promise.
+   * @param createPromise - Factory generating the promise on a cache miss.
    */
   public async getOrCreate(key: TKey, createPromise: (key: TKey) => Promise<TValue>): Promise<TValue> {
     const cached = this.store.get(key);
@@ -75,7 +60,6 @@ export class PromiseCache<TKey, TValue> {
     const promise = createPromise(key);
     this.store.set(key, promise);
     if (this.evictOnError) {
-      // Evict a rejected entry so the failed computation is retried on the next call.
       promise.catch((): void => {
         this.store.delete(key);
       });

--- a/test/unit/util/caching/CachedDecorator.test.ts
+++ b/test/unit/util/caching/CachedDecorator.test.ts
@@ -1,0 +1,115 @@
+import { cached } from '../../../../src/util/caching/CachedDecorator';
+
+describe('The cached decorator', (): void => {
+  it('caches a method result per instance based on the first argument.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Counter {
+      private count = 0;
+
+      @cached()
+      public async get(key: string): Promise<number> {
+        spy(key);
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const instance = new Counter();
+    await expect(instance.get('a')).resolves.toBe(0);
+    await expect(instance.get('a')).resolves.toBe(0);
+    await expect(instance.get('b')).resolves.toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(1, 'a');
+    expect(spy).toHaveBeenNthCalledWith(2, 'b');
+  });
+
+  it('gives each instance its own cache.', async(): Promise<void> => {
+    class Counter {
+      private count = 0;
+
+      @cached()
+      public async get(): Promise<number> {
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const first = new Counter();
+    const second = new Counter();
+    await expect(first.get()).resolves.toBe(0);
+    await expect(second.get()).resolves.toBe(0);
+    await expect(first.get()).resolves.toBe(0);
+  });
+
+  it('can key a WeakMap-backed cache on object identity.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      private count = 0;
+
+      @cached({ weak: true })
+      public async get(key: object): Promise<number> {
+        spy(key);
+        const value = this.count;
+        this.count += 1;
+        return value;
+      }
+    }
+    const store = new Store();
+    const key1 = {};
+    const key2 = {};
+    await expect(store.get(key1)).resolves.toBe(0);
+    await expect(store.get(key1)).resolves.toBe(0);
+    await expect(store.get(key2)).resolves.toBe(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports deriving the cache key from all arguments.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      @cached({ key: (a: string, b: string): string => `${a}:${b}` })
+      public async get(a: string, b: string): Promise<string> {
+        spy();
+        return `${a}${b}`;
+      }
+    }
+    const store = new Store();
+    await expect(store.get('a', 'b')).resolves.toBe('ab');
+    await expect(store.get('a', 'b')).resolves.toBe('ab');
+    await expect(store.get('a', 'c')).resolves.toBe('ac');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates concurrent calls onto a single computation.', async(): Promise<void> => {
+    const spy = jest.fn();
+    class Store {
+      @cached()
+      public async get(key: string): Promise<string> {
+        spy();
+        return key;
+      }
+    }
+    const store = new Store();
+    const [ first, second ] = await Promise.all([ store.get('a'), store.get('a') ]);
+    expect(first).toBe('a');
+    expect(second).toBe('a');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the method after a rejection by default.', async(): Promise<void> => {
+    let calls = 0;
+    class Store {
+      @cached()
+      public async get(key: string): Promise<number> {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error(`fail-${key}`);
+        }
+        return 5;
+      }
+    }
+    const store = new Store();
+    await expect(store.get('a')).rejects.toThrow('fail-a');
+    await expect(store.get('a')).resolves.toBe(5);
+    expect(calls).toBe(2);
+  });
+});

--- a/test/unit/util/caching/CachedDecorator.test.ts
+++ b/test/unit/util/caching/CachedDecorator.test.ts
@@ -89,7 +89,10 @@ describe('The cached decorator', (): void => {
       }
     }
     const store = new Store();
-    const [ first, second ] = await Promise.all([ store.get('a'), store.get('a') ]);
+    const firstPromise = store.get('a');
+    const secondPromise = store.get('a');
+    expect(firstPromise).toBe(secondPromise);
+    const [ first, second ] = await Promise.all([ firstPromise, secondPromise ]);
     expect(first).toBe('a');
     expect(second).toBe('a');
     expect(spy).toHaveBeenCalledTimes(1);

--- a/test/unit/util/caching/PromiseCache.test.ts
+++ b/test/unit/util/caching/PromiseCache.test.ts
@@ -1,0 +1,80 @@
+import { PromiseCache } from '../../../../src/util/caching/PromiseCache';
+
+describe('A PromiseCache', (): void => {
+  it('computes and caches a value on a miss and reuses it on a hit.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    const factory = jest.fn(async(): Promise<number> => 1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(1);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the key to the factory.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, string>();
+    const factory = jest.fn(async(key: string): Promise<string> => `v:${key}`);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe('v:a');
+    expect(factory).toHaveBeenLastCalledWith('a');
+  });
+
+  it('caches separate values for separate keys.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    let count = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      const value = count;
+      count += 1;
+      return value;
+    });
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate('b', factory)).resolves.toBe(1);
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(0);
+  });
+
+  it('deduplicates concurrent calls for the same key onto a single computation.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    const factory = jest.fn(async(): Promise<number> => 42);
+    const [ first, second ] = await Promise.all([ cache.getOrCreate('a', factory), cache.getOrCreate('a', factory) ]);
+    expect(first).toBe(42);
+    expect(second).toBe(42);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports a WeakMap backing store keyed on object identity.', async(): Promise<void> => {
+    const cache = new PromiseCache<object, number>(new WeakMap());
+    const key1 = {};
+    const key2 = {};
+    let count = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      const value = count;
+      count += 1;
+      return value;
+    });
+    await expect(cache.getOrCreate(key1, factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate(key1, factory)).resolves.toBe(0);
+    await expect(cache.getOrCreate(key2, factory)).resolves.toBe(1);
+  });
+
+  it('evicts an entry whose promise rejects so it is retried.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>();
+    let calls = 0;
+    const factory = jest.fn(async(): Promise<number> => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error('fail');
+      }
+      return 5;
+    });
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    await expect(cache.getOrCreate('a', factory)).resolves.toBe(5);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps a rejected entry cached when evictOnError is disabled.', async(): Promise<void> => {
+    const cache = new PromiseCache<string, number>(new Map(), { evictOnError: false });
+    const factory = jest.fn(async(): Promise<number> => {
+      throw new Error('fail');
+    });
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/unit/util/caching/PromiseCache.test.ts
+++ b/test/unit/util/caching/PromiseCache.test.ts
@@ -32,7 +32,10 @@ describe('A PromiseCache', (): void => {
   it('deduplicates concurrent calls for the same key onto a single computation.', async(): Promise<void> => {
     const cache = new PromiseCache<string, number>();
     const factory = jest.fn(async(): Promise<number> => 42);
-    const [ first, second ] = await Promise.all([ cache.getOrCreate('a', factory), cache.getOrCreate('a', factory) ]);
+    const firstPromise = cache.getOrCreate('a', factory);
+    const secondPromise = cache.getOrCreate('a', factory);
+    expect(firstPromise).toBe(secondPromise);
+    const [ first, second ] = await Promise.all([ firstPromise, secondPromise ]);
     expect(first).toBe(42);
     expect(second).toBe(42);
     expect(factory).toHaveBeenCalledTimes(1);
@@ -66,6 +69,19 @@ describe('A PromiseCache', (): void => {
     await expect(cache.getOrCreate('a', factory)).rejects.toThrow('fail');
     await expect(cache.getOrCreate('a', factory)).resolves.toBe(5);
     expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not evict a newer entry when an earlier promise rejects.', async(): Promise<void> => {
+    const store = new Map<string, Promise<number>>();
+    const cache = new PromiseCache<string, number>(store);
+    const firstPromise = cache.getOrCreate('a', async(): Promise<number> => {
+      throw new Error('fail');
+    });
+    const newerPromise = Promise.resolve(5);
+    store.set('a', newerPromise);
+
+    await expect(firstPromise).rejects.toThrow('fail');
+    expect(store.get('a')).toBe(newerPromise);
   });
 
   it('keeps a rejected entry cached when evictOnError is disabled.', async(): Promise<void> => {


### PR DESCRIPTION
#### 📁 Related issues

Addresses #2229.

#### ✍️ Description

Adds two small asynchronous caching utilities:

- `PromiseCache<TKey, TValue>` caches promises by key, deduplicating concurrent
  computations. Its injected `Map`/`WeakMap`-compatible store determines entry
  lifetime, and rejected promises are evicted by default.
- `cached(...)` applies a per-instance `PromiseCache` to an asynchronous method.
  It supports custom key derivation and `WeakMap` storage for object keys.

The implementation is exported through `src/index.ts`. This PR introduces the
shared abstraction only; performance measurements belong in changes that
adopt it on an existing hot path.

The utilities are used by these PRs on my fork:

- [jeswr/CommunitySolidServer#24](https://github.com/jeswr/CommunitySolidServer/pull/24)
  uses `PromiseCache` to cache compiled EJS and Handlebars templates by path.
- [jeswr/CommunitySolidServer#31](https://github.com/jeswr/CommunitySolidServer/pull/31)
  uses WeakMap-backed promise caches to deduplicate effective ACL and store
  lookups by `ResourceIdentifier`.

Both PRs are stacked on this work and should be rebased after it lands.

Local verification on current `versions/next-major`:

- source and test TypeScript compilation
- ESLint on all changed TypeScript files and Markdown lint on the release notes
- 14 focused unit tests with 100% statement, branch, function, and line coverage,
  covering promise identity, concurrent deduplication, rejection behavior and
  eviction races, `Map`/`WeakMap` storage, key derivation, and per-instance
  isolation

The intended semver level is **minor**.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label - _**This is a minor change, I do not have permission to apply labels**_
    * semver.minor: Backwards compatible feature additions.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [x] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [x] any relevant documentation was updated to reflect the changes in this PR.
