### PR TITLE
Pod quota counter

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -114,6 +114,32 @@ so the above values would result in a pod at `http://test.example.com/` instead.
 A file-based server that limits the amount of data a user can put in a pod.
 The values in the configuration determine the limit.
 
+## pod-quota-counter-file.json
+
+A storage backend that replaces the default per-write size calculation by an
+incremental per-pod byte counter. Where the default quota setup walks the whole
+pod on every write, this counter is updated O(1) per write and persisted to a
+per-pod sidecar (`/.internal/css-quota.json`), so quota checks are constant-time
+after a one-time bootstrap walk of each pod.
+It is not a standalone server configuration: import
+`css:config/storage/backend/quota/pod-quota-counter-file.json` on top of a quota
+server configuration (such as `quota-file.json`) or alongside
+`css:config/storage/backend/pod-quota-file.json` to opt in.
+The default quota configuration is unchanged.
+
+The counter is refreshed by a full walk on first access, on pod-root mtime
+changes, and (to bound staleness from deep out-of-band changes) whenever it is
+older than `maxAgeMs` (default 24 h). The max age can be changed by overriding
+`urn:solid-server:default:QuotaCounter`, e.g. to one week:
+
+```json
+{
+  "@type": "Override",
+  "overrideInstance": { "@id": "urn:solid-server:default:QuotaCounter" },
+  "overrideParameters": { "maxAgeMs": 604800000 }
+}
+```
+
 ## path-routing.json
 
 This configuration serves as an example of how a server can be configured

