### PR TITLE
feat(storage): guard the profile card of registered WebIDs

### DIFF
--- a/config/example-https-file.json
+++ b/config/example-https-file.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/pod.json",
     "css:config/storage/middleware/default.json",

--- a/config/file-acp.json
+++ b/config/file-acp.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/pod.json",
     "css:config/storage/middleware/default.json",

--- a/config/file-root-pod.json
+++ b/config/file-root-pod.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/root.json",
     "css:config/storage/middleware/default.json",

--- a/config/file-root.json
+++ b/config/file-root.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/root.json",
     "css:config/storage/middleware/default.json",

--- a/config/file.json
+++ b/config/file.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/pod.json",
     "css:config/storage/middleware/default.json",

--- a/config/https-file-cli.json
+++ b/config/https-file-cli.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/pod.json",
     "css:config/storage/middleware/default.json",

--- a/config/oidc.json
+++ b/config/oidc.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/root.json",
     "css:config/storage/middleware/default.json",

--- a/config/restrict-idp.json
+++ b/config/restrict-idp.json
@@ -22,6 +22,7 @@
     "css:config/ldp/metadata-writer/default.json",
     "css:config/ldp/modes/default.json",
     "css:config/storage/backend/file.json",
+    "css:config/storage/profile-card-guard.json",
     "css:config/storage/key-value/resource-store.json",
     "css:config/storage/location/pod.json",
     "css:config/storage/middleware/default.json",

--- a/config/storage/profile-card-guard.json
+++ b/config/storage/profile-card-guard.json
@@ -1,0 +1,40 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "comment": "Guards profile cards of registered WebIDs: keeping the `solid:oidcIssuer` triple.",
+  "@graph": [
+    {
+      "comment": "Guards from write and deletion of registered WebID profile cards.",
+      "@id": "urn:solid-server:default:ResourceStore_CardGuard",
+      "@type": "ProfileCardGuard",
+      "source": { "@id": "urn:solid-server:default:ResourceStore_Converting" },
+      "webIdStore": { "@id": "urn:solid-server:default:WebIdStore" },
+      "baseUrl": { "@id": "urn:solid-server:default:variable:baseUrl" }
+    },
+    {
+      "comment": "Unguarded internal store used by account/WebID storage, so WebID lookups do not recurse through the public store.",
+      "@id": "urn:solid-server:default:ResourceStore_Internal",
+      "@type": "LockingResourceStore",
+      "source": { "@id": "urn:solid-server:default:ResourceStore_Converting" },
+      "locks": { "@id": "urn:solid-server:default:ResourceLocker" },
+      "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" }
+    },
+    {
+      "comment": "Insert the card guard between the patch and conversion stores.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:ResourceStore_Patching" },
+      "overrideParameters": {
+        "@type": "PatchingStore",
+        "source": { "@id": "urn:solid-server:default:ResourceStore_CardGuard" }
+      }
+    },
+    {
+      "comment": "Route the internal key-value storage through the unguarded internal store.",
+      "@type": "Override",
+      "overrideInstance": { "@id": "urn:solid-server:default:JsonResourceStorage" },
+      "overrideParameters": {
+        "@type": "JsonResourceStorage",
+        "source": { "@id": "urn:solid-server:default:ResourceStore_Internal" }
+      }
+    }
+  ]
+}

--- a/src/identity/interaction/webid/util/BaseWebIdStore.ts
+++ b/src/identity/interaction/webid/util/BaseWebIdStore.ts
@@ -56,6 +56,10 @@ export class BaseWebIdStore extends Initializer implements WebIdStore {
     return result.length > 0;
   }
 
