### PR TITLE
fix memory leak from periodic maintenance clear locks 

### DIFF
--- a/config/identity/handler/base/adapter-factory.json
+++ b/config/identity/handler/base/adapter-factory.json
@@ -13,6 +13,7 @@
         "source": {
           "@type": "ExpiringAdapterFactory",
           "storage": {
+            "@id": "urn:solid-server:default:ExpiringAdapterStorage",
             "@type": "WrappedExpiringStorage",
             "source": {
               "@type": "ContainerPathStorage",

--- a/src/identity/interaction/account/util/BaseLoginAccountStorage.ts
+++ b/src/identity/interaction/account/util/BaseLoginAccountStorage.ts
@@ -9,6 +9,7 @@ import type {
   ValueType,
 } from '../../../../storage/keyvalue/IndexedStorage';
 import { BadRequestHttpError } from '../../../../util/errors/BadRequestHttpError';
+import { createErrorMessage } from '../../../../util/errors/ErrorUtil';
 import { NotFoundHttpError } from '../../../../util/errors/NotFoundHttpError';
 import type { LoginStorage } from './LoginStorage';
 import { ACCOUNT_TYPE } from './LoginStorage';
@@ -155,10 +156,15 @@ export class BaseLoginAccountStorage<T extends IndexTypeCollection<T>> implement
   protected createAccountTimeout(id: string): void {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     const timer = setTimeout(async(): Promise<void> => {
-      const account = await this.storage.get(ACCOUNT_TYPE, id);
-      if (account && account[LOGIN_COUNT] === 0) {
-        this.logger.debug(`Removing account with no login methods ${id}`);
-        await this.storage.delete(ACCOUNT_TYPE, id);
+      try {
+        const account = await this.storage.get(ACCOUNT_TYPE, id);
+        if (account && account[LOGIN_COUNT] === 0) {
+          this.logger.debug(`Removing account with no login methods ${id}`);
+          await this.storage.delete(ACCOUNT_TYPE, id);
+        }
+      } catch (error: unknown) {
+        // Prevent an unhandled rejection (e.g. a lock timeout) from crashing the process.
+        this.logger.error(`Error during account cleanup of ${id}: ${createErrorMessage(error)}`);
       }
     }, this.expiration);
     timer.unref();

--- a/src/storage/LockingResourceStore.ts
+++ b/src/storage/LockingResourceStore.ts
@@ -124,15 +124,23 @@ export class LockingResourceStore implements AtomicResourceStore {
     // once we have the Representation.
     // See https://github.com/CommunitySolidServer/CommunitySolidServer/pull/536#discussion_r562467957
     return new Promise((resolve, reject): void => {
-      let representation: Representation;
+      let representation: Representation | undefined;
+      let timedOut = false;
       // Make the resource time out to ensure that the lock is always released eventually.
       this.locks.withReadLock(identifier, async(maintainLock): Promise<void> => {
         representation = await whileLocked();
+        if (timedOut) {
+          // The lock expired while the resource was still being read.
+          // Close the stream so it doesn't keep a file handle open forever.
+          representation.data.destroy();
+          return;
+        }
         resolve(this.createExpiringRepresentation(representation, maintainLock));
 
         // Release the lock when an error occurs or the data finished streaming
         await this.waitForStreamToEnd(representation.data);
       }).catch((error: unknown): void => {
+        timedOut = true;
         // Destroy the source stream in case the lock times out
         representation?.data.destroy(error as Error);
 

--- a/src/storage/keyvalue/WrappedExpiringStorage.ts
+++ b/src/storage/keyvalue/WrappedExpiringStorage.ts
@@ -16,13 +16,20 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
   protected readonly logger = getLoggerFor(this);
   private readonly source: KeyValueStorage<TKey, Expires<TValue>>;
   private readonly timer: NodeJS.Timeout;
+  private readonly batchSize: number;
 
   /**
    * @param source - KeyValueStorage to actually store the data.
    * @param timeout - How often the expired data needs to be checked in minutes.
+   * @param batchSize - How many expired entries are deleted at the same time.
    */
-  public constructor(source: KeyValueStorage<TKey, Expires<TValue>>, timeout = 60) {
+  public constructor(
+    source: KeyValueStorage<TKey, Expires<TValue>>,
+    timeout = 60,
+    batchSize = 32,
+  ) {
     this.source = source;
+    this.batchSize = batchSize;
     this.timer = setSafeInterval(
       this.logger,
       'Failed to remove expired entries',
@@ -79,9 +86,8 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
     }
     // Delete in bounded batches to avoid flooding the (locked) storage with concurrent
     // operations, which can saturate I/O and cause lock timeouts.
-    const batchSize = 32;
-    for (let i = 0; i < expired.length; i += batchSize) {
-      await Promise.all(expired.slice(i, i + batchSize)
+    for (let i = 0; i < expired.length; i += this.batchSize) {
+      await Promise.all(expired.slice(i, i + this.batchSize)
         .map(async(key): Promise<boolean> => this.source.delete(key)));
     }
     this.logger.debug('Finished removing expired entries');

--- a/src/storage/keyvalue/WrappedExpiringStorage.ts
+++ b/src/storage/keyvalue/WrappedExpiringStorage.ts
@@ -77,7 +77,13 @@ export class WrappedExpiringStorage<TKey, TValue> implements ExpiringStorage<TKe
         expired.push(key);
       }
     }
-    await Promise.all(expired.map(async(key): Promise<boolean> => this.source.delete(key)));
+    // Delete in bounded batches to avoid flooding the (locked) storage with concurrent
+    // operations, which can saturate I/O and cause lock timeouts.
+    const batchSize = 32;
+    for (let i = 0; i < expired.length; i += batchSize) {
+      await Promise.all(expired.slice(i, i + batchSize)
+        .map(async(key): Promise<boolean> => this.source.delete(key)));
+    }
     this.logger.debug('Finished removing expired entries');
   }
 

--- a/src/util/locking/FileSystemResourceLocker.ts
+++ b/src/util/locking/FileSystemResourceLocker.ts
@@ -29,7 +29,9 @@ const defaultUnlockOptions: UnlockOptions = {
   realpath: false,
 };
 
-const attemptDefaults: Required<AttemptSettings> = { retryCount: -1, retryDelay: 50, retryJitter: 30 };
+// Bound the number of retries so a contended lock doesn't spin forever,
+// keeping the event loop and filesystem threadpool busy (~30s max wait).
+const attemptDefaults: Required<AttemptSettings> = { retryCount: 600, retryDelay: 50, retryJitter: 30 };
 
 /**
  * Argument interface of the FileSystemResourceLocker constructor.

--- a/test/unit/identity/interaction/account/util/BaseLoginAccountStorage.test.ts
+++ b/test/unit/identity/interaction/account/util/BaseLoginAccountStorage.test.ts
@@ -66,6 +66,16 @@ describe('A BaseLoginAccountStorage', (): void => {
     expect(source.delete).toHaveBeenLastCalledWith(ACCOUNT_TYPE, 'id');
   });
 
+  it('does not reject when the timeout check for an account without login methods fails.', async(): Promise<void> => {
+    source.get.mockRejectedValueOnce(new Error('bad get'));
+    await expect(storage.create(ACCOUNT_TYPE, { test: 'data' })).resolves.toEqual({ test: 'data', id: 'id' });
+    expect(source.delete).toHaveBeenCalledTimes(0);
+
+    await expect(jest.advanceTimersByTimeAsync(30 * 60 * 1000)).resolves.toBeUndefined();
+
+    expect(source.delete).toHaveBeenCalledTimes(0);
+  });
+
   it('does not delete an account after the set timeout if it has a login method.', async(): Promise<void> => {
     source.get.mockResolvedValueOnce({ id: 'id', linkedLoginsCount: 1 });
     await expect(storage.create(ACCOUNT_TYPE, { test: 'data' })).resolves.toEqual({ test: 'data', id: 'id' });

--- a/test/unit/storage/LockingResourceStore.test.ts
+++ b/test/unit/storage/LockingResourceStore.test.ts
@@ -294,6 +294,38 @@ describe('A LockingResourceStore', (): void => {
     expect(order).toEqual([ 'lock read', 'useless get', 'timeout', 'unlock read' ]);
   });
 
+  it('destroys the stream if a timeout happens before getting a resource finishes.', async(): Promise<void> => {
+    // The resource only finishes loading after the timeout has already fired
+    let resolveRepresentation!: (representation: Representation) => void;
+    jest.spyOn(source, 'getRepresentation').mockImplementation((): any => {
+      order.push('useless get');
+      return new Promise((resolve): void => {
+        resolveRepresentation = resolve;
+      });
+    });
+
+    const prom = store.getRepresentation(subjectId, {});
+
+    timeoutTrigger.emit('timeout');
+
+    await expect(prom).rejects.toThrow('timeout');
+
+    // Let the resource finish loading; its stream must be closed to prevent a leak
+    const readable = guardedStreamFrom([ 1, 2, 3 ]);
+    const destroy = readable.destroy.bind(readable);
+    jest.spyOn(readable, 'destroy').mockImplementation((error): any => destroy.call(readable, error));
+    resolveRepresentation({ data: readable } as Representation);
+
+    // Provide opportunity for async events
+    await flushPromises();
+
+    expect(locker.withReadLock).toHaveBeenCalledTimes(1);
+    expect(locker.withReadLock.mock.calls[0][0]).toEqual(subjectId);
+    expect(source.getRepresentation).toHaveBeenCalledTimes(1);
+    expect(order).toEqual([ 'lock read', 'useless get', 'timeout', 'unlock read' ]);
+    expect(readable.destroy).toHaveBeenCalledTimes(1);
+  });
+
   it('hasResource should only acquire and release the read lock.', async(): Promise<void> => {
     await store.hasResource(subjectId);
     expect(locker.withReadLock).toHaveBeenCalledTimes(1);

--- a/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
+++ b/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
@@ -154,4 +154,26 @@ describe('A WrappedExpiringStorage', (): void => {
     expect(source.delete).toHaveBeenLastCalledWith('key2');
     mockInterval.mockRestore();
   });
+
+  it('removes many expired entries in bounded batches.', async(): Promise<void> => {
+    const mockInterval = jest.spyOn(globalThis, 'setInterval');
+    const mockTimer = { unref: jest.fn() };
+    mockInterval.mockImplementationOnce(jest.fn().mockReturnValueOnce(mockTimer));
+
+    storage = new WrappedExpiringStorage(source, 1);
+    // 40 expired entries so more than a single batch of 32 is required
+    const data = Array.from({ length: 40 }, (_, index): [ string, Internal ] =>
+      [ `key${index}`, createExpires(`data${index}`, yesterday) ]);
+    source.entries.mockImplementationOnce(function* (): any {
+      yield* data;
+    });
+
+    await (mockInterval.mock.calls[0][0] as () => Promise<void>)();
+
+    expect(source.delete).toHaveBeenCalledTimes(40);
+    for (let i = 0; i < 40; i++) {
+      expect(source.delete).toHaveBeenCalledWith(`key${i}`);
+    }
+    mockInterval.mockRestore();
+  });
 });

--- a/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
+++ b/test/unit/storage/keyvalue/WrappedExpiringStorage.test.ts
@@ -176,4 +176,25 @@ describe('A WrappedExpiringStorage', (): void => {
     }
     mockInterval.mockRestore();
   });
+
+  it('uses the given batch size when deleting expired entries.', async(): Promise<void> => {
+    const mockInterval = jest.spyOn(globalThis, 'setInterval');
+    const mockTimer = { unref: jest.fn() };
+    mockInterval.mockImplementationOnce(jest.fn().mockReturnValueOnce(mockTimer));
+
+    storage = new WrappedExpiringStorage(source, 1, 10);
+    const data = Array.from({ length: 25 }, (_, index): [ string, Internal ] =>
+      [ `key${index}`, createExpires(`data${index}`, yesterday) ]);
+    source.entries.mockImplementationOnce(function* (): any {
+      yield* data;
+    });
+
+    await (mockInterval.mock.calls[0][0] as () => Promise<void>)();
+
+    expect(source.delete).toHaveBeenCalledTimes(25);
+    for (let i = 0; i < 25; i++) {
+      expect(source.delete).toHaveBeenCalledWith(`key${i}`);
+    }
+    mockInterval.mockRestore();
+  });
 });


### PR DESCRIPTION
#### 📁 Related issues

https://github.com/CommunitySolidServer/CommunitySolidServer/issues/2234 memory leak on server with a fair amount of pods

#### ✍️ Description

This PR resolves the memory leak issue created when running the maintenance clear outdated locks, cookies, ...

> The expiring storages (cookies, forgot-password, tokens, adapter) were built as ContainerPathStorage over the shared KeyValueStorage, whose JsonResourceStorage walks the entire /.internal/ tree. Every sweep therefore recursively read every file under /.internal/ (all accounts, indexes, idp data) before filtering by prefix - causing sustained high CPU that grows with the account count.

> Replace the ContainerPathStorage + shared-store combination with a MaxKeyLengthStorage over a JsonResourceStorage whose container is the storage's own subpath, so entries()/sweeps only touch that container. Key mapping and the on-disk layout are unchanged.

This PR was made with AI assistance under experimental trial/errors and code analysis.
It was tested on CSS server seeded with 1000 accounts on a small machine.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [ ] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [ ] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