--- a/config/storage/backend/quota/pod-quota-counter-file.json
+++ b/config/storage/backend/quota/pod-quota-counter-file.json
@@ -1,9 +1,9 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
-  "comment": "Design C: incremental per-pod byte counter. QuotaCounter + IncrementalSizeReporter + QuotaDeltaDataAccessor (delta hook). After a pod's one-time bootstrap walk, writes are O(1); a full du/Node walk only seeds/repairs a pod's counter. Import this on top of the existing pod-quota backend (e.g. alongside css:config/storage/backend/pod-quota-file.json) to opt in — the default pod-quota-file.json is unchanged.",
+  "comment": "Design C: incremental per-pod byte counter. QuotaCounter + IncrementalSizeReporter + QuotaDeltaDataAccessor (delta hook). After a pod's one-time bootstrap walk, writes are O(1); a full du/Node walk only seeds/repairs a pod's counter. Import this on top of the existing pod-quota backend (e.g. alongside css:config/storage/backend/pod-quota-file.json) to opt in — the default pod-quota-file.json is unchanged. Benchmark (3 000 x 1 KiB files): full walk ~365 ms vs. O(1) counter read ~0.25 ms per quota check (see scripts/benchmark-quota-counter.cjs).",
   "@graph": [
     {
-      "comment": "The shared per-pod counter (in-memory + sidecar + recount engine).",
+      "comment": "The shared per-pod counter (in-memory + sidecar + recount engine). maxAgeMs bounds how stale a counter may be: an older counter is re-walked on access (0 disables the age check, leaving only mtime staleness). Override urn:solid-server:default:QuotaCounter to change it.",
       "@id": "urn:solid-server:default:QuotaCounter",
       "@type": "QuotaCounter",
       "fileIdentifierMapper": {
@@ -14,7 +14,8 @@
       },
       "ignoreFolders": [
         "(^|/)\\.internal$"
-      ]
+      ],
+      "maxAgeMs": 86400000
     },
     {
       "comment": "SizeReporter backed by the counter: O(1) pod reads, single stat for resources.",

--- a/config/storage/backend/quota/pod-quota-counter-file.json
+++ b/config/storage/backend/quota/pod-quota-counter-file.json
@@ -1,9 +1,9 @@
 {
   "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
-  "comment": "Design C: incremental per-pod byte counter. QuotaCounter + IncrementalSizeReporter + QuotaDeltaDataAccessor (delta hook). After a pod's one-time bootstrap walk, writes are O(1); a full du/Node walk only seeds/repairs a pod's counter. Import this on top of the existing pod-quota backend (e.g. alongside css:config/storage/backend/pod-quota-file.json) to opt in — the default pod-quota-file.json is unchanged. Benchmark (3 000 x 1 KiB files): full walk ~365 ms vs. O(1) counter read ~0.25 ms per quota check (see scripts/benchmark-quota-counter.cjs).",
+  "comment": "incremental per-pod byte counter",
   "@graph": [
     {
-      "comment": "The shared per-pod counter (in-memory + sidecar + recount engine). maxAgeMs bounds how stale a counter may be: an older counter is re-walked on access (0 disables the age check, leaving only mtime staleness). Override urn:solid-server:default:QuotaCounter to change it.",
+      "comment": "The shared per-pod counter",
       "@id": "urn:solid-server:default:QuotaCounter",
       "@type": "QuotaCounter",
       "fileIdentifierMapper": {
@@ -18,7 +18,7 @@
       "maxAgeMs": 86400000
     },
     {
-      "comment": "SizeReporter backed by the counter: O(1) pod reads, single stat for resources.",
+      "comment": "SizeReporter backed by the counter",
       "@type": "Override",
       "overrideInstance": {
         "@id": "urn:solid-server:default:SizeReporter"
@@ -31,7 +31,7 @@
       }
     },
     {
-      "comment": "Delta hook: wraps the accessor chain and feeds per-write deltas to the counter. Preserves the content-length filter and the QuotaValidator.",
+      "comment": "Delta hook",
       "@type": "Override",
       "overrideInstance": {
         "@id": "urn:solid-server:default:FileDataAccessor"

--- a/config/storage/backend/quota/pod-quota-counter-file.json
+++ b/config/storage/backend/quota/pod-quota-counter-file.json
@@ -1,0 +1,64 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "comment": "Design C: incremental per-pod byte counter. QuotaCounter + IncrementalSizeReporter + QuotaDeltaDataAccessor (delta hook). After a pod's one-time bootstrap walk, writes are O(1); a full du/Node walk only seeds/repairs a pod's counter. Import this on top of the existing pod-quota backend (e.g. alongside css:config/storage/backend/pod-quota-file.json) to opt in — the default pod-quota-file.json is unchanged.",
+  "@graph": [
+    {
+      "comment": "The shared per-pod counter (in-memory + sidecar + recount engine).",
+      "@id": "urn:solid-server:default:QuotaCounter",
+      "@type": "QuotaCounter",
+      "fileIdentifierMapper": {
+        "@id": "urn:solid-server:default:FileIdentifierMapper"
+      },
+      "rootFilePath": {
+        "@id": "urn:solid-server:default:variable:rootFilePath"
+      },
+      "ignoreFolders": [
+        "(^|/)\\.internal$"
+      ]
+    },
+    {
+      "comment": "SizeReporter backed by the counter: O(1) pod reads, single stat for resources.",
+      "@type": "Override",
+      "overrideInstance": {
+        "@id": "urn:solid-server:default:SizeReporter"
+      },
+      "overrideParameters": {
+        "@type": "IncrementalSizeReporter",
+        "counter": {
+          "@id": "urn:solid-server:default:QuotaCounter"
+        }
+      }
+    },
+    {
+      "comment": "Delta hook: wraps the accessor chain and feeds per-write deltas to the counter. Preserves the content-length filter and the QuotaValidator.",
+      "@type": "Override",
+      "overrideInstance": {
+        "@id": "urn:solid-server:default:FileDataAccessor"
+      },
+      "overrideParameters": {
+        "@type": "QuotaDeltaDataAccessor",
+        "fileIdentifierMapper": {
+          "@id": "urn:solid-server:default:FileIdentifierMapper"
+        },
+        "identifierStrategy": {
+          "@id": "urn:solid-server:default:IdentifierStrategy"
+        },
+        "counter": {
+          "@id": "urn:solid-server:default:QuotaCounter"
+        },
+        "accessor": {
+          "@type": "FilterMetadataDataAccessor",
+          "accessor": {
+            "@id": "urn:solid-server:default:ValidatingFileDataAccessor"
+          },
+          "filters": [
+            {
+              "@type": "FilterPattern",
+              "predicate": "http://www.w3.org/2011/http-headers#content-length"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/scripts/benchmark-quota-counter.cjs
+++ b/scripts/benchmark-quota-counter.cjs
@@ -1,0 +1,78 @@
+/* eslint-disable no-console */
+// Benchmark: standard full-pod walk vs. the incremental QuotaCounter.
+// Run with: node scripts/benchmark-quota-counter.cjs
+'use strict';
+
+const { promises: fs } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join } = require('node:path');
+const { FileSizeReporter } = require('../dist/storage/size-reporter/FileSizeReporter');
+const { DuSizeReporter } = require('../dist/storage/size-reporter/DuSizeReporter');
+const { QuotaCounter } = require('../dist/storage/quota/QuotaCounter');
+
+const IGNORE = [ '(^|/)\\.internal$' ];
+const FILES = 3000;
+const FILE_SIZE = 1024;
+
+async function timeMsAsync(fn) {
+  const start = process.hrtime.bigint();
+  await fn();
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+async function main() {
+  const root = await fs.mkdtemp(join(tmpdir(), 'quota-bench-'));
+  const podPath = join(root, 'alice');
+  await fs.mkdir(podPath, { recursive: true });
+  const payload = Buffer.alloc(FILE_SIZE, 1);
+  for (let i = 0; i < FILES; i++) {
+    await fs.writeFile(join(podPath, `f${i}.bin`), payload);
+  }
+
+  const mapper = {
+    async mapUrlToFilePath(identifier, isMetadata) {
+      const url = new URL(identifier.path);
+      const base = join(root, url.pathname);
+      return { identifier, filePath: isMetadata ? `${base}.meta` : base, contentType: undefined, isMetadata };
+    },
+    async mapFilePathToUrl() {
+      throw new Error('Not implemented');
+    },
+  };
+  const POD = { path: 'http://example.com/alice/' };
+
+  // 1. Standard FileSizeReporter: one full pod walk (what the default quota
+  //    setup performs on every write).
+  const fileReporter = new FileSizeReporter(mapper, root);
+  const tWalk = await timeMsAsync(() => fileReporter.getSize(POD));
+  console.log(`FileSizeReporter  full pod walk (${FILES} x ${FILE_SIZE}B): ${tWalk.toFixed(2)} ms`);
+
+  // 2. QuotaCounter bootstrap: first access, fresh counter -> one full walk.
+  const counter = new QuotaCounter(mapper, root, IGNORE);
+  await counter.register(POD);
+  const tBootstrap = await timeMsAsync(() => counter.getSize(POD));
+  console.log(`QuotaCounter      bootstrap walk:                    ${tBootstrap.toFixed(2)} ms`);
+
+  // 3. QuotaCounter after bootstrap: O(1) in-memory read.
+  const tCached = await timeMsAsync(() => counter.getSize(POD));
+  console.log(`QuotaCounter      getSize (cached, O(1)):            ${tCached.toFixed(3)} ms`);
+
+  // 4. QuotaCounter.add: O(1) delta + atomic sidecar persist (per-write cost).
+  const tAdd = await timeMsAsync(() => counter.add(POD, 100));
+  console.log(`QuotaCounter      add delta + sidecar persist:       ${tAdd.toFixed(3)} ms`);
+
+  // 5. DuSizeReporter: cached du/Node walker (the A+B design).
+  const duReporter = new DuSizeReporter(mapper, root, IGNORE, 5000);
+  const tDu = await timeMsAsync(() => duReporter.getSize(POD));
+  console.log(`DuSizeReporter    first getSize (walk):              ${tDu.toFixed(2)} ms`);
+  const tDuCached = await timeMsAsync(() => duReporter.getSize(POD));
+  console.log(`DuSizeReporter    cached getSize:                    ${tDuCached.toFixed(3)} ms`);
+
+  await fs.rm(root, { recursive: true, force: true });
+  console.log(`\nSpeedup per write check: ${(tWalk / Math.max(tCached, 0.001)).toFixed(0)}x (walk vs. O(1) counter)`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -510,7 +510,12 @@ export * from './storage/patch/SparqlUpdatePatcher';
 
 // Storage/Quota
 export * from './storage/quota/GlobalQuotaStrategy';
+export * from './storage/quota/IncrementalSizeReporter';
+export * from './storage/quota/InternalPath';
+export * from './storage/quota/PodDiscovery';
 export * from './storage/quota/PodQuotaStrategy';
+export * from './storage/quota/QuotaCounter';
+export * from './storage/quota/QuotaDeltaDataAccessor';
 export * from './storage/quota/QuotaStrategy';
 
 // Storage/Routing
@@ -521,6 +526,7 @@ export * from './storage/routing/RegexRouterRule';
 export * from './storage/routing/RouterRule';
 
 // Storage/Size-Reporter
+export * from './storage/size-reporter/DuSizeReporter';
 export * from './storage/size-reporter/FileSizeReporter';
 export * from './storage/size-reporter/Size';
 export * from './storage/size-reporter/SizeReporter';

--- a/src/storage/quota/IncrementalSizeReporter.ts
+++ b/src/storage/quota/IncrementalSizeReporter.ts
@@ -1,0 +1,46 @@
+import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import type { Size } from '../size-reporter/Size';
+import { UNIT_BYTES } from '../size-reporter/Size';
+import type { SizeReporter } from '../size-reporter/SizeReporter';
+import type { QuotaCounter } from './QuotaCounter';
+
+/**
+ * {@link SizeReporter} backed by the incremental {@link QuotaCounter}.
+ *
+ * - `getSize(podRoot)` → **O(1)** counter read (recount only on bootstrap /
+ *   staleness).
+ * - `getSize(any other resource)` → single stat (used by
+ *   `QuotaStrategy.getAvailableSpace` to subtract the overwritten resource).
+ *
+ * Replaces `urn:solid-server:default:SizeReporter` in design C. The apparent
+ * byte unit is unchanged, so the configured quota limit keeps its meaning.
+ */
+export class IncrementalSizeReporter implements SizeReporter<unknown> {
+  private readonly counter: QuotaCounter;
+
+  public constructor(counter: QuotaCounter) {
+    this.counter = counter;
+  }
+
+  public getUnit(): string {
+    return UNIT_BYTES;
+  }
+
+  public async getSize(identifier: ResourceIdentifier): Promise<Size> {
+    if (await this.counter.isPodRoot(identifier)) {
+      return this.counter.getSize(identifier);
+    }
+    return { unit: UNIT_BYTES, amount: await this.counter.sizeOfResource(identifier) };
+  }
+
+  /** The size of a chunk is simply its length in bytes. */
+  public async calculateChunkSize(chunk: unknown): Promise<number> {
+    return Buffer.isBuffer(chunk) ? chunk.length : Number((chunk as { length?: number }).length) || 0;
+  }
+
+  /** The estimated size of a resource is simply the content-length header. */
+  public async estimateSize(metadata: RepresentationMetadata): Promise<number | undefined> {
+    return metadata.contentLength;
+  }
+}

--- a/src/storage/quota/IncrementalSizeReporter.ts
+++ b/src/storage/quota/IncrementalSizeReporter.ts
@@ -12,13 +12,6 @@ import type { QuotaCounter } from './QuotaCounter';
  *   staleness).
  * - `getSize(any other resource)` → single stat (used by
  *   `QuotaStrategy.getAvailableSpace` to subtract the overwritten resource).
- *
- * Replaces `urn:solid-server:default:SizeReporter` in design C. The apparent
- * byte unit is unchanged, so the configured quota limit keeps its meaning.
- *
- * On a 3 000-file pod a full `FileSizeReporter` walk takes ~365 ms, while this
- * reporter's O(1) counter read takes ~0.25 ms (see
- * `scripts/benchmark-quota-counter.cjs`).
  */
 export class IncrementalSizeReporter implements SizeReporter<unknown> {
   private readonly counter: QuotaCounter;
@@ -38,12 +31,10 @@ export class IncrementalSizeReporter implements SizeReporter<unknown> {
     return { unit: UNIT_BYTES, amount: await this.counter.sizeOfResource(identifier) };
   }
 
-  /** The size of a chunk is simply its length in bytes. */
   public async calculateChunkSize(chunk: unknown): Promise<number> {
     return Buffer.isBuffer(chunk) ? chunk.length : Number((chunk as { length?: number }).length) || 0;
   }
 
-  /** The estimated size of a resource is simply the content-length header. */
   public async estimateSize(metadata: RepresentationMetadata): Promise<number | undefined> {
     return metadata.contentLength;
   }

--- a/src/storage/quota/IncrementalSizeReporter.ts
+++ b/src/storage/quota/IncrementalSizeReporter.ts
@@ -15,6 +15,10 @@ import type { QuotaCounter } from './QuotaCounter';
  *
  * Replaces `urn:solid-server:default:SizeReporter` in design C. The apparent
  * byte unit is unchanged, so the configured quota limit keeps its meaning.
+ *
+ * On a 3 000-file pod a full `FileSizeReporter` walk takes ~365 ms, while this
+ * reporter's O(1) counter read takes ~0.25 ms (see
+ * `scripts/benchmark-quota-counter.cjs`).
  */
 export class IncrementalSizeReporter implements SizeReporter<unknown> {
   private readonly counter: QuotaCounter;

--- a/src/storage/quota/InternalPath.ts
+++ b/src/storage/quota/InternalPath.ts
@@ -1,0 +1,20 @@
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+
+/**
+ * CSS internal storage (locks, IDP adapter, ...) lives under `/.internal/`.
+ *
+ * IMPORTANT: `ResourceIdentifier.path` is the full canonical URL (e.g.
+ * `https://pod.example.org/.internal/...`), not a bare path — identifier
+ * strategies (e.g. `SubdomainIdentifierStrategy`) test it against URL regexes.
+ * We must extract the URL pathname before comparing, otherwise the check never
+ * matches. This works in both suffix and subdomain deployment modes.
+ */
+export function isInternalPath(identifier: ResourceIdentifier): boolean {
+  let path = identifier.path;
+  try {
+    path = new URL(identifier.path).pathname;
+  } catch {
+    // Not a parseable URL — use the raw path as-is.
+  }
+  return path === '/.internal' || path.startsWith('/.internal/');
+}

--- a/src/storage/quota/InternalPath.ts
+++ b/src/storage/quota/InternalPath.ts
@@ -1,14 +1,5 @@
 import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
 
-/**
- * CSS internal storage (locks, IDP adapter, ...) lives under `/.internal/`.
- *
- * IMPORTANT: `ResourceIdentifier.path` is the full canonical URL (e.g.
- * `https://pod.example.org/.internal/...`), not a bare path — identifier
- * strategies (e.g. `SubdomainIdentifierStrategy`) test it against URL regexes.
- * We must extract the URL pathname before comparing, otherwise the check never
- * matches. This works in both suffix and subdomain deployment modes.
- */
 export function isInternalPath(identifier: ResourceIdentifier): boolean {
   let path = identifier.path;
   try {

--- a/src/storage/quota/PodDiscovery.ts
+++ b/src/storage/quota/PodDiscovery.ts
@@ -7,12 +7,6 @@ import type { DataAccessor } from '../accessors/DataAccessor';
 
 /**
  * Finds the closest parent container that has `pim:Storage` as metadata.
- *
- * NOTE: like `PodQuotaStrategy.searchPimStorage` (post #2210), the metadata
- * is read BEFORE testing for a root container. In SUBDOMAIN mode every pod
- * root IS a root container, and a root container can be a pod — testing the
- * root first would return "no pod" for every subdomain pod root, silently
- * disabling pod quota there.
  */
 export async function discoverPod(
   identifier: ResourceIdentifier,

--- a/src/storage/quota/PodDiscovery.ts
+++ b/src/storage/quota/PodDiscovery.ts
@@ -1,0 +1,53 @@
+import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
+import type { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import { PIM, RDF } from '../../util/Vocabularies';
+import type { DataAccessor } from '../accessors/DataAccessor';
+
+/**
+ * Finds the closest parent container that has `pim:Storage` as metadata.
+ *
+ * NOTE: like `PodQuotaStrategy.searchPimStorage` (post #2210), the metadata
+ * is read BEFORE testing for a root container. In SUBDOMAIN mode every pod
+ * root IS a root container, and a root container can be a pod — testing the
+ * root first would return "no pod" for every subdomain pod root, silently
+ * disabling pod quota there.
+ */
+export async function discoverPod(
+  identifier: ResourceIdentifier,
+  accessor: DataAccessor,
+  identifierStrategy: IdentifierStrategy,
+): Promise<ResourceIdentifier | null> {
+  let metadata: RepresentationMetadata;
+  try {
+    metadata = await accessor.getMetadata(identifier);
+  } catch (error: unknown) {
+    if (NotFoundHttpError.isInstance(error)) {
+      // Resource and/or its metadata do not exist — walk up, but stop at a
+      // root container to avoid unbounded recursion.
+      if (identifierStrategy.isRootContainer(identifier)) {
+        return null;
+      }
+      return discoverPod(
+        identifierStrategy.getParentContainer(identifier),
+        accessor,
+        identifierStrategy,
+      );
+    }
+    throw error;
+  }
+  const hasPimStorage = metadata.getAll(RDF.terms.type)
+    .some((term): boolean => term.value === PIM.Storage);
+  if (hasPimStorage) {
+    return identifier;
+  }
+  if (identifierStrategy.isRootContainer(identifier)) {
+    return null;
+  }
+  return discoverPod(
+    identifierStrategy.getParentContainer(identifier),
+    accessor,
+    identifierStrategy,
+  );
+}

--- a/src/storage/quota/QuotaCounter.ts
+++ b/src/storage/quota/QuotaCounter.ts
@@ -17,28 +17,8 @@ interface CounterEntry {
 }
 
 /**
- * Incremental per-pod byte counter (design C).
- *
- * Keeps the apparent-byte total of every pod in memory, updated O(1) per
- * write by the {@link QuotaDeltaDataAccessor} delta hook, and persisted to a
- * per-pod sidecar (`<podRoot>/.internal/css-quota.json`, atomic rename) so
- * counters survive restarts. A full `du`/Node walk (via DuSizeReporter) is
- * only used to bootstrap a pod (first access, no sidecar) or recover a
- * de-synchronized counter.
- *
- * The counter is a cache; the filesystem is the source of truth. Staleness
- * (out-of-band changes, crash window) is detected cheaply by comparing the
- * pod root directory's mtime against the recorded one, then re-walking once.
- *
- * Because the pod root mtime only changes for direct children, deep out-of-band
- * changes are invisible to that check. An optional max age (`maxAgeMs`, 0 =
- * disabled) bounds this window: a counter older than the max age is always
- * re-walked on access, guaranteeing the total is at most `maxAgeMs` old.
- *
- * Benchmark (Windows, Node-walk fallback, 3 000 x 1 KiB files in one pod, see
- * `scripts/benchmark-quota-counter.cjs`): one full pod walk ~365 ms, an O(1)
- * counter read ~0.25 ms (~1 000-1 500x faster per quota check), and a delta +
- * sidecar persist ~4 ms per write.
+ * Incremental per-pod byte counter.
+ * The counter is a cache; the filesystem is the source of truth.
  */
 export class QuotaCounter {
   private readonly fileIdentifierMapper: FileIdentifierMapper;
@@ -64,26 +44,16 @@ export class QuotaCounter {
     this.walker = new DuSizeReporter(fileIdentifierMapper, rootFilePath, ignoreFolders, 0);
   }
 
-  /** The QuotaCounter always reports in bytes. */
   public getUnit(): string {
     return UNIT_BYTES;
   }
 
-  /**
-   * Returns the pod's current total, performing a recount (walk) only when
-   * the pod has no valid counter (first access, no sidecar, or staleness).
-   */
   public async getSize(podIdentifier: ResourceIdentifier): Promise<Size> {
     const path = await this.mapDataPath(podIdentifier);
     const entry = await this.ensureEntry(path, podIdentifier);
     return { unit: UNIT_BYTES, amount: entry.total };
   }
 
-  /**
-   * Marks a path as a pod root so {@link IncrementalSizeReporter} routes
-   * pod-root identifiers to the counter. Called by the delta hook when it
-   * first discovers a pod.
-   */
   public async register(podIdentifier: ResourceIdentifier): Promise<void> {
     const path = await this.mapDataPath(podIdentifier);
     if (!this.entries.has(path)) {
@@ -91,16 +61,10 @@ export class QuotaCounter {
     }
   }
 
-  /** Whether the given identifier maps to a known pod root. */
   public async isPodRoot(identifier: ResourceIdentifier): Promise<boolean> {
     return this.entries.has(await this.mapDataPath(identifier));
   }
 
-  /**
-   * Applies a size delta to the pod. Updates the in-memory counter and
-   * persists the sidecar atomically. Per-pod mutex serializes concurrent
-   * writes.
-   */
   public async add(podIdentifier: ResourceIdentifier, delta: number): Promise<void> {
     const path = await this.mapDataPath(podIdentifier);
     await this.withLock(path, async(): Promise<void> => {
@@ -127,12 +91,6 @@ export class QuotaCounter {
     });
   }
 
-  /**
-   * Apparent size of a single resource (not a pod root) — used by the
-   * reporter for the overwritten-resource subtraction in
-   * `QuotaStrategy.getAvailableSpace`. Single stat for a document; walk for a
-   * container.
-   */
   public async sizeOfResource(identifier: ResourceIdentifier): Promise<number> {
     const filePath = await this.mapDataPath(identifier);
     try {
@@ -147,16 +105,11 @@ export class QuotaCounter {
     }
   }
 
-  /** Maps an identifier to its data file path (normalized). */
   public async mapDataPath(identifier: ResourceIdentifier): Promise<string> {
     const { filePath } = await this.fileIdentifierMapper.mapUrlToFilePath(identifier, false);
     return normalizeFilePath(filePath);
   }
 
-  /**
-   * Full apparent-byte walk of a resource/container (used by the delta hook
-   * for container before/after sizing — rare, e.g. create/delete container).
-   */
   public async walk(identifier: ResourceIdentifier): Promise<number> {
     return (await this.walker.getSize(identifier)).amount;
   }
@@ -198,11 +151,6 @@ export class QuotaCounter {
     });
   }
 
-  /**
-   * Whether the entry can be trusted without a recount: it must be valid and,
-   * when a max age is configured, not older than `maxAgeMs`. A `maxAgeMs` of 0
-   * (or less) disables the age check entirely.
-   */
   private isFresh(entry: CounterEntry | undefined): entry is CounterEntry {
     return entry !== undefined && entry.valid &&
       (this.maxAgeMs <= 0 || Date.now() - entry.updatedAt < this.maxAgeMs);
@@ -264,12 +212,6 @@ export class QuotaCounter {
     }
   }
 
-  /**
-   * Persist, then record the pod root mtime AFTER the persist. Persisting the
-   * sidecar may create the `.internal/` directory (a new pod-root child), which
-   * bumps the pod root's mtime — recording the mtime before would leave every
-   * subsequent read thinking the counter is stale.
-   */
   private async persistWithMtime(path: string, entry: CounterEntry): Promise<void> {
     await this.persist(path, entry);
     entry.podMtimeMs = await this.podRootMtime(path);

--- a/src/storage/quota/QuotaCounter.ts
+++ b/src/storage/quota/QuotaCounter.ts
@@ -12,6 +12,8 @@ interface CounterEntry {
   total: number;
   valid: boolean;
   podMtimeMs: number;
+  /** Epoch ms at which the counter was last known to be correct. */
+  updatedAt: number;
 }
 
 /**
@@ -27,11 +29,22 @@ interface CounterEntry {
  * The counter is a cache; the filesystem is the source of truth. Staleness
  * (out-of-band changes, crash window) is detected cheaply by comparing the
  * pod root directory's mtime against the recorded one, then re-walking once.
+ *
+ * Because the pod root mtime only changes for direct children, deep out-of-band
+ * changes are invisible to that check. An optional max age (`maxAgeMs`, 0 =
+ * disabled) bounds this window: a counter older than the max age is always
+ * re-walked on access, guaranteeing the total is at most `maxAgeMs` old.
+ *
+ * Benchmark (Windows, Node-walk fallback, 3 000 x 1 KiB files in one pod, see
+ * `scripts/benchmark-quota-counter.cjs`): one full pod walk ~365 ms, an O(1)
+ * counter read ~0.25 ms (~1 000-1 500x faster per quota check), and a delta +
+ * sidecar persist ~4 ms per write.
  */
 export class QuotaCounter {
   private readonly fileIdentifierMapper: FileIdentifierMapper;
   private readonly rootFilePath: string;
   private readonly sidecarRelativePath: string;
+  private readonly maxAgeMs: number;
   private readonly walker: DuSizeReporter;
   private readonly entries = new Map<string, CounterEntry>();
   private readonly locks = new Map<string, Promise<void>>();
@@ -41,10 +54,12 @@ export class QuotaCounter {
     rootFilePath: string,
     ignoreFolders: string[] = [],
     sidecarRelativePath = '/.internal/css-quota.json',
+    maxAgeMs = 0,
   ) {
     this.fileIdentifierMapper = fileIdentifierMapper;
     this.rootFilePath = normalizeFilePath(rootFilePath);
     this.sidecarRelativePath = sidecarRelativePath;
+    this.maxAgeMs = maxAgeMs;
     // Dedicated walker with no cache — every call is a fresh recount.
     this.walker = new DuSizeReporter(fileIdentifierMapper, rootFilePath, ignoreFolders, 0);
   }
@@ -72,7 +87,7 @@ export class QuotaCounter {
   public async register(podIdentifier: ResourceIdentifier): Promise<void> {
     const path = await this.mapDataPath(podIdentifier);
     if (!this.entries.has(path)) {
-      this.entries.set(path, { total: 0, valid: false, podMtimeMs: 0 });
+      this.entries.set(path, { total: 0, valid: false, podMtimeMs: 0, updatedAt: Date.now() });
     }
   }
 
@@ -89,9 +104,10 @@ export class QuotaCounter {
   public async add(podIdentifier: ResourceIdentifier, delta: number): Promise<void> {
     const path = await this.mapDataPath(podIdentifier);
     await this.withLock(path, async(): Promise<void> => {
-      const entry = this.entries.get(path) ?? { total: 0, valid: false, podMtimeMs: 0 };
+      const entry = this.entries.get(path) ?? { total: 0, valid: false, podMtimeMs: 0, updatedAt: Date.now() };
       entry.total += delta;
       entry.valid = true;
+      entry.updatedAt = Date.now();
       this.entries.set(path, entry);
       await this.persistWithMtime(path, entry);
     });
@@ -149,7 +165,7 @@ export class QuotaCounter {
 
   private async ensureEntry(path: string, podIdentifier: ResourceIdentifier): Promise<CounterEntry> {
     let entry = this.entries.get(path);
-    if (entry?.valid) {
+    if (this.isFresh(entry)) {
       const mtime = await this.podRootMtime(path);
       if (entry.podMtimeMs === mtime) {
         return entry;
@@ -159,27 +175,37 @@ export class QuotaCounter {
     // Try the sidecar first (persisted counter), then a full walk.
     return this.withLock(path, async(): Promise<CounterEntry> => {
       entry = this.entries.get(path);
-      if (entry?.valid) {
+      if (this.isFresh(entry)) {
         const mtime = await this.podRootMtime(path);
         if (entry.podMtimeMs === mtime) {
           return entry;
         }
       }
       const loaded = await this.loadSidecar(path);
-      if (loaded?.valid) {
+      if (this.isFresh(loaded)) {
         const mtime = await this.podRootMtime(path);
         if (loaded.podMtimeMs === mtime) {
           this.entries.set(path, loaded);
           return loaded;
         }
       }
-      // No valid counter — full walk (bootstrap / recovery).
+      // No valid counter — full walk (bootstrap / recovery / max-age expiry).
       const total = (await this.walker.getSize(podIdentifier)).amount;
-      const fresh: CounterEntry = { total, valid: true, podMtimeMs: 0 };
+      const fresh: CounterEntry = { total, valid: true, podMtimeMs: 0, updatedAt: Date.now() };
       this.entries.set(path, fresh);
       await this.persistWithMtime(path, fresh);
       return fresh;
     });
+  }
+
+  /**
+   * Whether the entry can be trusted without a recount: it must be valid and,
+   * when a max age is configured, not older than `maxAgeMs`. A `maxAgeMs` of 0
+   * (or less) disables the age check entirely.
+   */
+  private isFresh(entry: CounterEntry | undefined): entry is CounterEntry {
+    return entry !== undefined && entry.valid &&
+      (this.maxAgeMs <= 0 || Date.now() - entry.updatedAt < this.maxAgeMs);
   }
 
   private async podRootMtime(path: string): Promise<number> {
@@ -204,7 +230,16 @@ export class QuotaCounter {
         'total' in parsed && 'podMtimeMs' in parsed &&
         typeof parsed.total === 'number' && typeof parsed.podMtimeMs === 'number'
       ) {
-        return { total: parsed.total, valid: true, podMtimeMs: parsed.podMtimeMs };
+        // Older sidecars may lack `updatedAt`; treat them as immediately stale
+        // so they are refreshed once when a max age is configured.
+        let updatedAt = 0;
+        if ('updatedAt' in parsed && typeof parsed.updatedAt === 'string') {
+          updatedAt = Date.parse(parsed.updatedAt);
+          if (!Number.isFinite(updatedAt)) {
+            updatedAt = 0;
+          }
+        }
+        return { total: parsed.total, valid: true, podMtimeMs: parsed.podMtimeMs, updatedAt };
       }
     } catch {
       // Missing or malformed sidecar → recount.

--- a/src/storage/quota/QuotaCounter.ts
+++ b/src/storage/quota/QuotaCounter.ts
@@ -1,0 +1,265 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import { joinFilePath, normalizeFilePath } from '../../util/PathUtil';
+import type { FileIdentifierMapper } from '../mapping/FileIdentifierMapper';
+import type { Size } from '../size-reporter/Size';
+import { UNIT_BYTES } from '../size-reporter/Size';
+import { DuSizeReporter } from '../size-reporter/DuSizeReporter';
+
+// In-memory counter entry for one pod.
+interface CounterEntry {
+  total: number;
+  valid: boolean;
+  podMtimeMs: number;
+}
+
+/**
+ * Incremental per-pod byte counter (design C).
+ *
+ * Keeps the apparent-byte total of every pod in memory, updated O(1) per
+ * write by the {@link QuotaDeltaDataAccessor} delta hook, and persisted to a
+ * per-pod sidecar (`<podRoot>/.internal/css-quota.json`, atomic rename) so
+ * counters survive restarts. A full `du`/Node walk (via DuSizeReporter) is
+ * only used to bootstrap a pod (first access, no sidecar) or recover a
+ * de-synchronized counter.
+ *
+ * The counter is a cache; the filesystem is the source of truth. Staleness
+ * (out-of-band changes, crash window) is detected cheaply by comparing the
+ * pod root directory's mtime against the recorded one, then re-walking once.
+ */
+export class QuotaCounter {
+  private readonly fileIdentifierMapper: FileIdentifierMapper;
+  private readonly rootFilePath: string;
+  private readonly sidecarRelativePath: string;
+  private readonly walker: DuSizeReporter;
+  private readonly entries = new Map<string, CounterEntry>();
+  private readonly locks = new Map<string, Promise<void>>();
+
+  public constructor(
+    fileIdentifierMapper: FileIdentifierMapper,
+    rootFilePath: string,
+    ignoreFolders: string[] = [],
+    sidecarRelativePath = '/.internal/css-quota.json',
+  ) {
+    this.fileIdentifierMapper = fileIdentifierMapper;
+    this.rootFilePath = normalizeFilePath(rootFilePath);
+    this.sidecarRelativePath = sidecarRelativePath;
+    // Dedicated walker with no cache — every call is a fresh recount.
+    this.walker = new DuSizeReporter(fileIdentifierMapper, rootFilePath, ignoreFolders, 0);
+  }
+
+  /** The QuotaCounter always reports in bytes. */
+  public getUnit(): string {
+    return UNIT_BYTES;
+  }
+
+  /**
+   * Returns the pod's current total, performing a recount (walk) only when
+   * the pod has no valid counter (first access, no sidecar, or staleness).
+   */
+  public async getSize(podIdentifier: ResourceIdentifier): Promise<Size> {
+    const path = await this.mapDataPath(podIdentifier);
+    const entry = await this.ensureEntry(path, podIdentifier);
+    return { unit: UNIT_BYTES, amount: entry.total };
+  }
+
+  /**
+   * Marks a path as a pod root so {@link IncrementalSizeReporter} routes
+   * pod-root identifiers to the counter. Called by the delta hook when it
+   * first discovers a pod.
+   */
+  public async register(podIdentifier: ResourceIdentifier): Promise<void> {
+    const path = await this.mapDataPath(podIdentifier);
+    if (!this.entries.has(path)) {
+      this.entries.set(path, { total: 0, valid: false, podMtimeMs: 0 });
+    }
+  }
+
+  /** Whether the given identifier maps to a known pod root. */
+  public async isPodRoot(identifier: ResourceIdentifier): Promise<boolean> {
+    return this.entries.has(await this.mapDataPath(identifier));
+  }
+
+  /**
+   * Applies a size delta to the pod. Updates the in-memory counter and
+   * persists the sidecar atomically. Per-pod mutex serializes concurrent
+   * writes.
+   */
+  public async add(podIdentifier: ResourceIdentifier, delta: number): Promise<void> {
+    const path = await this.mapDataPath(podIdentifier);
+    await this.withLock(path, async(): Promise<void> => {
+      const entry = this.entries.get(path) ?? { total: 0, valid: false, podMtimeMs: 0 };
+      entry.total += delta;
+      entry.valid = true;
+      this.entries.set(path, entry);
+      await this.persistWithMtime(path, entry);
+    });
+  }
+
+  /** Drops the counter for a pod and removes its sidecar (pod deletion). */
+  public async remove(podIdentifier: ResourceIdentifier): Promise<void> {
+    const path = await this.mapDataPath(podIdentifier);
+    await this.withLock(path, async(): Promise<void> => {
+      this.entries.delete(path);
+      try {
+        await fs.rm(this.sidecarPath(path), { force: true });
+      } catch {
+        // Best-effort: dropping the in-memory counter is authoritative; a leftover
+        // sidecar is detected via pod-root mtime and re-walked on next access.
+      }
+    });
+  }
+
+  /**
+   * Apparent size of a single resource (not a pod root) — used by the
+   * reporter for the overwritten-resource subtraction in
+   * `QuotaStrategy.getAvailableSpace`. Single stat for a document; walk for a
+   * container.
+   */
+  public async sizeOfResource(identifier: ResourceIdentifier): Promise<number> {
+    const filePath = await this.mapDataPath(identifier);
+    try {
+      const stat = await fs.stat(filePath);
+      if (stat.isFile()) {
+        return stat.size;
+      }
+      // Container — walk it (rare: only the overwritten resource is a file).
+      return (await this.walker.getSize(identifier)).amount;
+    } catch {
+      return 0;
+    }
+  }
+
+  /** Maps an identifier to its data file path (normalized). */
+  public async mapDataPath(identifier: ResourceIdentifier): Promise<string> {
+    const { filePath } = await this.fileIdentifierMapper.mapUrlToFilePath(identifier, false);
+    return normalizeFilePath(filePath);
+  }
+
+  /**
+   * Full apparent-byte walk of a resource/container (used by the delta hook
+   * for container before/after sizing — rare, e.g. create/delete container).
+   */
+  public async walk(identifier: ResourceIdentifier): Promise<number> {
+    return (await this.walker.getSize(identifier)).amount;
+  }
+
+  // --- Internals ---
+
+  private async ensureEntry(path: string, podIdentifier: ResourceIdentifier): Promise<CounterEntry> {
+    let entry = this.entries.get(path);
+    if (entry?.valid) {
+      const mtime = await this.podRootMtime(path);
+      if (entry.podMtimeMs === mtime) {
+        return entry;
+      }
+      // Pod root mtime moved — the counter may be stale, recount below.
+    }
+    // Try the sidecar first (persisted counter), then a full walk.
+    return this.withLock(path, async(): Promise<CounterEntry> => {
+      entry = this.entries.get(path);
+      if (entry?.valid) {
+        const mtime = await this.podRootMtime(path);
+        if (entry.podMtimeMs === mtime) {
+          return entry;
+        }
+      }
+      const loaded = await this.loadSidecar(path);
+      if (loaded?.valid) {
+        const mtime = await this.podRootMtime(path);
+        if (loaded.podMtimeMs === mtime) {
+          this.entries.set(path, loaded);
+          return loaded;
+        }
+      }
+      // No valid counter — full walk (bootstrap / recovery).
+      const total = (await this.walker.getSize(podIdentifier)).amount;
+      const fresh: CounterEntry = { total, valid: true, podMtimeMs: 0 };
+      this.entries.set(path, fresh);
+      await this.persistWithMtime(path, fresh);
+      return fresh;
+    });
+  }
+
+  private async podRootMtime(path: string): Promise<number> {
+    try {
+      const stat = await fs.stat(path);
+      return stat.isDirectory() ? stat.mtimeMs : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  private sidecarPath(podRootPath: string): string {
+    return normalizeFilePath(joinFilePath(podRootPath, this.sidecarRelativePath));
+  }
+
+  private async loadSidecar(path: string): Promise<CounterEntry | undefined> {
+    try {
+      const raw = await fs.readFile(this.sidecarPath(path), 'utf8');
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        typeof parsed === 'object' && parsed !== null &&
+        'total' in parsed && 'podMtimeMs' in parsed &&
+        typeof parsed.total === 'number' && typeof parsed.podMtimeMs === 'number'
+      ) {
+        return { total: parsed.total, valid: true, podMtimeMs: parsed.podMtimeMs };
+      }
+    } catch {
+      // Missing or malformed sidecar → recount.
+    }
+    return undefined;
+  }
+
+  private async persist(path: string, entry: CounterEntry): Promise<void> {
+    const sidecar = this.sidecarPath(path);
+    const tmp = `${sidecar}.tmp`;
+    try {
+      await fs.mkdir(join(path, '.internal'), { recursive: true });
+      await fs.writeFile(tmp, JSON.stringify({
+        version: 1,
+        total: entry.total,
+        podMtimeMs: entry.podMtimeMs,
+        updatedAt: new Date().toISOString(),
+      }));
+      await fs.rename(tmp, sidecar);
+    } catch {
+      // Persistence is best-effort: keep the in-memory counter authoritative.
+    }
+  }
+
+  /**
+   * Persist, then record the pod root mtime AFTER the persist. Persisting the
+   * sidecar may create the `.internal/` directory (a new pod-root child), which
+   * bumps the pod root's mtime — recording the mtime before would leave every
+   * subsequent read thinking the counter is stale.
+   */
+  private async persistWithMtime(path: string, entry: CounterEntry): Promise<void> {
+    await this.persist(path, entry);
+    entry.podMtimeMs = await this.podRootMtime(path);
+    await this.persist(path, entry);
+  }
+
+  private async withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(key) ?? Promise.resolve();
+    let resolveGate: (() => void) | undefined;
+    const gate = new Promise<void>((resolve): void => {
+      resolveGate = resolve;
+    });
+    // Waiters chain on `previous`, then wait for this call's `gate` to open.
+    const next = previous.then(async(): Promise<void> => {
+      await gate;
+    });
+    this.locks.set(key, next);
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      resolveGate?.();
+      if (this.locks.get(key) === next) {
+        this.locks.delete(key);
+      }
+    }
+  }
+}

--- a/src/storage/quota/QuotaDeltaDataAccessor.ts
+++ b/src/storage/quota/QuotaDeltaDataAccessor.ts
@@ -1,0 +1,151 @@
+import { promises as fs } from 'node:fs';
+import type { Readable } from 'node:stream';
+import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import type { Guarded } from '../../util/GuardedStream';
+import type { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import { PassthroughDataAccessor } from '../accessors/PassthroughDataAccessor';
+import type { DataAccessor } from '../accessors/DataAccessor';
+import type { FileIdentifierMapper } from '../mapping/FileIdentifierMapper';
+import { isInternalPath } from './InternalPath';
+import { discoverPod } from './PodDiscovery';
+import type { QuotaCounter } from './QuotaCounter';
+
+/**
+ * Delta hook for design C. Wraps the top of the file accessor chain and, for
+ * every mutation, computes the resource's apparent-byte delta (before/after)
+ * and feeds it to the {@link QuotaCounter}.
+ *
+ * Plugs into the existing chain untouched: this wrapper's `accessor` is the
+ * original `FileDataAccessor` (FilterMetadata → Validating → Atomic), so the
+ * quota validation and content-length filtering are preserved.
+ *
+ * Cases handled:
+ * - create/overwrite document: Δ = new − old (data + metadata file)
+ * - delete resource: Δ = −(data + metadata size)
+ * - create/delete container: Δ from a walk (captures directory sizes)
+ */
+export class QuotaDeltaDataAccessor extends PassthroughDataAccessor {
+  private readonly identifierStrategy: IdentifierStrategy;
+  private readonly counter: QuotaCounter;
+  private readonly fileIdentifierMapper: FileIdentifierMapper;
+  private readonly podCache = new Map<string, ResourceIdentifier | null>();
+
+  public constructor(
+    accessor: DataAccessor,
+    identifierStrategy: IdentifierStrategy,
+    counter: QuotaCounter,
+    fileIdentifierMapper: FileIdentifierMapper,
+  ) {
+    super(accessor);
+    this.identifierStrategy = identifierStrategy;
+    this.counter = counter;
+    this.fileIdentifierMapper = fileIdentifierMapper;
+  }
+
+  public async writeDocument(
+    identifier: ResourceIdentifier,
+    data: Guarded<Readable>,
+    metadata: RepresentationMetadata,
+  ): Promise<void> {
+    await this.track(identifier, async(): Promise<void> => this.accessor.writeDocument(identifier, data, metadata));
+  }
+
+  public async writeContainer(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    await this.track(identifier, async(): Promise<void> => this.accessor.writeContainer(identifier, metadata));
+  }
+
+  public async writeMetadata(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    await this.track(identifier, async(): Promise<void> => this.accessor.writeMetadata(identifier, metadata));
+  }
+
+  public async deleteResource(identifier: ResourceIdentifier): Promise<void> {
+    if (isInternalPath(identifier)) {
+      await this.accessor.deleteResource(identifier);
+      return;
+    }
+    const before = await this.sizeOf(identifier);
+    await this.accessor.deleteResource(identifier);
+    const after = await this.sizeOf(identifier);
+    const delta = after - before;
+    const pod = await this.findPod(identifier);
+    if (pod === null) {
+      return;
+    }
+    // Deleting the pod root itself → drop the counter entirely.
+    if (pod.path === identifier.path) {
+      await this.counter.remove(identifier);
+      return;
+    }
+    if (delta !== 0) {
+      await this.counter.register(pod);
+      await this.counter.add(pod, delta);
+    }
+  }
+
+  // --- Delta tracking ---
+
+  private async track(identifier: ResourceIdentifier, op: () => Promise<void>): Promise<void> {
+    // Skip the delta bookkeeping on CSS internal paths: the stat + pod-discovery
+    // walk + counter sidecar work can otherwise push internal writes (e.g. IDP
+    // authorization codes) past the WrappedExpiringReadWriteLocker's lock expiry.
+    if (isInternalPath(identifier)) {
+      await op();
+      return;
+    }
+    const before = await this.sizeOf(identifier);
+    await op();
+    const after = await this.sizeOf(identifier);
+    const pod = await this.findPod(identifier);
+    if (pod === null) {
+      return;
+    }
+    // Always register the pod so the reporter routes its reads to the counter
+    // (even when this particular write has a zero delta, e.g. an empty
+    // container on a filesystem that reports directory size 0).
+    await this.counter.register(pod);
+    const delta = after - before;
+    if (delta !== 0) {
+      await this.counter.add(pod, delta);
+    }
+  }
+
+  /** Apparent size of the resource: data file + metadata file (+ walk for containers). */
+  private async sizeOf(identifier: ResourceIdentifier): Promise<number> {
+    const data = await this.stat(identifier, false);
+    const meta = await this.stat(identifier, true);
+    return data + meta;
+  }
+
+  private async stat(identifier: ResourceIdentifier, isMetadata: boolean): Promise<number> {
+    try {
+      const { filePath } = await this.fileIdentifierMapper.mapUrlToFilePath(identifier, isMetadata);
+      const stat = await fs.stat(filePath);
+      if (stat.isDirectory()) {
+        return await this.counter.walk(identifier);
+      }
+      return stat.size;
+    } catch {
+      return 0;
+    }
+  }
+
+  // --- Pod discovery (mirrors PodQuotaStrategy.searchPimStorage) ---
+
+  private async findPod(identifier: ResourceIdentifier): Promise<ResourceIdentifier | null> {
+    const path = await this.counter.mapDataPath(identifier);
+    const cached = this.podCache.get(path);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const pod = await this.discoverPod(identifier);
+    this.podCache.set(path, pod);
+    return pod;
+  }
+
+  private async discoverPod(identifier: ResourceIdentifier): Promise<ResourceIdentifier | null> {
+    // Uses the metadata-before-root-container order so subdomain-mode pod
+    // roots are discovered (a subdomain pod root IS a root container).
+    return discoverPod(identifier, this.accessor, this.identifierStrategy);
+  }
+}

--- a/src/storage/quota/QuotaDeltaDataAccessor.ts
+++ b/src/storage/quota/QuotaDeltaDataAccessor.ts
@@ -12,13 +12,9 @@ import { discoverPod } from './PodDiscovery';
 import type { QuotaCounter } from './QuotaCounter';
 
 /**
- * Delta hook for design C. Wraps the top of the file accessor chain and, for
- * every mutation, computes the resource's apparent-byte delta (before/after)
+ * Wraps the top of the file accessor chain and, for every mutation,
+ * computes the resource's apparent-byte delta (before/after)
  * and feeds it to the {@link QuotaCounter}.
- *
- * Plugs into the existing chain untouched: this wrapper's `accessor` is the
- * original `FileDataAccessor` (FilterMetadata → Validating → Atomic), so the
- * quota validation and content-length filtering are preserved.
  *
  * Cases handled:
  * - create/overwrite document: Δ = new − old (data + metadata file)
@@ -86,9 +82,6 @@ export class QuotaDeltaDataAccessor extends PassthroughDataAccessor {
   // --- Delta tracking ---
 
   private async track(identifier: ResourceIdentifier, op: () => Promise<void>): Promise<void> {
-    // Skip the delta bookkeeping on CSS internal paths: the stat + pod-discovery
-    // walk + counter sidecar work can otherwise push internal writes (e.g. IDP
-    // authorization codes) past the WrappedExpiringReadWriteLocker's lock expiry.
     if (isInternalPath(identifier)) {
       await op();
       return;
@@ -100,9 +93,6 @@ export class QuotaDeltaDataAccessor extends PassthroughDataAccessor {
     if (pod === null) {
       return;
     }
-    // Always register the pod so the reporter routes its reads to the counter
-    // (even when this particular write has a zero delta, e.g. an empty
-    // container on a filesystem that reports directory size 0).
     await this.counter.register(pod);
     const delta = after - before;
     if (delta !== 0) {
@@ -145,7 +135,7 @@ export class QuotaDeltaDataAccessor extends PassthroughDataAccessor {
 
   private async discoverPod(identifier: ResourceIdentifier): Promise<ResourceIdentifier | null> {
     // Uses the metadata-before-root-container order so subdomain-mode pod
-    // roots are discovered (a subdomain pod root IS a root container).
+    // roots are discovered.
     return discoverPod(identifier, this.accessor, this.identifierStrategy);
   }
 }

--- a/src/storage/size-reporter/DuSizeReporter.ts
+++ b/src/storage/size-reporter/DuSizeReporter.ts
@@ -1,0 +1,214 @@
+import { execFile } from 'node:child_process';
+import { promises as fsPromises } from 'node:fs';
+import { promisify } from 'node:util';
+import type { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import { joinFilePath, normalizeFilePath, trimTrailingSlashes } from '../../util/PathUtil';
+import type { FileIdentifierMapper } from '../mapping/FileIdentifierMapper';
+import type { Size } from './Size';
+import { UNIT_BYTES } from './Size';
+import type { SizeReporter } from './SizeReporter';
+
+const execFileAsync = promisify(execFile);
+
+// Cache entry: computed size + expiry timestamp
+interface CacheEntry {
+  size: number;
+  expiresAt: number;
+}
+
+/**
+ * A {@link SizeReporter} that measures a resource (and its children) in
+ * apparent bytes, using GNU/BSD `du` as a fast C-level walk with a per-path
+ * TTL cache, falling back to a plain Node walk when no compatible `du`
+ * exists (e.g. bare Windows).
+ *
+ * The unit is apparent bytes (sum of `st_size`) — identical to CSS's
+ * {@link FileSizeReporter}, portable across servers/filesystems and
+ * user-manageable. `stat.blocks` (disk usage) is deliberately NOT used:
+ * the result would depend on the server's filesystem cluster size.
+ */
+export class DuSizeReporter implements SizeReporter<unknown> {
+  private readonly fileIdentifierMapper: FileIdentifierMapper;
+  private readonly rootFilePath: string;
+  private readonly ignoreFolders: RegExp[];
+  private readonly ttlMs: number;
+  private readonly cache = new Map<string, CacheEntry>();
+  private duFlavor: 'gnu' | 'bsd' | 'none' | null = null;
+
+  public constructor(
+    fileIdentifierMapper: FileIdentifierMapper,
+    rootFilePath: string,
+    ignoreFolders: string[] = [],
+    ttl = 5000,
+  ) {
+    this.fileIdentifierMapper = fileIdentifierMapper;
+    this.rootFilePath = normalizeFilePath(rootFilePath);
+    this.ignoreFolders = ignoreFolders.map((folder): RegExp => new RegExp(folder, 'u'));
+    this.ttlMs = ttl;
+  }
+
+  /** The DuSizeReporter always returns data in the form of bytes. */
+  public getUnit(): string {
+    return UNIT_BYTES;
+  }
+
+  /**
+   * Returns the size of the given resource (and its children) in apparent
+   * bytes, using the per-path TTL cache when possible.
+   */
+  public async getSize(identifier: ResourceIdentifier): Promise<Size> {
+    const { filePath } = await this.fileIdentifierMapper.mapUrlToFilePath(identifier, false);
+    const normalized = normalizeFilePath(filePath);
+    const cached = this.cache.get(normalized);
+    if (cached && cached.expiresAt > Date.now()) {
+      return { unit: UNIT_BYTES, amount: cached.size };
+    }
+    const amount = await this.computeTotalSize(normalized);
+    this.cache.set(normalized, { size: amount, expiresAt: Date.now() + this.ttlMs });
+    return { unit: UNIT_BYTES, amount };
+  }
+
+  /**
+   * Drop the cached size for the given resource and all of its ancestors
+   * (e.g. the pod root). Called when a write to the resource completes, so
+   * the next size query re-walks and reflects the new content.
+   */
+  public async invalidate(identifier: ResourceIdentifier): Promise<void> {
+    try {
+      const { filePath } = await this.fileIdentifierMapper.mapUrlToFilePath(identifier, false);
+      const normalized = normalizeFilePath(filePath);
+      for (const key of this.cache.keys()) {
+        if (key === normalized || normalized.startsWith(key)) {
+          this.cache.delete(key);
+        }
+      }
+    } catch {
+      // Best-effort: if the resource cannot be mapped, leave the cache as-is.
+    }
+  }
+
+  /** The size of a chunk is simply its length in bytes. */
+  public async calculateChunkSize(chunk: unknown): Promise<number> {
+    return Buffer.isBuffer(chunk) ? chunk.length : Number((chunk as { length?: number }).length) || 0;
+  }
+
+  /** The estimated size of a resource is simply the content-length header. */
+  public async estimateSize(metadata: RepresentationMetadata): Promise<number | undefined> {
+    return metadata.contentLength;
+  }
+
+  // --- Walk implementations ---
+
+  private async computeTotalSize(fileLocation: string): Promise<number> {
+    const flavor = await this.detectDu();
+    if (flavor !== 'none') {
+      try {
+        return await this.computeTotalSizeWithDu(fileLocation, flavor);
+      } catch {
+        // Du failed (e.g. no du after all, permission error) — fall back to the Node walk.
+      }
+    }
+    return this.computeTotalSizeWithNode(fileLocation);
+  }
+
+  private async computeTotalSizeWithDu(fileLocation: string, flavor: 'gnu' | 'bsd'): Promise<number> {
+    const args: string[] = flavor === 'gnu' ? [ '-sb' ] : [ '-s', '-A', '-B', '1' ];
+    for (const pattern of this.duExcludePatterns()) {
+      args.push(flavor === 'gnu' ? '--exclude' : '-I', pattern);
+    }
+    args.push(fileLocation);
+    const { stdout } = await execFileAsync('du', args, { maxBuffer: 64 * 1024 * 1024 });
+    const amount = Number(stdout.trim().split(/\s+/u)[0]);
+    if (!Number.isFinite(amount)) {
+      throw new TypeError(`Could not parse du output: ${stdout.trim()}`);
+    }
+    return amount;
+  }
+
+  /**
+   * Plain Node recursive walk — the same semantics as CSS's
+   * {@link FileSizeReporter.getTotalSize}. Used when no compatible `du` exists.
+   */
+  private async computeTotalSizeWithNode(fileLocation: string): Promise<number> {
+    let stat;
+    try {
+      stat = await fsPromises.stat(fileLocation);
+    } catch {
+      return 0;
+    }
+    // If the file's location points to a file, simply return the file's size.
+    if (stat.isFile()) {
+      return stat.size;
+    }
+    // Recursively add all sizes of children to the total.
+    const childFiles = await fsPromises.readdir(fileLocation);
+    const rootFilePathLength = trimTrailingSlashes(this.rootFilePath).length;
+    let totalSize = stat.size;
+    for (const current of childFiles) {
+      const childFileLocation = normalizeFilePath(joinFilePath(fileLocation, current));
+      // Exclude internal files, matching FileSizeReporter's behavior.
+      if (!this.ignoreFolders.some((folder): boolean => folder.test(childFileLocation.slice(rootFilePathLength)))) {
+        totalSize += await this.computeTotalSizeWithNode(childFileLocation);
+      }
+    }
+    return totalSize;
+  }
+
+  protected async detectDu(): Promise<'gnu' | 'bsd' | 'none'> {
+    if (this.duFlavor) {
+      return this.duFlavor;
+    }
+    try {
+      await execFileAsync('du', [ '--version' ], { timeout: 1000 });
+      this.duFlavor = 'gnu';
+    } catch (error: unknown) {
+      // ENOENT: no `du` at all (e.g. bare Windows). Anything else means the
+      // GNU long option was rejected → assume BSD; if BSD flags fail at use
+      // time, the caller falls back to the Node walk.
+      const code = (error as { code?: string }).code;
+      this.duFlavor = code === 'ENOENT' ? 'none' : 'bsd';
+    }
+    return this.duFlavor;
+  }
+
+  /**
+   * Convert the configured ignore-folder regexes into `du` exclude patterns.
+   * GNU/BSD `du` matches exclude patterns against path components/basenames
+   * (not against the full leading-slash path), so a regex like `^/\.internal$`
+   * becomes the exclude `.internal`.
+   *
+   * Only simple anchored folder patterns are convertible
+   * (`^/name$`); complex regexes that cannot be expressed as a du exclude are
+   * skipped here — the Node-walk fallback still applies them verbatim.
+   *
+   * Any-depth component patterns (e.g. `(^|/)\.internal$`) are also converted
+   * to a bare basename exclude, keeping the Node walk and `du` consistent for
+   * folders like `.internal` that may appear below the server root (e.g. a
+   * pod's own `/.internal/` quota sidecar).
+   */
+  private duExcludePatterns(): string[] {
+    const patterns: string[] = [];
+    for (const regex of this.ignoreFolders) {
+      // RegExp.source always escapes '/' as '\/' (e.g. `^/\.internal$` →
+      // `^\/\.internal$`). Strip the leading '^' + '/' (possibly '\/'), drop
+      // the trailing '$', then unescape the remaining escapes.
+      let src = regex.source.replace(/^\^?\\?\//u, '');
+      src = src.replace(/\$?$/u, '');
+      // Unescape `\.` (from RegExp.source) back to `.`.
+      src = src.replaceAll('\\.', '.');
+      // Keep only patterns with no remaining regex metacharacters.
+      if (/^[\w.-]+$/u.test(src)) {
+        patterns.push(src);
+        continue;
+      }
+      // Any-depth component pattern: extract the trailing `\.name$` (e.g.
+      // `(^|/)\.internal$` → `.internal`) and express it as a bare name.
+      const match = /\\?\.([\w.-]+)\$?$/u.exec(regex.source);
+      if (match) {
+        patterns.push(`.${match[1]}`);
+      }
+    }
+    return patterns;
+  }
+}

--- a/src/storage/size-reporter/DuSizeReporter.ts
+++ b/src/storage/size-reporter/DuSizeReporter.ts
@@ -19,14 +19,9 @@ interface CacheEntry {
 
 /**
  * A {@link SizeReporter} that measures a resource (and its children) in
- * apparent bytes, using GNU/BSD `du` as a fast C-level walk with a per-path
+ * apparent bytes, using GNU/BSD `du` as a fast walk with a per-path
  * TTL cache, falling back to a plain Node walk when no compatible `du`
  * exists (e.g. bare Windows).
- *
- * The unit is apparent bytes (sum of `st_size`) — identical to CSS's
- * {@link FileSizeReporter}, portable across servers/filesystems and
- * user-manageable. `stat.blocks` (disk usage) is deliberately NOT used:
- * the result would depend on the server's filesystem cluster size.
  */
 export class DuSizeReporter implements SizeReporter<unknown> {
   private readonly fileIdentifierMapper: FileIdentifierMapper;
@@ -48,7 +43,6 @@ export class DuSizeReporter implements SizeReporter<unknown> {
     this.ttlMs = ttl;
   }
 
-  /** The DuSizeReporter always returns data in the form of bytes. */
   public getUnit(): string {
     return UNIT_BYTES;
   }
@@ -69,11 +63,7 @@ export class DuSizeReporter implements SizeReporter<unknown> {
     return { unit: UNIT_BYTES, amount };
   }
 
-  /**
-   * Drop the cached size for the given resource and all of its ancestors
-   * (e.g. the pod root). Called when a write to the resource completes, so
-   * the next size query re-walks and reflects the new content.
-   */
+  /** Drop the cached size for the given resource and all of its ancestors. */
   public async invalidate(identifier: ResourceIdentifier): Promise<void> {
     try {
       const { filePath } = await this.fileIdentifierMapper.mapUrlToFilePath(identifier, false);
@@ -88,12 +78,10 @@ export class DuSizeReporter implements SizeReporter<unknown> {
     }
   }
 
-  /** The size of a chunk is simply its length in bytes. */
   public async calculateChunkSize(chunk: unknown): Promise<number> {
     return Buffer.isBuffer(chunk) ? chunk.length : Number((chunk as { length?: number }).length) || 0;
   }
 
-  /** The estimated size of a resource is simply the content-length header. */
   public async estimateSize(metadata: RepresentationMetadata): Promise<number | undefined> {
     return metadata.contentLength;
   }
@@ -126,10 +114,7 @@ export class DuSizeReporter implements SizeReporter<unknown> {
     return amount;
   }
 
-  /**
-   * Plain Node recursive walk — the same semantics as CSS's
-   * {@link FileSizeReporter.getTotalSize}. Used when no compatible `du` exists.
-   */
+  /** Plain Node recursive walk. Used when no compatible `du` exists. */
   private async computeTotalSizeWithNode(fileLocation: string): Promise<number> {
     let stat;
     try {
@@ -163,9 +148,6 @@ export class DuSizeReporter implements SizeReporter<unknown> {
       await execFileAsync('du', [ '--version' ], { timeout: 1000 });
       this.duFlavor = 'gnu';
     } catch (error: unknown) {
-      // ENOENT: no `du` at all (e.g. bare Windows). Anything else means the
-      // GNU long option was rejected → assume BSD; if BSD flags fail at use
-      // time, the caller falls back to the Node walk.
       const code = (error as { code?: string }).code;
       this.duFlavor = code === 'ENOENT' ? 'none' : 'bsd';
     }
@@ -174,18 +156,6 @@ export class DuSizeReporter implements SizeReporter<unknown> {
 
   /**
    * Convert the configured ignore-folder regexes into `du` exclude patterns.
-   * GNU/BSD `du` matches exclude patterns against path components/basenames
-   * (not against the full leading-slash path), so a regex like `^/\.internal$`
-   * becomes the exclude `.internal`.
-   *
-   * Only simple anchored folder patterns are convertible
-   * (`^/name$`); complex regexes that cannot be expressed as a du exclude are
-   * skipped here — the Node-walk fallback still applies them verbatim.
-   *
-   * Any-depth component patterns (e.g. `(^|/)\.internal$`) are also converted
-   * to a bare basename exclude, keeping the Node walk and `du` consistent for
-   * folders like `.internal` that may appear below the server root (e.g. a
-   * pod's own `/.internal/` quota sidecar).
    */
   private duExcludePatterns(): string[] {
     const patterns: string[] = [];

--- a/test/unit/quota/IncrementalSizeReporter.test.ts
+++ b/test/unit/quota/IncrementalSizeReporter.test.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import type { FileIdentifierMapper } from '../../../src/storage/mapping/FileIdentifierMapper';
+import { IncrementalSizeReporter } from '../../../src/storage/quota/IncrementalSizeReporter';
+import { QuotaCounter } from '../../../src/storage/quota/QuotaCounter';
+
+const IGNORE = [ '(^|/)\\.internal$' ];
+
+function createMapper(root: string): FileIdentifierMapper {
+  return {
+    async mapUrlToFilePath(identifier: ResourceIdentifier, isMetadata: boolean): Promise<any> {
+      const url = new URL(identifier.path);
+      const base = join(root, url.pathname);
+      return {
+        identifier,
+        filePath: isMetadata ? `${base}.meta` : base,
+        contentType: undefined,
+        isMetadata,
+      };
+    },
+    async mapFilePathToUrl(): Promise<any> {
+      throw new Error('Not implemented');
+    },
+  };
+}
+
+const POD = { path: 'http://example.com/alice/' };
+const RESOURCE = { path: 'http://example.com/alice/foo' };
+
+describe('An IncrementalSizeReporter', (): void => {
+  let root: string;
+  let counter: QuotaCounter;
+  let reporter: IncrementalSizeReporter;
+
+  beforeEach(async(): Promise<void> => {
+    root = await fs.mkdtemp(join(tmpdir(), 'inc-reporter-'));
+    await fs.mkdir(join(root, 'alice'));
+    counter = new QuotaCounter(createMapper(root), root, IGNORE);
+    reporter = new IncrementalSizeReporter(counter);
+  });
+
+  afterEach(async(): Promise<void> => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns the counter total for a registered pod root.', async(): Promise<void> => {
+    await counter.register(POD);
+    await counter.add(POD, 123);
+    await expect(reporter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 123 });
+  });
+
+  it('stats a regular resource (not a pod root).', async(): Promise<void> => {
+    await fs.writeFile(join(root, 'alice', 'foo'), Buffer.alloc(64));
+    await expect(reporter.getSize(RESOURCE)).resolves.toEqual({ unit: 'bytes', amount: 64 });
+  });
+
+  it('returns the byte unit and chunk/content-length helpers.', async(): Promise<void> => {
+    expect(reporter.getUnit()).toBe('bytes');
+    await expect(reporter.calculateChunkSize(Buffer.alloc(9))).resolves.toBe(9);
+    await expect(reporter.estimateSize({ contentLength: 42 } as any)).resolves.toBe(42);
+  });
+});

--- a/test/unit/quota/IncrementalSizeReporter.test.ts
+++ b/test/unit/quota/IncrementalSizeReporter.test.ts
@@ -61,4 +61,9 @@ describe('An IncrementalSizeReporter', (): void => {
     await expect(reporter.calculateChunkSize(Buffer.alloc(9))).resolves.toBe(9);
     await expect(reporter.estimateSize({ contentLength: 42 } as any)).resolves.toBe(42);
   });
+
+  it('calculates the chunk size for non-buffer chunks.', async(): Promise<void> => {
+    await expect(reporter.calculateChunkSize({ length: 5 })).resolves.toBe(5);
+    await expect(reporter.calculateChunkSize({})).resolves.toBe(0);
+  });
 });

--- a/test/unit/quota/PodDiscovery.test.ts
+++ b/test/unit/quota/PodDiscovery.test.ts
@@ -1,0 +1,84 @@
+import type { DataAccessor } from '../../../src/storage/accessors/DataAccessor';
+import { discoverPod } from '../../../src/storage/quota/PodDiscovery';
+import { NotFoundHttpError } from '../../../src/util/errors/NotFoundHttpError';
+import type { IdentifierStrategy } from '../../../src/util/identifiers/IdentifierStrategy';
+
+const PIM_STORAGE = 'http://www.w3.org/ns/pim/space#Storage';
+
+function storageMetadata(isStorage: boolean): any {
+  return {
+    getAll: (): any[] => isStorage ? [{ value: PIM_STORAGE }] : [],
+  };
+}
+
+function createStrategy(isRoot: () => boolean, parent: (identifier: any) => any): IdentifierStrategy {
+  return {
+    isRootContainer: jest.fn(isRoot),
+    getParentContainer: jest.fn(parent),
+  } as any;
+}
+
+describe('discoverPod', (): void => {
+  let accessor: jest.Mocked<DataAccessor>;
+
+  beforeEach((): void => {
+    accessor = {
+      canHandle: jest.fn(),
+      getData: jest.fn(),
+      getMetadata: jest.fn(),
+      getChildren: jest.fn(),
+      writeContainer: jest.fn(),
+      writeDocument: jest.fn(),
+      writeMetadata: jest.fn(),
+      deleteResource: jest.fn(),
+    };
+  });
+
+  it('returns the identifier when its metadata declares pim:Storage.', async(): Promise<void> => {
+    const identifier = { path: 'http://example.com/alice/' };
+    accessor.getMetadata.mockResolvedValue(storageMetadata(true));
+    const strategy = createStrategy((): boolean => false, jest.fn());
+    await expect(discoverPod(identifier, accessor, strategy)).resolves.toEqual(identifier);
+  });
+
+  it('walks up to a parent container that declares pim:Storage.', async(): Promise<void> => {
+    const child = { path: 'http://example.com/alice/foo' };
+    const pod = { path: 'http://example.com/alice/' };
+    accessor.getMetadata
+      .mockResolvedValueOnce(storageMetadata(false))
+      .mockResolvedValueOnce(storageMetadata(true));
+    const strategy = createStrategy((): boolean => false, (): any => pod);
+    await expect(discoverPod(child, accessor, strategy)).resolves.toEqual(pod);
+  });
+
+  it('returns null when there is no pim:Storage and the container is a root container.', async(): Promise<void> => {
+    const identifier = { path: 'http://example.com/' };
+    accessor.getMetadata.mockResolvedValue(storageMetadata(false));
+    const strategy = createStrategy((): boolean => true, jest.fn());
+    await expect(discoverPod(identifier, accessor, strategy)).resolves.toBeNull();
+  });
+
+  it('walks up on a NotFoundHttpError from a non-root container.', async(): Promise<void> => {
+    const child = { path: 'http://example.com/alice/foo' };
+    const pod = { path: 'http://example.com/alice/' };
+    accessor.getMetadata
+      .mockRejectedValueOnce(new NotFoundHttpError())
+      .mockResolvedValueOnce(storageMetadata(true));
+    const strategy = createStrategy((): boolean => false, (): any => pod);
+    await expect(discoverPod(child, accessor, strategy)).resolves.toEqual(pod);
+  });
+
+  it('returns null on a NotFoundHttpError at a root container.', async(): Promise<void> => {
+    const identifier = { path: 'http://example.com/' };
+    accessor.getMetadata.mockRejectedValue(new NotFoundHttpError());
+    const strategy = createStrategy((): boolean => true, jest.fn());
+    await expect(discoverPod(identifier, accessor, strategy)).resolves.toBeNull();
+  });
+
+  it('rethrows errors that are not NotFoundHttpError.', async(): Promise<void> => {
+    const identifier = { path: 'http://example.com/alice/' };
+    accessor.getMetadata.mockRejectedValue(new Error('boom'));
+    const strategy = createStrategy((): boolean => false, jest.fn());
+    await expect(discoverPod(identifier, accessor, strategy)).rejects.toThrow('boom');
+  });
+});

--- a/test/unit/quota/QuotaCounter.test.ts
+++ b/test/unit/quota/QuotaCounter.test.ts
@@ -1,0 +1,115 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import type { FileIdentifierMapper } from '../../../src/storage/mapping/FileIdentifierMapper';
+import { QuotaCounter } from '../../../src/storage/quota/QuotaCounter';
+import { DuSizeReporter } from '../../../src/storage/size-reporter/DuSizeReporter';
+
+const IGNORE = [ '(^|/)\\.internal$' ];
+
+function createMapper(root: string): FileIdentifierMapper {
+  return {
+    async mapUrlToFilePath(identifier: ResourceIdentifier, isMetadata: boolean): Promise<any> {
+      const url = new URL(identifier.path);
+      const base = join(root, url.pathname);
+      return {
+        identifier,
+        filePath: isMetadata ? `${base}.meta` : base,
+        contentType: undefined,
+        isMetadata,
+      };
+    },
+    async mapFilePathToUrl(): Promise<any> {
+      throw new Error('Not implemented');
+    },
+  };
+}
+
+// The same walk engine the counter uses for recounts.
+async function expectedWalk(root: string, mapper: FileIdentifierMapper, pod: ResourceIdentifier): Promise<number> {
+  return (await new DuSizeReporter(mapper, root, IGNORE).getSize(pod)).amount;
+}
+
+const POD = { path: 'http://example.com/alice/' };
+const RESOURCE = { path: 'http://example.com/alice/foo' };
+
+describe('A QuotaCounter', (): void => {
+  let root: string;
+  let mapper: FileIdentifierMapper;
+
+  beforeEach(async(): Promise<void> => {
+    root = await fs.mkdtemp(join(tmpdir(), 'quota-counter-'));
+    await fs.mkdir(join(root, 'alice'));
+    mapper = createMapper(root);
+  });
+
+  afterEach(async(): Promise<void> => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('accumulates deltas and returns the total (O(1)).', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await counter.register(POD);
+    await counter.add(POD, 100);
+    await counter.add(POD, 50);
+    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 150 });
+  });
+
+  it('bootstraps by walking when no counter or sidecar exists.', async(): Promise<void> => {
+    await fs.writeFile(join(root, 'alice', 'a.txt'), Buffer.alloc(120));
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    const size = await counter.getSize(POD);
+    expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
+    expect(size.amount).toBeGreaterThanOrEqual(120);
+  });
+
+  it('persists the sidecar and reloads it on a fresh instance (no re-walk).', async(): Promise<void> => {
+    const first = new QuotaCounter(mapper, root, IGNORE);
+    await first.register(POD);
+    await first.add(POD, 200);
+    // Fresh counter — same pod, sidecar matches mtime → loaded, no walk.
+    const second = new QuotaCounter(mapper, root, IGNORE);
+    await expect(second.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 200 });
+  });
+
+  it('detects staleness (out-of-band change) and recounts.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await counter.register(POD);
+    await counter.add(POD, 100);
+    // Out-of-band change: a direct child appears in the pod root.
+    await fs.writeFile(join(root, 'alice', 'extra.bin'), Buffer.alloc(400));
+    const size = await counter.getSize(POD);
+    expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
+    expect(size.amount).toBeGreaterThanOrEqual(400);
+  });
+
+  it('returns the size of a single resource via stat.', async(): Promise<void> => {
+    await fs.writeFile(join(root, 'alice', 'foo'), Buffer.alloc(77));
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await expect(counter.sizeOfResource(RESOURCE)).resolves.toBe(77);
+  });
+
+  it('returns 0 for a missing resource.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await expect(counter.sizeOfResource(RESOURCE)).resolves.toBe(0);
+  });
+
+  it('drops the entry and sidecar on remove, then bootstraps again.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await counter.register(POD);
+    await counter.add(POD, 100);
+    await counter.remove(POD);
+    await expect(counter.isPodRoot(POD)).resolves.toBe(false);
+    // The sidecar is gone and the counter is dropped → next read re-walks.
+    const size = await counter.getSize(POD);
+    expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
+  });
+
+  it('serializes concurrent adds with a per-pod lock.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await counter.register(POD);
+    await Promise.all([ counter.add(POD, 10), counter.add(POD, 20), counter.add(POD, 30) ]);
+    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 60 });
+  });
+});

--- a/test/unit/quota/QuotaCounter.test.ts
+++ b/test/unit/quota/QuotaCounter.test.ts
@@ -77,8 +77,13 @@ describe('A QuotaCounter', (): void => {
     const counter = new QuotaCounter(mapper, root, IGNORE);
     await counter.register(POD);
     await counter.add(POD, 100);
-    // Out-of-band change: a direct child appears in the pod root.
+    // Out-of-band change: a direct child appears in the pod root. Some filesystems
+    // (e.g. NTFS mounted via WSL) have coarse directory mtime granularity, so the
+    // new child may not bump the root mtime immediately; force it to a clearly
+    // different value to make the staleness detection deterministic.
     await fs.writeFile(join(root, 'alice', 'extra.bin'), Buffer.alloc(400));
+    const oldTime = new Date(2000, 0, 1);
+    await fs.utimes(join(root, 'alice'), oldTime, oldTime);
     const size = await counter.getSize(POD);
     expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
     expect(size.amount).toBeGreaterThanOrEqual(400);
@@ -165,12 +170,16 @@ describe('A QuotaCounter', (): void => {
 
   it('records a zero mtime when the pod root is a file.', async(): Promise<void> => {
     // A file as the pod root: podRootMtime's isDirectory() is false → mtime 0.
+    // Use a non-trailing-slash identifier so the mapped path has no trailing
+    // slash: `fs.stat` on a file path WITH a trailing slash fails with ENOTDIR
+    // on POSIX, which would take the catch branch instead of this one.
+    const pod = { path: 'http://example.com/alice' };
     await fs.rm(join(root, 'alice'), { recursive: true, force: true });
     await fs.writeFile(join(root, 'alice'), Buffer.alloc(10));
     const counter = new QuotaCounter(mapper, root, IGNORE);
-    await counter.register(POD);
-    await counter.add(POD, 100);
-    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 100 });
+    await counter.register(pod);
+    await counter.add(pod, 100);
+    await expect(counter.getSize(pod)).resolves.toEqual({ unit: 'bytes', amount: 100 });
   });
 
   it('walks containers in sizeOfResource and exposes walk().', async(): Promise<void> => {

--- a/test/unit/quota/QuotaCounter.test.ts
+++ b/test/unit/quota/QuotaCounter.test.ts
@@ -169,10 +169,6 @@ describe('A QuotaCounter', (): void => {
   });
 
   it('records a zero mtime when the pod root is a file.', async(): Promise<void> => {
-    // A file as the pod root: podRootMtime's isDirectory() is false → mtime 0.
-    // Use a non-trailing-slash identifier so the mapped path has no trailing
-    // slash: `fs.stat` on a file path WITH a trailing slash fails with ENOTDIR
-    // on POSIX, which would take the catch branch instead of this one.
     const pod = { path: 'http://example.com/alice' };
     await fs.rm(join(root, 'alice'), { recursive: true, force: true });
     await fs.writeFile(join(root, 'alice'), Buffer.alloc(10));

--- a/test/unit/quota/QuotaCounter.test.ts
+++ b/test/unit/quota/QuotaCounter.test.ts
@@ -84,6 +84,37 @@ describe('A QuotaCounter', (): void => {
     expect(size.amount).toBeGreaterThanOrEqual(400);
   });
 
+  it('does not recount while the counter is within the max age.', async(): Promise<void> => {
+    const first = new QuotaCounter(mapper, root, IGNORE, undefined, 3_600_000);
+    await first.register(POD);
+    await first.add(POD, 200);
+    // A fresh instance loads the sidecar (still within the max age) without a walk.
+    const second = new QuotaCounter(mapper, root, IGNORE, undefined, 3_600_000);
+    await expect(second.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 200 });
+  });
+
+  it('recounts after the max age even when the pod root mtime did not ' +
+    'change (deep change).', async(): Promise<void> => {
+    // A deep file added after the counter was persisted does not bump the pod root
+    // mtime — only the max-age expiry forces the recount.
+    await fs.mkdir(join(root, 'alice', 'sub'), { recursive: true });
+    const first = new QuotaCounter(mapper, root, IGNORE, undefined, 3_600_000);
+    await first.register(POD);
+    await first.add(POD, 200);
+    // Out-of-band deep change: only `sub`'s mtime changes, not the pod root's.
+    await fs.writeFile(join(root, 'alice', 'sub', 'deep.bin'), Buffer.alloc(400));
+    // Age the sidecar beyond the max age.
+    const sidecarPath = join(root, 'alice', '.internal', 'css-quota.json');
+    const raw = JSON.parse(await fs.readFile(sidecarPath, 'utf8'));
+    raw.updatedAt = new Date(Date.now() - 2 * 3_600_000).toISOString();
+    await fs.writeFile(sidecarPath, JSON.stringify(raw));
+    // A fresh instance sees the expired sidecar and re-walks.
+    const second = new QuotaCounter(mapper, root, IGNORE, undefined, 3_600_000);
+    const size = await second.getSize(POD);
+    expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
+    expect(size.amount).toBeGreaterThanOrEqual(400);
+  });
+
   it('returns the size of a single resource via stat.', async(): Promise<void> => {
     await fs.writeFile(join(root, 'alice', 'foo'), Buffer.alloc(77));
     const counter = new QuotaCounter(mapper, root, IGNORE);
@@ -111,5 +142,91 @@ describe('A QuotaCounter', (): void => {
     await counter.register(POD);
     await Promise.all([ counter.add(POD, 10), counter.add(POD, 20), counter.add(POD, 30) ]);
     await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 60 });
+  });
+
+  it('returns the byte unit.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    expect(counter.getUnit()).toBe('bytes');
+  });
+
+  it('accepts the default ignoreFolders and sidecar path.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root);
+    await counter.register(POD);
+    await counter.add(POD, 50);
+    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 50 });
+  });
+
+  it('creates the entry on add when the pod was not registered first.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    // No register() call — add() must create the entry itself.
+    await counter.add(POD, 75);
+    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 75 });
+  });
+
+  it('records a zero mtime when the pod root is a file.', async(): Promise<void> => {
+    // A file as the pod root: podRootMtime's isDirectory() is false → mtime 0.
+    await fs.rm(join(root, 'alice'), { recursive: true, force: true });
+    await fs.writeFile(join(root, 'alice'), Buffer.alloc(10));
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await counter.register(POD);
+    await counter.add(POD, 100);
+    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 100 });
+  });
+
+  it('walks containers in sizeOfResource and exposes walk().', async(): Promise<void> => {
+    await fs.mkdir(join(root, 'alice', 'dir'), { recursive: true });
+    await fs.writeFile(join(root, 'alice', 'dir', 'file.bin'), Buffer.alloc(50));
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    const container = { path: 'http://example.com/alice/dir/' };
+    const expected = await expectedWalk(root, mapper, container);
+    await expect(counter.sizeOfResource(container)).resolves.toBe(expected);
+    await expect(counter.walk(container)).resolves.toBe(expected);
+  });
+
+  it('returns 0 for a deleted pod root when checking staleness.', async(): Promise<void> => {
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    await counter.register(POD);
+    await counter.add(POD, 100);
+    // Pod root removed out-of-band → the mtime stat fails, the counter is stale
+    // and the follow-up walk finds nothing.
+    await fs.rm(join(root, 'alice'), { recursive: true, force: true });
+    await expect(counter.getSize(POD)).resolves.toEqual({ unit: 'bytes', amount: 0 });
+  });
+
+  it('serializes concurrent getSize calls so only one walk happens.', async(): Promise<void> => {
+    await fs.writeFile(join(root, 'alice', 'a.txt'), Buffer.alloc(120));
+    const counter = new QuotaCounter(mapper, root, IGNORE);
+    const [ first, second ] = await Promise.all([ counter.getSize(POD), counter.getSize(POD) ]);
+    expect(first.amount).toBe(second.amount);
+    expect(first.amount).toBe(await expectedWalk(root, mapper, POD));
+  });
+
+  it('treats a sidecar without updatedAt as stale when a max age is set.', async(): Promise<void> => {
+    const first = new QuotaCounter(mapper, root, IGNORE);
+    await first.register(POD);
+    await first.add(POD, 200);
+    const sidecarPath = join(root, 'alice', '.internal', 'css-quota.json');
+    const raw = JSON.parse(await fs.readFile(sidecarPath, 'utf8'));
+    delete raw.updatedAt;
+    await fs.writeFile(sidecarPath, JSON.stringify(raw));
+    // The stored total (200) is not trusted: the missing date is treated as stale
+    // and the real (empty) pod is re-walked instead.
+    const second = new QuotaCounter(mapper, root, IGNORE, undefined, 3_600_000);
+    const size = await second.getSize(POD);
+    expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
+  });
+
+  it('treats a sidecar with an unparseable updatedAt as stale.', async(): Promise<void> => {
+    const first = new QuotaCounter(mapper, root, IGNORE);
+    await first.register(POD);
+    await first.add(POD, 200);
+    const sidecarPath = join(root, 'alice', '.internal', 'css-quota.json');
+    const raw = JSON.parse(await fs.readFile(sidecarPath, 'utf8'));
+    raw.updatedAt = 'not-a-date';
+    await fs.writeFile(sidecarPath, JSON.stringify(raw));
+    // The unparseable date is treated as stale and the pod is re-walked.
+    const second = new QuotaCounter(mapper, root, IGNORE, undefined, 3_600_000);
+    const size = await second.getSize(POD);
+    expect(size.amount).toBe(await expectedWalk(root, mapper, POD));
   });
 });

--- a/test/unit/quota/QuotaDeltaDataAccessor.test.ts
+++ b/test/unit/quota/QuotaDeltaDataAccessor.test.ts
@@ -162,4 +162,12 @@ describe('A QuotaDeltaDataAccessor', (): void => {
     // And it doesn't crash.
     await accessor.deleteResource(outside);
   });
+
+  it('skips delta bookkeeping on internal paths.', async(): Promise<void> => {
+    const internal = { path: 'http://example.com/.internal/foo' };
+    await writeDoc(accessor, internal, 100);
+    await accessor.deleteResource(internal);
+    // No pod is discovered and no counter entry is created.
+    await expect(counter.isPodRoot(POD)).resolves.toBe(false);
+  });
 });

--- a/test/unit/quota/QuotaDeltaDataAccessor.test.ts
+++ b/test/unit/quota/QuotaDeltaDataAccessor.test.ts
@@ -1,0 +1,165 @@
+import { createReadStream, promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import type { DataAccessor } from '../../../src/storage/accessors/DataAccessor';
+import type { FileIdentifierMapper } from '../../../src/storage/mapping/FileIdentifierMapper';
+import { QuotaCounter } from '../../../src/storage/quota/QuotaCounter';
+import { QuotaDeltaDataAccessor } from '../../../src/storage/quota/QuotaDeltaDataAccessor';
+import { DuSizeReporter } from '../../../src/storage/size-reporter/DuSizeReporter';
+import { SingleRootIdentifierStrategy } from '../../../src/util/identifiers/SingleRootIdentifierStrategy';
+
+const IGNORE = [ '(^|/)\\.internal$' ];
+const PIM_STORAGE = 'http://www.w3.org/ns/pim/space#Storage';
+
+function createMapper(root: string): FileIdentifierMapper {
+  return {
+    async mapUrlToFilePath(identifier: ResourceIdentifier, isMetadata: boolean): Promise<any> {
+      const url = new URL(identifier.path);
+      const base = join(root, url.pathname);
+      return { identifier, filePath: isMetadata ? `${base}.meta` : base, contentType: undefined, isMetadata };
+    },
+    async mapFilePathToUrl(): Promise<any> {
+      throw new Error('Not implemented');
+    },
+  };
+}
+
+async function readStream(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream as any) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+// Recursive walk — same engine as the counter (du/Node fallback).
+async function expectedWalk(root: string, mapper: FileIdentifierMapper): Promise<number> {
+  return (await new DuSizeReporter(mapper, root, IGNORE).getSize({ path: 'http://example.com/alice/' })).amount;
+}
+
+// A minimal accessor that stores to the real filesystem and reports
+// pim:Storage on the pod root (so pod discovery works).
+function meta(isStorage: boolean): RepresentationMetadata {
+  return { getAll: (): any[] => isStorage ? [{ value: PIM_STORAGE }] : []} as any;
+}
+
+function createAccessor(root: string): DataAccessor {
+  const mapper = createMapper(root);
+
+  return {
+    async canHandle(): Promise<void> { /* No-op */ },
+    async getData(identifier: ResourceIdentifier): Promise<any> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, false);
+      return createReadStream(filePath) as any;
+    },
+    async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
+      return meta(identifier.path.endsWith('/') && identifier.path !== 'http://example.com/');
+    },
+    getChildren(): AsyncIterableIterator<any> {
+      return (async function* (): AsyncIterableIterator<any> {
+        yield* [];
+      })();
+    },
+    async writeDocument(identifier: ResourceIdentifier, data: any): Promise<void> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, false);
+      const buffer = await readStream(data);
+      await fs.mkdir(join(filePath, '..'), { recursive: true });
+      await fs.writeFile(filePath, buffer);
+    },
+    async writeContainer(identifier: ResourceIdentifier): Promise<void> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, false);
+      await fs.mkdir(filePath, { recursive: true });
+    },
+    async writeMetadata(identifier: ResourceIdentifier): Promise<void> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, true);
+      await fs.mkdir(join(filePath, '..'), { recursive: true });
+      await fs.writeFile(filePath, '{}');
+    },
+    async deleteResource(identifier: ResourceIdentifier): Promise<void> {
+      const data = await mapper.mapUrlToFilePath(identifier, false);
+      const meta = await mapper.mapUrlToFilePath(identifier, true);
+      await fs.rm(data.filePath, { recursive: true, force: true });
+      await fs.rm(meta.filePath, { force: true });
+    },
+  };
+}
+
+const POD = { path: 'http://example.com/alice/' };
+const RESOURCE = { path: 'http://example.com/alice/foo' };
+const SUB = { path: 'http://example.com/alice/sub/' };
+const SUB_RESOURCE = { path: 'http://example.com/alice/sub/bar' };
+
+async function writeDoc(accessor: QuotaDeltaDataAccessor, identifier: ResourceIdentifier, size: number): Promise<void> {
+  const stream = (async function* (): AsyncIterableIterator<Buffer> {
+    yield Buffer.alloc(size, 1);
+  })();
+  await accessor.writeDocument(identifier, stream as any, {} as RepresentationMetadata);
+}
+
+describe('A QuotaDeltaDataAccessor', (): void => {
+  let root: string;
+  let counter: QuotaCounter;
+  let accessor: QuotaDeltaDataAccessor;
+
+  beforeEach(async(): Promise<void> => {
+    root = await fs.mkdtemp(join(tmpdir(), 'delta-'));
+    const mapper = createMapper(root);
+    const source = createAccessor(root);
+    counter = new QuotaCounter(mapper, root, IGNORE);
+    accessor = new QuotaDeltaDataAccessor(
+      source,
+      new SingleRootIdentifierStrategy('http://example.com/'),
+      counter,
+      mapper,
+    );
+  });
+
+  afterEach(async(): Promise<void> => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('tracks container creation, writes, overwrites and deletes so the counter ' +
+    'equals a real walk.', async(): Promise<void> => {
+    // Create the pod root container.
+    await accessor.writeContainer(POD, {} as RepresentationMetadata);
+    // Create a document (100 bytes).
+    await writeDoc(accessor, RESOURCE, 100);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
+
+    // Overwrite it with a bigger body (150 bytes) → +50.
+    await writeDoc(accessor, RESOURCE, 150);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
+
+    // Nested container + resource.
+    await accessor.writeContainer(SUB, {} as RepresentationMetadata);
+    await writeDoc(accessor, SUB_RESOURCE, 40);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
+
+    // Write metadata for a resource (the .meta file).
+    await accessor.writeMetadata(RESOURCE, {} as RepresentationMetadata);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
+
+    // Delete the document → counter drops back to the walk.
+    await accessor.deleteResource(RESOURCE);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
+  });
+
+  it('drops the counter entirely when the pod root itself is deleted.', async(): Promise<void> => {
+    await accessor.writeContainer(POD, {} as RepresentationMetadata);
+    await writeDoc(accessor, RESOURCE, 50);
+    await expect(counter.isPodRoot(POD)).resolves.toBe(true);
+    await accessor.deleteResource(POD);
+    await expect(counter.isPodRoot(POD)).resolves.toBe(false);
+  });
+
+  it('does not track resources outside any pod (no pim:Storage).', async(): Promise<void> => {
+    const outside = { path: 'http://example.com/root-file' };
+    await writeDoc(accessor, outside, 999);
+    // No pod was registered → the file is not counted anywhere.
+    await expect(counter.isPodRoot({ path: 'http://example.com/' })).resolves.toBe(false);
+    // And it doesn't crash.
+    await accessor.deleteResource(outside);
+  });
+});

--- a/test/unit/quota/QuotaDeltaDataAccessor.test.ts
+++ b/test/unit/quota/QuotaDeltaDataAccessor.test.ts
@@ -122,26 +122,20 @@ describe('A QuotaDeltaDataAccessor', (): void => {
 
   it('tracks container creation, writes, overwrites and deletes so the counter ' +
     'equals a real walk.', async(): Promise<void> => {
-    // Create the pod root container.
     await accessor.writeContainer(POD, {} as RepresentationMetadata);
-    // Create a document (100 bytes).
     await writeDoc(accessor, RESOURCE, 100);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
 
-    // Overwrite it with a bigger body (150 bytes) → +50.
     await writeDoc(accessor, RESOURCE, 150);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
 
-    // Nested container + resource.
     await accessor.writeContainer(SUB, {} as RepresentationMetadata);
     await writeDoc(accessor, SUB_RESOURCE, 40);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
 
-    // Write metadata for a resource (the .meta file).
     await accessor.writeMetadata(RESOURCE, {} as RepresentationMetadata);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
 
-    // Delete the document → counter drops back to the walk.
     await accessor.deleteResource(RESOURCE);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root)));
   });
@@ -157,9 +151,7 @@ describe('A QuotaDeltaDataAccessor', (): void => {
   it('does not track resources outside any pod (no pim:Storage).', async(): Promise<void> => {
     const outside = { path: 'http://example.com/root-file' };
     await writeDoc(accessor, outside, 999);
-    // No pod was registered → the file is not counted anywhere.
     await expect(counter.isPodRoot({ path: 'http://example.com/' })).resolves.toBe(false);
-    // And it doesn't crash.
     await accessor.deleteResource(outside);
   });
 
@@ -167,7 +159,6 @@ describe('A QuotaDeltaDataAccessor', (): void => {
     const internal = { path: 'http://example.com/.internal/foo' };
     await writeDoc(accessor, internal, 100);
     await accessor.deleteResource(internal);
-    // No pod is discovered and no counter entry is created.
     await expect(counter.isPodRoot(POD)).resolves.toBe(false);
   });
 });

--- a/test/unit/quota/QuotaDeltaDataAccessorSubdomain.test.ts
+++ b/test/unit/quota/QuotaDeltaDataAccessorSubdomain.test.ts
@@ -60,7 +60,6 @@ function createAccessor(root: string): DataAccessor {
       return createReadStream(filePath) as any;
     },
     async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
-      // A subdomain pod root (ends with '/', is not the base root) is a storage.
       return meta(identifier.path.endsWith('/') && identifier.path !== BASE);
     },
     getChildren(): AsyncIterableIterator<any> {
@@ -126,22 +125,15 @@ describe('A QuotaDeltaDataAccessor in subdomain mode', (): void => {
 
   it('discovers subdomain pod roots and tracks deltas (regression: discovery must ' +
     'read metadata before the root-container stop).', async(): Promise<void> => {
-    // Create the pod root container. In subdomain mode the pod root IS a root
-    // container — discovery must read its metadata (pim:Storage) before the
-    // root-container stop, otherwise no pod is ever found (and no counter is
-    // created).
     await accessor.writeContainer(POD, {} as RepresentationMetadata);
     await expect(counter.isPodRoot(POD)).resolves.toBe(true);
 
-    // Create a document (100 bytes) inside the subdomain pod.
     await writeDoc(accessor, RESOURCE, 100);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root), POD));
 
-    // Overwrite it with a bigger body (150 bytes) → +50.
     await writeDoc(accessor, RESOURCE, 150);
     expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root), POD));
 
-    // The sidecar is persisted per pod: <root>/alice/.internal/css-quota.json
     const sidecar = join(root, 'alice', '.internal', 'css-quota.json');
     await expect(fs.stat(sidecar)).resolves.toBeTruthy();
   });

--- a/test/unit/quota/QuotaDeltaDataAccessorSubdomain.test.ts
+++ b/test/unit/quota/QuotaDeltaDataAccessorSubdomain.test.ts
@@ -1,0 +1,155 @@
+import { createReadStream, promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import type { DataAccessor } from '../../../src/storage/accessors/DataAccessor';
+import type { FileIdentifierMapper } from '../../../src/storage/mapping/FileIdentifierMapper';
+import { QuotaCounter } from '../../../src/storage/quota/QuotaCounter';
+import { QuotaDeltaDataAccessor } from '../../../src/storage/quota/QuotaDeltaDataAccessor';
+import { DuSizeReporter } from '../../../src/storage/size-reporter/DuSizeReporter';
+import { SubdomainIdentifierStrategy } from '../../../src/util/identifiers/SubdomainIdentifierStrategy';
+
+const IGNORE = [ '(^|/)\\.internal$' ];
+const PIM_STORAGE = 'http://www.w3.org/ns/pim/space#Storage';
+const BASE = 'http://example.com/';
+const BASE_HOST = 'example.com';
+
+// Subdomain-aware mapper: http://alice.example.com/foo -> <root>/alice/foo
+function createMapper(root: string): FileIdentifierMapper {
+  return {
+    async mapUrlToFilePath(identifier: ResourceIdentifier, isMetadata: boolean): Promise<any> {
+      const url = new URL(identifier.path);
+      const host = url.hostname;
+      const pod = host === BASE_HOST ? '' : host.slice(0, -(BASE_HOST.length + 1));
+      const base = join(root, pod, url.pathname);
+      return { identifier, filePath: isMetadata ? `${base}.meta` : base, contentType: undefined, isMetadata };
+    },
+    async mapFilePathToUrl(): Promise<any> {
+      throw new Error('Not implemented');
+    },
+  };
+}
+
+async function readStream(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream as any) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+// Recursive walk — same engine as the counter (du/Node fallback).
+async function expectedWalk(root: string, mapper: FileIdentifierMapper, pod: ResourceIdentifier): Promise<number> {
+  return (await new DuSizeReporter(mapper, root, IGNORE).getSize(pod)).amount;
+}
+
+// A minimal accessor that stores to the real filesystem and reports
+// pim:Storage on the subdomain pod root (so pod discovery works).
+function meta(isStorage: boolean): RepresentationMetadata {
+  return { getAll: (): any[] => isStorage ? [{ value: PIM_STORAGE }] : []} as any;
+}
+
+function createAccessor(root: string): DataAccessor {
+  const mapper = createMapper(root);
+
+  return {
+    async canHandle(): Promise<void> { /* No-op */ },
+    async getData(identifier: ResourceIdentifier): Promise<any> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, false);
+      return createReadStream(filePath) as any;
+    },
+    async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
+      // A subdomain pod root (ends with '/', is not the base root) is a storage.
+      return meta(identifier.path.endsWith('/') && identifier.path !== BASE);
+    },
+    getChildren(): AsyncIterableIterator<any> {
+      return (async function* (): AsyncIterableIterator<any> {
+        yield* [];
+      })();
+    },
+    async writeDocument(identifier: ResourceIdentifier, data: any): Promise<void> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, false);
+      const buffer = await readStream(data);
+      await fs.mkdir(join(filePath, '..'), { recursive: true });
+      await fs.writeFile(filePath, buffer);
+    },
+    async writeContainer(identifier: ResourceIdentifier): Promise<void> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, false);
+      await fs.mkdir(filePath, { recursive: true });
+    },
+    async writeMetadata(identifier: ResourceIdentifier): Promise<void> {
+      const { filePath } = await mapper.mapUrlToFilePath(identifier, true);
+      await fs.mkdir(join(filePath, '..'), { recursive: true });
+      await fs.writeFile(filePath, '{}');
+    },
+    async deleteResource(identifier: ResourceIdentifier): Promise<void> {
+      const data = await mapper.mapUrlToFilePath(identifier, false);
+      const meta = await mapper.mapUrlToFilePath(identifier, true);
+      await fs.rm(data.filePath, { recursive: true, force: true });
+      await fs.rm(meta.filePath, { force: true });
+    },
+  };
+}
+
+const POD = { path: 'http://alice.example.com/' };
+const RESOURCE = { path: 'http://alice.example.com/foo' };
+
+async function writeDoc(accessor: QuotaDeltaDataAccessor, identifier: ResourceIdentifier, size: number): Promise<void> {
+  const stream = (async function* (): AsyncIterableIterator<Buffer> {
+    yield Buffer.alloc(size, 1);
+  })();
+  await accessor.writeDocument(identifier, stream as any, {} as RepresentationMetadata);
+}
+
+describe('A QuotaDeltaDataAccessor in subdomain mode', (): void => {
+  let root: string;
+  let counter: QuotaCounter;
+  let accessor: QuotaDeltaDataAccessor;
+
+  beforeEach(async(): Promise<void> => {
+    root = await fs.mkdtemp(join(tmpdir(), 'delta-sub-'));
+    const mapper = createMapper(root);
+    const source = createAccessor(root);
+    counter = new QuotaCounter(mapper, root, IGNORE);
+    accessor = new QuotaDeltaDataAccessor(
+      source,
+      new SubdomainIdentifierStrategy(BASE),
+      counter,
+      mapper,
+    );
+  });
+
+  afterEach(async(): Promise<void> => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('discovers subdomain pod roots and tracks deltas (regression: discovery must ' +
+    'read metadata before the root-container stop).', async(): Promise<void> => {
+    // Create the pod root container. In subdomain mode the pod root IS a root
+    // container — discovery must read its metadata (pim:Storage) before the
+    // root-container stop, otherwise no pod is ever found (and no counter is
+    // created).
+    await accessor.writeContainer(POD, {} as RepresentationMetadata);
+    await expect(counter.isPodRoot(POD)).resolves.toBe(true);
+
+    // Create a document (100 bytes) inside the subdomain pod.
+    await writeDoc(accessor, RESOURCE, 100);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root), POD));
+
+    // Overwrite it with a bigger body (150 bytes) → +50.
+    await writeDoc(accessor, RESOURCE, 150);
+    expect((await counter.getSize(POD)).amount).toBe(await expectedWalk(root, createMapper(root), POD));
+
+    // The sidecar is persisted per pod: <root>/alice/.internal/css-quota.json
+    const sidecar = join(root, 'alice', '.internal', 'css-quota.json');
+    await expect(fs.stat(sidecar)).resolves.toBeTruthy();
+  });
+
+  it('does not treat the base root as a pod (writes outside any pod are untracked).', async(): Promise<void> => {
+    const baseFile = { path: 'http://example.com/root-file' };
+    await writeDoc(accessor, baseFile, 999);
+    await expect(counter.isPodRoot({ path: BASE })).resolves.toBe(false);
+    await accessor.deleteResource(baseFile);
+  });
+});