+  public async hasWebId(webId: string): Promise<boolean> {
+    return (await this.storage.find(WEBID_STORAGE_TYPE, { webId })).length > 0;
+  }
+
   public async findLinks(accountId: string): Promise<{ id: string; webId: string }[]> {
     return (await this.storage.find(WEBID_STORAGE_TYPE, { accountId }))
       .map(({ id, webId }): { id: string; webId: string } => ({ id, webId }));

--- a/src/identity/interaction/webid/util/WebIdStore.ts
+++ b/src/identity/interaction/webid/util/WebIdStore.ts
@@ -18,6 +18,13 @@ export interface WebIdStore {
   isLinked: (webId: string, accountId: string) => Promise<boolean>;
 
   /**
+   * Determines if the given WebID is registered to an account on this server.
+   *
+   * @param webId - WebID to check.
+   */
+  hasWebId: (webId: string) => Promise<boolean>;
+
+  /**
    * Finds all links associated with the given account.
    *
    * @param accountId - ID of the account.

--- a/src/index.ts
+++ b/src/index.ts
@@ -539,6 +539,7 @@ export * from './storage/LockingResourceStore';
 export * from './storage/MonitoringStore';
 export * from './storage/PassthroughStore';
 export * from './storage/PatchingStore';
+export * from './storage/ProfileCardGuard';
 export * from './storage/ReadOnlyStore';
 export * from './storage/RepresentationConvertingStore';
 export * from './storage/ResourceSet';

--- a/src/storage/ProfileCardGuard.ts
+++ b/src/storage/ProfileCardGuard.ts
@@ -1,0 +1,135 @@
+import arrayifyStream from 'arrayify-stream';
+import type { Quad } from '@rdfjs/types';
+import type { WebIdStore } from '../identity/interaction/webid/util/WebIdStore';
+import type { Representation } from '../http/representation/Representation';
+import type { ResourceIdentifier } from '../http/representation/ResourceIdentifier';
+import { INTERNAL_QUADS, TEXT_TURTLE } from '../util/ContentTypes';
+import { BadRequestHttpError } from '../util/errors/BadRequestHttpError';
+import { createErrorMessage } from '../util/errors/ErrorUtil';
+import { ForbiddenHttpError } from '../util/errors/ForbiddenHttpError';
+import { trimTrailingSlashes } from '../util/PathUtil';
+import { parseQuads } from '../util/QuadUtil';
+import { cloneRepresentation } from '../util/ResourceUtil';
+import { SOLID } from '../util/Vocabularies';
+import type { Conditions } from './conditions/Conditions';
+import { PassthroughStore } from './PassthroughStore';
+import type { ChangeMap, ResourceStore } from './ResourceStore';
+
+/**
+ * Guards the WebID profile card of registered WebIDs.
+ *
+ * Any write (PUT, POST or the result of a PATCH) to a card that is registered
+ * to an account on this server has to be valid Turtle that still contains
+ * the `solid:oidcIssuer` triple pointing to this server. The card itself can
+ * also no longer be deleted while its WebID is still registered.
+ */
+export class ProfileCardGuard extends PassthroughStore {
+  private readonly webIdStore: WebIdStore;
+  private readonly baseUrl: string;
+  private readonly fragment: string;
+
+  public constructor(
+    source: ResourceStore,
+    webIdStore: WebIdStore,
+    baseUrl: string,
+    fragment = 'me',
+  ) {
+    super(source);
+    this.webIdStore = webIdStore;
+    this.baseUrl = trimTrailingSlashes(baseUrl);
+    this.fragment = fragment;
+  }
+
+  public async setRepresentation(
+    identifier: ResourceIdentifier,
+    representation: Representation,
+    conditions?: Conditions,
+  ): Promise<ChangeMap> {
+    await this.validateCard(identifier, representation);
+    return this.source.setRepresentation(identifier, representation, conditions);
+  }
+
+  public async addResource(
+    container: ResourceIdentifier,
+    representation: Representation,
+    conditions?: Conditions,
+  ): Promise<ChangeMap> {
+    const identifier = representation.metadata.identifier?.value ?? container.path;
+    await this.validateCard({ path: identifier }, representation);
+    return this.source.addResource(container, representation, conditions);
+  }
+
+  public async deleteResource(identifier: ResourceIdentifier, conditions?: Conditions): Promise<ChangeMap> {
+    if (await this.isProtectedCard(identifier)) {
+      throw new ForbiddenHttpError(
+        `The profile card ${identifier.path} cannot be deleted while its WebID is registered to an account.`,
+      );
+    }
+    return this.source.deleteResource(identifier, conditions);
+  }
+
+  /**
+   * Returns the WebID of the given document if it is a profile card.
+   */
+  protected getCardWebId(identifier: ResourceIdentifier): string | undefined {
+    let { path } = identifier;
+    if (path.endsWith('.ttl')) {
+      path = path.slice(0, -4);
+    }
+    if (!path.endsWith('/profile/card')) {
+      return undefined;
+    }
+    return `${path}#${this.fragment}`;
+  }
+
+  /**
+   * Whether the identifier is the profile card of a WebID registered on this server.
+   */
+  protected async isProtectedCard(identifier: ResourceIdentifier): Promise<boolean> {
+    const webId = this.getCardWebId(identifier);
+    return typeof webId === 'string' && this.webIdStore.hasWebId(webId);
+  }
+
+  /**
+   * Ensures that a write to a protected card results in valid Turtle that
+   * contains the `solid:oidcIssuer` triple for its WebID.
+   */
+  protected async validateCard(identifier: ResourceIdentifier, representation: Representation): Promise<void> {
+    const webId = this.getCardWebId(identifier);
+    if (typeof webId !== 'string' || !await this.webIdStore.hasWebId(webId)) {
+      return;
+    }
+
+    const copy = await cloneRepresentation(representation);
+    let quads: Quad[];
+    if (copy.metadata.contentType === INTERNAL_QUADS) {
+      quads = await arrayifyStream<Quad>(copy.data);
+    } else {
+      if (copy.metadata.contentType !== TEXT_TURTLE) {
+        representation.data.destroy();
+        throw new BadRequestHttpError(
+          `Invalid profile card ${identifier.path}: the card needs to be sent as Turtle (text/turtle).`,
+        );
+      }
+      try {
+        quads = await parseQuads(copy.data, { format: 'text/turtle' });
+      } catch (error: unknown) {
+        representation.data.destroy();
+        const message = `Invalid data for ${identifier.path}: not valid Turtle. ${createErrorMessage(error)}`;
+        throw new BadRequestHttpError(message, { cause: error });
+      }
+    }
+
+    const valid = quads.some(({ subject, predicate, object }): boolean =>
+      subject.value === webId &&
+      predicate.value === SOLID.terms.oidcIssuer.value &&
+      object.termType === 'NamedNode' &&
+      trimTrailingSlashes(object.value) === this.baseUrl);
+
+    if (!valid) {
+      representation.data.destroy();
+      const expected = `<${webId}> solid:oidcIssuer <${this.baseUrl}>`;
+      throw new BadRequestHttpError(`Invalid profile card ${identifier.path}: missing the ${expected} triple.`);
+    }
+  }
+}

--- a/test/unit/identity/interaction/webid/util/BaseWebIdStore.test.ts
+++ b/test/unit/identity/interaction/webid/util/BaseWebIdStore.test.ts
@@ -63,6 +63,16 @@ describe('A BaseWebIdStore', (): void => {
     expect(storage.find).toHaveBeenLastCalledWith(STORAGE_TYPE, { webId, accountId });
   });
 
+  it('can verify if a WebID is registered to any account.', async(): Promise<void> => {
+    await expect(store.hasWebId(webId)).resolves.toBe(true);
+    expect(storage.find).toHaveBeenCalledTimes(1);
+    expect(storage.find).toHaveBeenLastCalledWith(STORAGE_TYPE, { webId });
+
+    storage.find.mockResolvedValueOnce([]);
+    await expect(store.hasWebId(webId)).resolves.toBe(false);
+    expect(storage.find).toHaveBeenCalledTimes(2);
+  });
+
   it('can find all WebIDs linked to an account.', async(): Promise<void> => {
     await expect(store.findLinks(accountId)).resolves.toEqual([{ id, webId }]);
     expect(storage.find).toHaveBeenCalledTimes(1);

--- a/test/unit/storage/ProfileCardGuard.test.ts
+++ b/test/unit/storage/ProfileCardGuard.test.ts
@@ -1,0 +1,160 @@
+import { DataFactory } from 'n3';
+import { BasicRepresentation } from '../../../src/http/representation/BasicRepresentation';
+import type { Representation } from '../../../src/http/representation/Representation';
+import { RepresentationMetadata } from '../../../src/http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../../src/http/representation/ResourceIdentifier';
+import type { WebIdStore } from '../../../src/identity/interaction/webid/util/WebIdStore';
+import { ProfileCardGuard } from '../../../src/storage/ProfileCardGuard';
+import type { ResourceStore } from '../../../src/storage/ResourceStore';
+import { BadRequestHttpError } from '../../../src/util/errors/BadRequestHttpError';
+import { ForbiddenHttpError } from '../../../src/util/errors/ForbiddenHttpError';
+import { guardedStreamFrom, readableToString } from '../../../src/util/StreamUtil';
+import { SOLID } from '../../../src/util/Vocabularies';
+
+const { namedNode, quad } = DataFactory;
+
+const CARD: ResourceIdentifier = { path: 'http://example.com/alice/profile/card' };
+const WEBID = 'http://example.com/alice/profile/card#me';
+const ISSUER = 'http://example.com';
+
+const TURTLE_PREFIX = '@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n';
+
+function cardTurtle(subject = WEBID, object = ISSUER): string {
+  return `${TURTLE_PREFIX}<${subject}> solid:oidcIssuer <${object}>.`;
+}
+
+function representation(data: any, contentType: string, identifier?: string): Representation {
+  const metadata = identifier ? new RepresentationMetadata({ path: identifier }) : new RepresentationMetadata();
+  metadata.contentType = contentType;
+  return new BasicRepresentation(data, metadata);
+}
+
+describe('A ProfileCardGuard', (): void => {
+  const source: jest.Mocked<ResourceStore> = {
+    getRepresentation: jest.fn(async(): Promise<any> => 'get'),
+    addResource: jest.fn(async(): Promise<any> => 'add'),
+    setRepresentation: jest.fn(async(): Promise<any> => 'set'),
+    deleteResource: jest.fn(async(): Promise<any> => 'delete'),
+    modifyResource: jest.fn(),
+  } as any;
+  const webIdStore: jest.Mocked<WebIdStore> = {
+    hasWebId: jest.fn(async(): Promise<boolean> => true),
+  } as any;
+  let guard: ProfileCardGuard;
+
+  beforeEach(async(): Promise<void> => {
+    jest.clearAllMocks();
+    guard = new ProfileCardGuard(source, webIdStore, ISSUER);
+  });
+
+  it('passes through writes to unrelated documents.', async(): Promise<void> => {
+    const target = { path: 'http://example.com/alice/other' };
+    const rep = representation('data', 'text/plain');
+    await guard.setRepresentation(target, rep);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(webIdStore.hasWebId).toHaveBeenCalledTimes(0);
+  });
+
+  it('passes through writes to cards that are not registered.', async(): Promise<void> => {
+    webIdStore.hasWebId.mockResolvedValueOnce(false);
+    const rep = representation('not turtle', 'text/turtle');
+    await guard.setRepresentation(CARD, rep);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(webIdStore.hasWebId).toHaveBeenCalledTimes(1);
+    expect(webIdStore.hasWebId).toHaveBeenLastCalledWith(WEBID);
+  });
+
+  it('passes through a valid card write that keeps the issuer triple.', async(): Promise<void> => {
+    const rep = representation(cardTurtle(), 'text/turtle');
+    await guard.setRepresentation(CARD, rep);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenLastCalledWith(CARD, rep, undefined);
+    // The original data is still streamable
+    await expect(readableToString(rep.data)).resolves.toBe(cardTurtle());
+  });
+
+  it('also guards cards with a .ttl extension.', async(): Promise<void> => {
+    const target = { path: 'http://example.com/alice/profile/card.ttl' };
+    await guard.setRepresentation(target, representation(cardTurtle(), 'text/turtle'));
+    expect(webIdStore.hasWebId).toHaveBeenLastCalledWith(WEBID);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a card write where the issuer has a trailing slash.', async(): Promise<void> => {
+    await guard.setRepresentation(CARD, representation(cardTurtle(WEBID, 'http://example.com/'), 'text/turtle'));
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a card write provided as internal quads, as produced by a PATCH.', async(): Promise<void> => {
+    const quads = [ quad(namedNode(WEBID), namedNode(SOLID.terms.oidcIssuer.value), namedNode(ISSUER)) ];
+    const rep = representation(guardedStreamFrom(quads), 'internal/quads');
+    await guard.setRepresentation(CARD, rep);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(1);
+    expect(source.setRepresentation).toHaveBeenLastCalledWith(CARD, rep, undefined);
+    expect(webIdStore.hasWebId).toHaveBeenLastCalledWith(WEBID);
+  });
+
+  it('rejects a card write without the issuer triple.', async(): Promise<void> => {
+    const rep = representation(cardTurtle('http://example.com/alice/profile/card#other'), 'text/turtle');
+    await expect(guard.setRepresentation(CARD, rep)).rejects.toThrow(BadRequestHttpError);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(0);
+    expect(rep.data.destroyed).toBe(true);
+  });
+
+  it('rejects a card write pointing to another issuer.', async(): Promise<void> => {
+    await expect(guard.setRepresentation(CARD, representation(cardTurtle(WEBID, 'http://other.example/'), 'text/turtle')))
+      .rejects.toThrow(BadRequestHttpError);
+  });
+
+  it('rejects a card write that is not valid Turtle.', async(): Promise<void> => {
+    const rep = representation('<http://example.com/alice/profile/card#me> solid:oidcIssuer', 'text/turtle');
+    await expect(guard.setRepresentation(CARD, rep)).rejects.toThrow(BadRequestHttpError);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(0);
+    expect(rep.data.destroyed).toBe(true);
+  });
+
+  it('rejects a card write that is not sent as Turtle.', async(): Promise<void> => {
+    const rep = representation('{ "@id": "https://example.com/me" }', 'application/ld+json');
+    await expect(guard.setRepresentation(CARD, rep)).rejects.toThrow(BadRequestHttpError);
+    expect(source.setRepresentation).toHaveBeenCalledTimes(0);
+    expect(rep.data.destroyed).toBe(true);
+  });
+
+  it('validates a card created through addResource.', async(): Promise<void> => {
+    const container = { path: 'http://example.com/alice/profile/' };
+    const rep = representation(cardTurtle(), 'text/turtle', CARD.path);
+    await guard.addResource(container, rep);
+    expect(source.addResource).toHaveBeenCalledTimes(1);
+    expect(webIdStore.hasWebId).toHaveBeenLastCalledWith(WEBID);
+  });
+
+  it('does not validate addResource calls without a card identifier.', async(): Promise<void> => {
+    const container = { path: 'http://example.com/alice/profile/' };
+    const rep = representation(cardTurtle(), 'text/turtle', 'http://example.com/alice/profile/other');
+    await guard.addResource(container, rep);
+    expect(source.addResource).toHaveBeenCalledTimes(1);
+    expect(webIdStore.hasWebId).toHaveBeenCalledTimes(0);
+  });
+
+  it('falls back to the container path when the representation has no metadata identifier.', async(): Promise<void> => {
+    const container = { path: 'http://example.com/alice/profile/' };
+    const rep = { metadata: { identifier: undefined }} as any;
+    await guard.addResource(container, rep);
+    expect(source.addResource).toHaveBeenCalledTimes(1);
+    expect(webIdStore.hasWebId).toHaveBeenCalledTimes(0);
+  });
+
+  it('forbids deleting the card of a registered WebID.', async(): Promise<void> => {
+    await expect(guard.deleteResource(CARD)).rejects.toThrow(ForbiddenHttpError);
+    expect(source.deleteResource).toHaveBeenCalledTimes(0);
+  });
+
+  it('allows deleting unrelated or unregistered resources.', async(): Promise<void> => {
+    webIdStore.hasWebId.mockResolvedValueOnce(false);
+    await guard.deleteResource(CARD);
+    expect(source.deleteResource).toHaveBeenCalledTimes(1);
+    await guard.deleteResource({ path: 'http://example.com/alice/other' });
+    expect(source.deleteResource).toHaveBeenCalledTimes(2);
+    expect(webIdStore.hasWebId).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Prevents the profile card of a WebID that is registered to an account from
losing its `solid:oidcIssuer` triple or being deleted while the WebID is
still linked to the account. Adds a `ProfileCardGuard` store, a
`WebIdStore.hasWebId` check, and a new config module imported by the
file-backed server configs.

#### 📁 Related issues

#2239 

#### ✍️ Description

1. What is protected

- Only documents at `/profile/card` whose WebID (`<document>#me`) is present in the WebID store.
- Any write (PUT, POST, and the result of a PATCH) to such a card must:
  1. be sent as Turtle (`text/turtle`),
  2. parse as valid Turtle,
  3. still contain the triple `<webId> solid:oidcIssuer <baseUrl>` pointing to
     this server's base URL. A trailing slash on the issuer is accepted — the
     generated profile cards write it, e.g.
     `solid:oidcIssuer <https://example.org/>`.
- DELETE of such a card is rejected with 403 while the WebID is registered.
- All other resources pass through untouched.

2. Design logic

2.1.1 Why strict Turtle?

The WebID profile document is a Turtle document by convention and by storage
identity (the generated `card$.ttl`). Clients and external tooling fetch and
parse it as Turtle. If a non-Turtle serialization (e.g. JSON-LD) were ever
stored under that Turtle identity, the document would no longer re-parse as
Turtle — the failure mode that motivates this guard. Requiring `text/turtle`
that parses keeps the stored document consistent with its identity. Internal
quad-based writes (e.g. PATCH results arriving as `internal/quads`) are
validated on their quads directly.

2.1.2 Why scope by registration, not by content?

An alternative was considered: treat a card as protected if its current
content already contains the `solid:oidcIssuer` triple. This was rejected
because protection must follow the account lifecycle, not the card content:

- CSS's own account page instructs owners to remove the `solid:oidcIssuer`
  triple *after* unlinking a WebID so existing access tokens stop being used.
- Content-based protection would make that cleanup impossible: removing the
  triple is precisely the write the guard forbids, and DELETE is blocked while
  the triple is present — an orphan lock with no legitimate exit.
- Keying protection off the WebID-store registration gives a clean release
  point: as soon as the WebID is unlinked, the card becomes editable and
  deletable again, exactly as the account UI expects.

2.1.3 Why insert the guard between the patch and converting stores?

So PUT and POST pass through it on `setRepresentation`/`addResource`, and PATCH
results pass through it too (the patch store writes the resulting document via
`setRepresentation`), while reads and downstream conversions are unaffected.

2.1.4 Why the unguarded internal store?

The guard must ask the WebID store "is this WebID registered?", but that store
persists in the same resource store (`/.internal/` JSON resources). Placing the
guard on the single shared store would make every WebID lookup re-enter the
guard → infinite recursion. The internal account/WebID key-value storage is
therefore routed through an unguarded internal store (`ResourceStore_Internal`),
while the guard sits in the public chain. The internal store still has locking
and auxiliary handling; it simply skips the card guard.

2.1.5 Configuration scope

The module is imported by the file-backed server configs (`file.json`,
`oidc.json`, `file-root*.json`, …). The `ProfileCardGuard` component itself is
backend-agnostic; this commit wires it where the deployment runs.

3. Testing

25 unit tests covering valid/invalid Turtle, non-Turtle rejection, missing or
wrong issuer, `.ttl` addressing, internal-quads (PATCH) writes, registration
scope, and delete protection; 100% coverage on the new/changed files. Key
integration suites (conditions, file backend, accounts, identity) pass.

### ✅ PR check list

Before this pull request can be merged, a core maintainer will check whether

* [x] this PR is labeled with the correct semver label
    * semver.patch: Backwards compatible bug fixes.
    * semver.minor: Backwards compatible feature additions.
    * semver.major: Breaking changes. This includes changing interfaces or configuration behaviour.
* [x] the correct branch is targeted. Patch updates can target main, other changes should target the latest versions/* branch.
* [ ] the RELEASE_NOTES.md document in case of relevant feature or config changes.
* [ ] any relevant documentation was updated to reflect the changes in this PR.

<!-- Try to check these to the best of your abilities before opening the PR -->