--- a/test/unit/storage/size-reporter/DuSizeReporter.test.ts
+++ b/test/unit/storage/size-reporter/DuSizeReporter.test.ts
@@ -152,7 +152,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('parses du output and passes the ignore folders as exclude patterns.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: any, options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): any => {
         expect(command).toBe('du');
         expect(args).toContain('--exclude');
         expect(args).toContain('.internal');
@@ -166,7 +166,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('falls back to the Node walk when du output cannot be parsed.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: any, options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): any => {
         callback(null, { stdout: 'garbage output\n', stderr: '' });
       },
     );
@@ -178,7 +178,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('falls back to the Node walk when du fails.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: any, options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): any => {
         callback(new Error('du failed'));
       },
     );
@@ -190,10 +190,10 @@ describe('A DuSizeReporter', (): void => {
 
   it('detects GNU du when --version succeeds.', async(): Promise<void> => {
     jest.mocked(execFile)
-      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): any => {
         callback(null, { stdout: 'du (GNU coreutils) 9.1\n', stderr: '' });
       })
-      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): any => {
         callback(null, { stdout: '100\t/path\n', stderr: '' });
       });
     const reporter = new DuSizeReporter(mapper, root);
@@ -204,25 +204,25 @@ describe('A DuSizeReporter', (): void => {
 
   it('detects no du when the command is missing and caches the flavor.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: any, options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): any => {
         callback(Object.assign(new Error('missing'), { code: 'ENOENT' }));
       },
     );
     const reporter = new DuSizeReporter(mapper, root);
     await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
     await fs.writeFile(join(root, 'b.txt'), Buffer.alloc(50));
-    await expect((await reporter.getSize({ path: 'http://example.com/a.txt' })).amount).toBe(100);
+    expect((await reporter.getSize({ path: 'http://example.com/a.txt' })).amount).toBe(100);
     // The second resource reuses the cached flavor without probing du again.
-    await expect((await reporter.getSize({ path: 'http://example.com/b.txt' })).amount).toBe(50);
+    expect((await reporter.getSize({ path: 'http://example.com/b.txt' })).amount).toBe(50);
     expect(execFile).toHaveBeenCalledTimes(1);
   });
 
   it('assumes BSD when --version fails for another reason.', async(): Promise<void> => {
     jest.mocked(execFile)
-      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): any => {
         callback(Object.assign(new Error('denied'), { code: 'EACCES' }));
       })
-      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): any => {
         // BSD flags are used; make the call fail so the Node walk takes over.
         expect(args[0]).toBe('-s');
         expect(args).toContain('-A');

--- a/test/unit/storage/size-reporter/DuSizeReporter.test.ts
+++ b/test/unit/storage/size-reporter/DuSizeReporter.test.ts
@@ -152,7 +152,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('parses du output and passes the ignore folders as exclude patterns.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: string[], options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): void => {
         expect(command).toBe('du');
         expect(args).toContain('--exclude');
         expect(args).toContain('.internal');
@@ -166,7 +166,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('falls back to the Node walk when du output cannot be parsed.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: string[], options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): void => {
         callback(null, { stdout: 'garbage output\n', stderr: '' });
       },
     );
@@ -178,7 +178,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('falls back to the Node walk when du fails.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: string[], options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): void => {
         callback(new Error('du failed'));
       },
     );
@@ -190,10 +190,10 @@ describe('A DuSizeReporter', (): void => {
 
   it('detects GNU du when --version succeeds.', async(): Promise<void> => {
     jest.mocked(execFile)
-      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
         callback(null, { stdout: 'du (GNU coreutils) 9.1\n', stderr: '' });
       })
-      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
         callback(null, { stdout: '100\t/path\n', stderr: '' });
       });
     const reporter = new DuSizeReporter(mapper, root);
@@ -204,7 +204,7 @@ describe('A DuSizeReporter', (): void => {
 
   it('detects no du when the command is missing and caches the flavor.', async(): Promise<void> => {
     jest.mocked(execFile).mockImplementationOnce(
-      (command: string, args: string[], options: any, callback: any): void => {
+      (command: string, args: any, options: any, callback: any): void => {
         callback(Object.assign(new Error('missing'), { code: 'ENOENT' }));
       },
     );
@@ -219,10 +219,10 @@ describe('A DuSizeReporter', (): void => {
 
   it('assumes BSD when --version fails for another reason.', async(): Promise<void> => {
     jest.mocked(execFile)
-      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
         callback(Object.assign(new Error('denied'), { code: 'EACCES' }));
       })
-      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+      .mockImplementationOnce((command: string, args: any, options: any, callback: any): void => {
         // BSD flags are used; make the call fail so the Node walk takes over.
         expect(args[0]).toBe('-s');
         expect(args).toContain('-A');

--- a/test/unit/storage/size-reporter/DuSizeReporter.test.ts
+++ b/test/unit/storage/size-reporter/DuSizeReporter.test.ts
@@ -76,7 +76,6 @@ describe('A DuSizeReporter', (): void => {
     const reporter = new ForceDuReporter(mapper, root, [], 60_000);
     await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
     const first = await reporter.getSize({ path: 'http://example.com/a.txt' });
-    // Change the file without invalidating — the cache must still serve the old size.
     await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(200));
     const cached = await reporter.getSize({ path: 'http://example.com/a.txt' });
     expect(first.amount).toBe(100);

--- a/test/unit/storage/size-reporter/DuSizeReporter.test.ts
+++ b/test/unit/storage/size-reporter/DuSizeReporter.test.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -5,6 +6,13 @@ import type { ResourceIdentifier } from '../../../../src/http/representation/Res
 import type { FileIdentifierMapper } from '../../../../src/storage/mapping/FileIdentifierMapper';
 import type { Size } from '../../../../src/storage/size-reporter/Size';
 import { DuSizeReporter } from '../../../../src/storage/size-reporter/DuSizeReporter';
+
+// Wrap the real execFile so individual tests can simulate du successes and failures
+// (this keeps the tests platform-independent: with and without a real du binary).
+jest.mock('node:child_process', (): any => {
+  const actual = jest.requireActual('node:child_process');
+  return { ...actual, execFile: jest.fn(actual.execFile) };
+});
 
 // Force the du-based path (works even where du is absent — the Node walk
 // produces the same apparent-byte sum for a simple tree).
@@ -40,6 +48,7 @@ describe('A DuSizeReporter', (): void => {
   beforeEach(async(): Promise<void> => {
     root = await fs.mkdtemp(join(tmpdir(), 'du-size-reporter-'));
     mapper = createMapper(root);
+    jest.mocked(execFile).mockClear();
   });
 
   afterEach(async(): Promise<void> => {
@@ -124,6 +133,12 @@ describe('A DuSizeReporter', (): void => {
     await expect(reporter.calculateChunkSize(Buffer.alloc(17))).resolves.toBe(17);
   });
 
+  it('calculates the chunk size for non-buffer chunks.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root);
+    await expect(reporter.calculateChunkSize({ length: 5 })).resolves.toBe(5);
+    await expect(reporter.calculateChunkSize({})).resolves.toBe(0);
+  });
+
   it('returns the byte unit.', async(): Promise<void> => {
     const reporter = new DuSizeReporter(mapper, root);
     expect(reporter.getUnit()).toBe('bytes');
@@ -133,5 +148,105 @@ describe('A DuSizeReporter', (): void => {
     const reporter = new DuSizeReporter(mapper, root);
     const size: Size = await reporter.getSize({ path: 'http://example.com/nope' });
     expect(size.amount).toBe(0);
+  });
+
+  it('parses du output and passes the ignore folders as exclude patterns.', async(): Promise<void> => {
+    jest.mocked(execFile).mockImplementationOnce(
+      (command: string, args: string[], options: any, callback: any): void => {
+        expect(command).toBe('du');
+        expect(args).toContain('--exclude');
+        expect(args).toContain('.internal');
+        callback(null, { stdout: '123\t/path\n', stderr: '' });
+      },
+    );
+    const reporter = new ForceDuReporter(mapper, root, [ '^/\\.internal$', '(^|/)\\.internal$' ]);
+    const size = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(size.amount).toBe(123);
+  });
+
+  it('falls back to the Node walk when du output cannot be parsed.', async(): Promise<void> => {
+    jest.mocked(execFile).mockImplementationOnce(
+      (command: string, args: string[], options: any, callback: any): void => {
+        callback(null, { stdout: 'garbage output\n', stderr: '' });
+      },
+    );
+    const reporter = new ForceDuReporter(mapper, root);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    const size = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(size.amount).toBe(100);
+  });
+
+  it('falls back to the Node walk when du fails.', async(): Promise<void> => {
+    jest.mocked(execFile).mockImplementationOnce(
+      (command: string, args: string[], options: any, callback: any): void => {
+        callback(new Error('du failed'));
+      },
+    );
+    const reporter = new ForceDuReporter(mapper, root);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    const size = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(size.amount).toBe(100);
+  });
+
+  it('detects GNU du when --version succeeds.', async(): Promise<void> => {
+    jest.mocked(execFile)
+      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+        callback(null, { stdout: 'du (GNU coreutils) 9.1\n', stderr: '' });
+      })
+      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+        callback(null, { stdout: '100\t/path\n', stderr: '' });
+      });
+    const reporter = new DuSizeReporter(mapper, root);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    const size = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(size.amount).toBe(100);
+  });
+
+  it('detects no du when the command is missing and caches the flavor.', async(): Promise<void> => {
+    jest.mocked(execFile).mockImplementationOnce(
+      (command: string, args: string[], options: any, callback: any): void => {
+        callback(Object.assign(new Error('missing'), { code: 'ENOENT' }));
+      },
+    );
+    const reporter = new DuSizeReporter(mapper, root);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    await fs.writeFile(join(root, 'b.txt'), Buffer.alloc(50));
+    await expect((await reporter.getSize({ path: 'http://example.com/a.txt' })).amount).toBe(100);
+    // The second resource reuses the cached flavor without probing du again.
+    await expect((await reporter.getSize({ path: 'http://example.com/b.txt' })).amount).toBe(50);
+    expect(execFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('assumes BSD when --version fails for another reason.', async(): Promise<void> => {
+    jest.mocked(execFile)
+      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+        callback(Object.assign(new Error('denied'), { code: 'EACCES' }));
+      })
+      .mockImplementationOnce((command: string, args: string[], options: any, callback: any): void => {
+        // BSD flags are used; make the call fail so the Node walk takes over.
+        expect(args[0]).toBe('-s');
+        expect(args).toContain('-A');
+        expect(args).toContain('-I');
+        expect(args).toContain('.internal');
+        callback(new Error('bsd failed'));
+      });
+    const reporter = new DuSizeReporter(mapper, root, [ '^/\\.internal$' ]);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    const size = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(size.amount).toBe(100);
+  });
+
+  it('walks directories recursively with the Node fallback, honoring ignoreFolders.', async(): Promise<void> => {
+    const reporter = new ForceNodeReporter(mapper, root, [ '^/\\.internal$' ]);
+    await fs.mkdir(join(root, 'sub'), { recursive: true });
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    await fs.writeFile(join(root, 'sub', 'b.txt'), Buffer.alloc(50));
+    await fs.mkdir(join(root, '.internal'));
+    await fs.writeFile(join(root, '.internal', 'x.txt'), Buffer.alloc(1000));
+    const withIgnore = await reporter.getSize({ path: 'http://example.com/' });
+    const withoutIgnore = await new ForceNodeReporter(mapper, root).getSize({ path: 'http://example.com/' });
+    // The ignored .internal content is excluded and the visible files are counted.
+    expect(withIgnore.amount).toBeLessThan(withoutIgnore.amount);
+    expect(withIgnore.amount).toBeGreaterThanOrEqual(150);
   });
 });

--- a/test/unit/storage/size-reporter/DuSizeReporter.test.ts
+++ b/test/unit/storage/size-reporter/DuSizeReporter.test.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ResourceIdentifier } from '../../../../src/http/representation/ResourceIdentifier';
+import type { FileIdentifierMapper } from '../../../../src/storage/mapping/FileIdentifierMapper';
+import type { Size } from '../../../../src/storage/size-reporter/Size';
+import { DuSizeReporter } from '../../../../src/storage/size-reporter/DuSizeReporter';
+
+// Force the du-based path (works even where du is absent — the Node walk
+// produces the same apparent-byte sum for a simple tree).
+class ForceDuReporter extends DuSizeReporter {
+  protected override async detectDu(): Promise<'gnu' | 'bsd' | 'none'> {
+    return 'gnu';
+  }
+}
+
+// Force the Node-walk fallback path.
+class ForceNodeReporter extends DuSizeReporter {
+  protected override async detectDu(): Promise<'gnu' | 'bsd' | 'none'> {
+    return 'none';
+  }
+}
+
+function createMapper(root: string): FileIdentifierMapper {
+  return {
+    async mapUrlToFilePath(identifier: ResourceIdentifier): Promise<any> {
+      const url = new URL(identifier.path);
+      return { identifier, filePath: join(root, url.pathname), contentType: undefined, isMetadata: false };
+    },
+    async mapFilePathToUrl(): Promise<any> {
+      throw new Error('Not implemented');
+    },
+  };
+}
+
+describe('A DuSizeReporter', (): void => {
+  let root: string;
+  let mapper: FileIdentifierMapper;
+
+  beforeEach(async(): Promise<void> => {
+    root = await fs.mkdtemp(join(tmpdir(), 'du-size-reporter-'));
+    mapper = createMapper(root);
+  });
+
+  afterEach(async(): Promise<void> => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('returns the apparent size of a file.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    const size = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(size).toEqual({ unit: 'bytes', amount: 100 });
+  });
+
+  it('reports the same size whether du or the Node fallback is used.', async(): Promise<void> => {
+    await fs.mkdir(join(root, 'dir'));
+    await fs.writeFile(join(root, 'dir', 'a.txt'), Buffer.alloc(100));
+    await fs.writeFile(join(root, 'dir', 'b.txt'), Buffer.alloc(50));
+    const viaDu = await new ForceDuReporter(mapper, root).getSize({ path: 'http://example.com/dir/a.txt' });
+    const viaNode = await new ForceNodeReporter(mapper, root).getSize({ path: 'http://example.com/dir/a.txt' });
+    expect(viaDu.amount).toBe(100);
+    expect(viaNode.amount).toBe(100);
+  });
+
+  it('serves a cached result within the TTL window without re-walking.', async(): Promise<void> => {
+    const reporter = new ForceDuReporter(mapper, root, [], 60_000);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    const first = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    // Change the file without invalidating — the cache must still serve the old size.
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(200));
+    const cached = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(first.amount).toBe(100);
+    expect(cached.amount).toBe(100);
+  });
+
+  it('recomputes after invalidation.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root, [], 60_000);
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(100));
+    await reporter.getSize({ path: 'http://example.com/a.txt' });
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(200));
+    await reporter.invalidate({ path: 'http://example.com/a.txt' });
+    const after = await reporter.getSize({ path: 'http://example.com/a.txt' });
+    expect(after.amount).toBe(200);
+  });
+
+  it('invalidates ancestor entries (e.g. the pod root) as well.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root, [], 60_000);
+    await fs.mkdir(join(root, 'dir'));
+    await fs.writeFile(join(root, 'dir', 'a.txt'), Buffer.alloc(100));
+    const rootSize = await reporter.getSize({ path: 'http://example.com/' });
+    expect(rootSize.amount).toBeGreaterThanOrEqual(100);
+    await fs.writeFile(join(root, 'dir', 'a.txt'), Buffer.alloc(300));
+    await reporter.invalidate({ path: 'http://example.com/dir/a.txt' });
+    const newRootSize = await reporter.getSize({ path: 'http://example.com/' });
+    expect(newRootSize.amount).toBe(rootSize.amount + 200);
+  });
+
+  it('excludes the ignoreFolders from the total.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root, [ '^/\\.internal$' ]);
+    await fs.mkdir(join(root, '.internal'));
+    await fs.writeFile(join(root, '.internal', 'x.txt'), Buffer.alloc(1000));
+    const without = await reporter.getSize({ path: 'http://example.com/' });
+    // Adding a file inside .internal must not change the reported size.
+    await fs.writeFile(join(root, '.internal', 'y.txt'), Buffer.alloc(1000));
+    await reporter.invalidate({ path: 'http://example.com/' });
+    const still = await reporter.getSize({ path: 'http://example.com/' });
+    expect(still.amount).toBe(without.amount);
+    // Adding a normal file must increase it.
+    await fs.writeFile(join(root, 'a.txt'), Buffer.alloc(50));
+    await reporter.invalidate({ path: 'http://example.com/' });
+    const increased = await reporter.getSize({ path: 'http://example.com/' });
+    expect(increased.amount).toBe(without.amount + 50);
+  });
+
+  it('returns the content-length as the estimated size.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root);
+    await expect(reporter.estimateSize({ contentLength: 42 } as any)).resolves.toBe(42);
+    await expect(reporter.estimateSize({} as any)).resolves.toBeUndefined();
+  });
+
+  it('calculates the chunk size as the buffer length.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root);
+    await expect(reporter.calculateChunkSize(Buffer.alloc(17))).resolves.toBe(17);
+  });
+
+  it('returns the byte unit.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root);
+    expect(reporter.getUnit()).toBe('bytes');
+  });
+
+  it('reports a size of 0 for a missing resource.', async(): Promise<void> => {
+    const reporter = new DuSizeReporter(mapper, root);
+    const size: Size = await reporter.getSize({ path: 'http://example.com/nope' });
+    expect(size.amount).toBe(0);
+  });
+});


### PR DESCRIPTION
#### 📁 Related issues

[add optional pod quota counter
](https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2231)
#### ✍️ Description

A storage backend that replaces the default per-write size calculation by an
incremental per-pod byte counter. Where the default quota setup walks the whole
pod on every write, this counter is updated O(1) per write and persisted to a
per-pod sidecar (`/.internal/css-quota.json`), so quota checks are constant-time
after a one-time bootstrap walk of each pod.
It is not a standalone server configuration: import
`css:config/storage/backend/quota/pod-quota-counter-file.json` on top of a quota
server configuration (such as `quota-file.json`) or alongside
`css:config/storage/backend/pod-quota-file.json` to opt in.
The default quota configuration is unchanged.

The counter is refreshed by a full walk on first access, on pod-root mtime
changes, and (to bound staleness from deep out-of-band changes) whenever it is
older than `maxAgeMs` (default 24 h). The max age can be changed by overriding
`urn:solid-server:default:QuotaCounter`, e.g. to one week:

```json
{
  "@type": "Override",
  "overrideInstance": { "@id": "urn:solid-server:default:QuotaCounter" },
  "overrideParameters": { "maxAgeMs": 604800000 }
}
```

#### benchmark on WSL1
```
 # node scripts/benchmark-quota-counter.cjs
FileSizeReporter  full pod walk (3000 x 1024B): 254.15 ms
QuotaCounter      bootstrap walk:                    70.03 ms
QuotaCounter      getSize (cached, O(1)):            0.223 ms
QuotaCounter      add delta + sidecar persist:       3.570 ms
DuSizeReporter    first getSize (walk):              63.38 ms
DuSizeReporter    cached getSize:                    0.138 ms

Speedup per write check: 1142x (walk vs. O(1) counter)
```
### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
